### PR TITLE
fix: double spaces in doc blocks

### DIFF
--- a/pint.json
+++ b/pint.json
@@ -111,7 +111,7 @@
         "phpdoc_align": {
             "align": "left",
             "spacing": {
-                "param": 2
+                "param": 1
             }
         },
         "phpdoc_indent": true,

--- a/src/BoostServiceProvider.php
+++ b/src/BoostServiceProvider.php
@@ -142,7 +142,7 @@ class BoostServiceProvider extends ServiceProvider
      * "data":[
      * {"message":"Unhandled Promise Rejection","reason":{"name":"TypeError","message":"NetworkError when attempting to fetch resource.","stack":""}}]
      *
-     * @param  array<mixed>  $data
+     * @param array<mixed> $data
      */
     protected function buildLogMessageFromData(array $data): string
     {
@@ -176,7 +176,7 @@ class BoostServiceProvider extends ServiceProvider
     /**
      * Register a Blade directive for the browser logger script.
      *
-     * @param  BladeCompiler  $bladeCompiler
+     * @param BladeCompiler $bladeCompiler
      */
     protected function registerBladeDirectives(BladeCompiler $bladeCompiler): void
     {

--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -30,7 +30,7 @@ trait MakesHttpRequests
     }
 
     /**
-     * @param  array<string, mixed>  $json
+     * @param array<string, mixed> $json
      */
     public function json(string $url, array $json): Response
     {

--- a/src/Contracts/Ide.php
+++ b/src/Contracts/Ide.php
@@ -10,8 +10,8 @@ interface Ide
     // Things to note: supports relative (absolute path required)? global mcp only? Prefer local file, but if global only we have to add the project name to the server name
 
     /**
-     * @param  array<int, string>  $args
-     * @param  array<string, string>  $env
+     * @param array<int, string> $args
+     * @param array<string, string> $env
      */
     public function installMcp(string $key, string $command, array $args = [], array $env = []): bool;
 }

--- a/src/Install/Agents/FileMcpIde.php
+++ b/src/Install/Agents/FileMcpIde.php
@@ -16,8 +16,8 @@ abstract class FileMcpIde implements Ide
     }
 
     /**
-     * @param  array<int, string>  $args
-     * @param  array<string, string>  $env
+     * @param array<int, string> $args
+     * @param array<string, string> $env
      */
     public function installMcp(string $key, string $command, array $args = [], array $env = []): bool
     {

--- a/src/Install/Agents/ShellMcpIde.php
+++ b/src/Install/Agents/ShellMcpIde.php
@@ -12,8 +12,8 @@ abstract class ShellMcpIde implements Ide
     protected string $shellCommand = 'echo "{command} {args} {env}"';
 
     /**
-     * @param  array<int, string>  $args
-     * @param  array<string, string>  $env
+     * @param array<int, string> $args
+     * @param array<string, string> $env
      */
     public function installMcp(string $key, string $command, array $args = [], array $env = []): bool
     {

--- a/src/Install/ApplicationDetector.php
+++ b/src/Install/ApplicationDetector.php
@@ -189,7 +189,7 @@ class ApplicationDetector
     /**
      * Check if an application is installed based on its configuration.
      *
-     * @param  array<string, string|array<string>>  $config
+     * @param array<string, string|array<string>> $config
      */
     protected function isAppInstalled(array $config, string $platform): bool
     {
@@ -219,7 +219,7 @@ class ApplicationDetector
     /**
      * Check if an application is used in the current project.
      *
-     * @param  array<string, string|array<string>>  $config
+     * @param array<string, string|array<string>> $config
      */
     protected function isAppUsedInProject(array $config, string $basePath): bool
     {
@@ -297,7 +297,7 @@ class ApplicationDetector
     /**
      * Add custom detection configuration for an application.
      *
-     * @param  array<string, array<string, string|array<string>>>  $config
+     * @param array<string, array<string, string|array<string>>> $config
      */
     public function addDetectionConfig(string $app, array $config, ?string $platform = null): void
     {
@@ -314,7 +314,7 @@ class ApplicationDetector
     /**
      * Add custom project detection configuration for an application.
      *
-     * @param  array<string, string|array<string>>  $config
+     * @param array<string, string|array<string>> $config
      */
     public function addProjectDetectionConfig(string $app, array $config): void
     {

--- a/src/Install/Cli/DisplayHelper.php
+++ b/src/Install/Cli/DisplayHelper.php
@@ -7,7 +7,7 @@ namespace Laravel\Boost\Install\Cli;
 class DisplayHelper
 {
     /**
-     * @param  array<int, array<int|string, mixed>>  $data
+     * @param array<int, array<int|string, mixed>> $data
      */
     public static function datatable(array $data, int $cols = 80): void
     {
@@ -96,7 +96,7 @@ class DisplayHelper
     }
 
     /**
-     * @param  array<int, string>  $items
+     * @param array<int, string> $items
      */
     public static function grid(array $items, int $cols = 80): void
     {

--- a/src/Mcp/ToolExecutor.php
+++ b/src/Mcp/ToolExecutor.php
@@ -19,7 +19,7 @@ class ToolExecutor
     /**
      * Execute a tool with the given arguments.
      *
-     * @param  array<string, mixed>  $arguments
+     * @param array<string, mixed> $arguments
      */
     public function execute(string $toolClass, array $arguments = []): ToolResult
     {
@@ -37,7 +37,7 @@ class ToolExecutor
     /**
      * Execute tool in a separate process for isolation.
      *
-     * @param  array<string, mixed>  $arguments
+     * @param array<string, mixed> $arguments
      */
     protected function executeInProcess(string $toolClass, array $arguments): ToolResult
     {
@@ -80,7 +80,7 @@ class ToolExecutor
     /**
      * Execute tool inline (current process).
      *
-     * @param  array<string, mixed>  $arguments
+     * @param array<string, mixed> $arguments
      */
     protected function executeInline(string $toolClass, array $arguments): ToolResult
     {
@@ -117,7 +117,7 @@ class ToolExecutor
     /**
      * Reconstruct a ToolResult from JSON data.
      *
-     * @param  array<string, mixed>  $data
+     * @param array<string, mixed> $data
      */
     protected function reconstructToolResult(array $data): ToolResult
     {

--- a/src/Mcp/Tools/ApplicationInfo.php
+++ b/src/Mcp/Tools/ApplicationInfo.php
@@ -32,7 +32,7 @@ class ApplicationInfo extends Tool
     }
 
     /**
-     * @param  array<string>  $arguments
+     * @param array<string> $arguments
      */
     public function handle(array $arguments): ToolResult
     {

--- a/src/Mcp/Tools/BrowserLogs.php
+++ b/src/Mcp/Tools/BrowserLogs.php
@@ -31,7 +31,7 @@ class BrowserLogs extends Tool
     }
 
     /**
-     * @param  array<string>  $arguments
+     * @param array<string> $arguments
      */
     public function handle(array $arguments): ToolResult
     {

--- a/src/Mcp/Tools/DatabaseConnections.php
+++ b/src/Mcp/Tools/DatabaseConnections.php
@@ -24,7 +24,7 @@ class DatabaseConnections extends Tool
     }
 
     /**
-     * @param  array<string>  $arguments
+     * @param array<string> $arguments
      */
     public function handle(array $arguments): ToolResult
     {

--- a/src/Mcp/Tools/DatabaseQuery.php
+++ b/src/Mcp/Tools/DatabaseQuery.php
@@ -38,7 +38,7 @@ class DatabaseQuery extends Tool
     }
 
     /**
-     * @param  array<string>  $arguments
+     * @param array<string> $arguments
      */
     public function handle(array $arguments): ToolResult
     {

--- a/src/Mcp/Tools/DatabaseSchema.php
+++ b/src/Mcp/Tools/DatabaseSchema.php
@@ -32,7 +32,7 @@ class DatabaseSchema extends Tool
     }
 
     /**
-     * @param  array<string>  $arguments
+     * @param array<string> $arguments
      */
     public function handle(array $arguments): ToolResult
     {

--- a/src/Mcp/Tools/GetAbsoluteUrl.php
+++ b/src/Mcp/Tools/GetAbsoluteUrl.php
@@ -31,7 +31,7 @@ class GetAbsoluteUrl extends Tool
     }
 
     /**
-     * @param  array<string>  $arguments
+     * @param array<string> $arguments
      */
     public function handle(array $arguments): ToolResult
     {

--- a/src/Mcp/Tools/GetConfig.php
+++ b/src/Mcp/Tools/GetConfig.php
@@ -27,7 +27,7 @@ class GetConfig extends Tool
     }
 
     /**
-     * @param  array<string>  $arguments
+     * @param array<string> $arguments
      */
     public function handle(array $arguments): ToolResult
     {

--- a/src/Mcp/Tools/LastError.php
+++ b/src/Mcp/Tools/LastError.php
@@ -53,7 +53,7 @@ class LastError extends Tool
     }
 
     /**
-     * @param  array<string>  $arguments
+     * @param array<string> $arguments
      */
     public function handle(array $arguments): ToolResult
     {

--- a/src/Mcp/Tools/ListArtisanCommands.php
+++ b/src/Mcp/Tools/ListArtisanCommands.php
@@ -26,7 +26,7 @@ class ListArtisanCommands extends Tool
     }
 
     /**
-     * @param  array<string>  $arguments
+     * @param array<string> $arguments
      */
     public function handle(array $arguments): ToolResult
     {

--- a/src/Mcp/Tools/ListAvailableConfigKeys.php
+++ b/src/Mcp/Tools/ListAvailableConfigKeys.php
@@ -25,7 +25,7 @@ class ListAvailableConfigKeys extends Tool
     }
 
     /**
-     * @param  array<string>  $arguments
+     * @param array<string> $arguments
      */
     public function handle(array $arguments): ToolResult
     {
@@ -39,7 +39,7 @@ class ListAvailableConfigKeys extends Tool
     /**
      * Flatten a multi-dimensional config array into dot notation keys.
      *
-     * @param  array<int|string, string|array<int|string, string>>  $array
+     * @param array<int|string, string|array<int|string, string>> $array
      * @return array<int|string, int|string>
      */
     private function flattenToDotNotation(array $array, string $prefix = ''): array

--- a/src/Mcp/Tools/ListAvailableEnvVars.php
+++ b/src/Mcp/Tools/ListAvailableEnvVars.php
@@ -27,7 +27,7 @@ class ListAvailableEnvVars extends Tool
     }
 
     /**
-     * @param  array<string>  $arguments
+     * @param array<string> $arguments
      */
     public function handle(array $arguments): ToolResult
     {

--- a/src/Mcp/Tools/ListRoutes.php
+++ b/src/Mcp/Tools/ListRoutes.php
@@ -37,7 +37,7 @@ class ListRoutes extends Tool
     }
 
     /**
-     * @param  array<string>  $arguments
+     * @param array<string> $arguments
      */
     public function handle(array $arguments): ToolResult
     {
@@ -79,7 +79,7 @@ class ListRoutes extends Tool
     }
 
     /**
-     * @param  array<string|bool>  $options
+     * @param array<string|bool> $options
      */
     private function artisan(string $command, array $options = []): string
     {

--- a/src/Mcp/Tools/ReadLogEntries.php
+++ b/src/Mcp/Tools/ReadLogEntries.php
@@ -30,7 +30,7 @@ class ReadLogEntries extends Tool
     }
 
     /**
-     * @param  array<string>  $arguments
+     * @param array<string> $arguments
      */
     public function handle(array $arguments): ToolResult
     {

--- a/src/Mcp/Tools/ReportFeedback.php
+++ b/src/Mcp/Tools/ReportFeedback.php
@@ -28,7 +28,7 @@ class ReportFeedback extends Tool
     }
 
     /**
-     * @param  array<string, string>  $arguments
+     * @param array<string, string> $arguments
      */
     public function handle(array $arguments): ToolResult|Generator
     {

--- a/src/Mcp/Tools/SearchDocs.php
+++ b/src/Mcp/Tools/SearchDocs.php
@@ -46,7 +46,7 @@ class SearchDocs extends Tool
     }
 
     /**
-     * @param  array<string, mixed>  $arguments
+     * @param array<string, mixed> $arguments
      */
     public function handle(array $arguments): ToolResult|Generator
     {

--- a/src/Mcp/Tools/Tinker.php
+++ b/src/Mcp/Tools/Tinker.php
@@ -32,7 +32,7 @@ class Tinker extends Tool
     }
 
     /**
-     * @param  array<string|int>  $arguments
+     * @param array<string|int> $arguments
      */
     public function handle(array $arguments): ToolResult
     {


### PR DESCRIPTION
This MR update the pint config to enforce single space in docblock. https://github.com/laravel/boost/pull/10#discussion_r2265284492