### PR TITLE
Remove `AssistCommand` from registered commands

### DIFF
--- a/src/BoostServiceProvider.php
+++ b/src/BoostServiceProvider.php
@@ -82,7 +82,6 @@ class BoostServiceProvider extends ServiceProvider
                 Console\StartCommand::class,
                 Console\InstallCommand::class,
                 Console\ExecuteToolCommand::class,
-                Console\AssistCommand::class,
             ]);
         }
     }


### PR DESCRIPTION
The command does not exist
