### PR TITLE
style: explicit string variables, interpolation curly braces

### DIFF
--- a/pint.json
+++ b/pint.json
@@ -12,7 +12,9 @@
         "blank_line_after_namespace": true,
         "blank_line_after_opening_tag": true,
         "blank_line_before_statement": {
-            "statements": ["return"]
+            "statements": [
+                "return"
+            ]
         },
         "blank_line_between_import_groups": true,
         "blank_lines_before_namespace": true,
@@ -38,6 +40,7 @@
         "declare_equal_normalize": true,
         "elseif": true,
         "encoding": true,
+        "explicit_string_variable": true,
         "full_opening_tag": true,
         "function_declaration": true,
         "heredoc_to_nowdoc": true,
@@ -74,7 +77,11 @@
         "no_empty_phpdoc": true,
         "no_empty_statement": true,
         "no_extra_blank_lines": {
-            "tokens": ["extra", "throw", "use"]
+            "tokens": [
+                "extra",
+                "throw",
+                "use"
+            ]
         },
         "no_leading_import_slash": true,
         "no_leading_namespace_whitespace": true,
@@ -86,7 +93,10 @@
         "no_singleline_whitespace_before_semicolons": true,
         "no_space_around_double_colon": true,
         "no_spaces_around_offset": {
-            "positions": ["inside", "outside"]
+            "positions": [
+                "inside",
+                "outside"
+            ]
         },
         "no_spaces_after_function_name": true,
         "no_trailing_comma_in_singleline": true,
@@ -106,7 +116,11 @@
         "object_operator_without_whitespace": true,
         "ordered_imports": {
             "sort_algorithm": "alpha",
-            "imports_order": ["const", "class", "function"]
+            "imports_order": [
+                "const",
+                "class",
+                "function"
+            ]
         },
         "phpdoc_align": {
             "align": "left",
@@ -120,17 +134,41 @@
         "phpdoc_no_package": true,
         "phpdoc_no_useless_inheritdoc": true,
         "phpdoc_order": {
-            "order": ["param", "return", "throws"]
+            "order": [
+                "param",
+                "return",
+                "throws"
+            ]
         },
         "phpdoc_return_self_reference": true,
         "phpdoc_scalar": true,
         "phpdoc_separation": {
             "groups": [
-                ["deprecated", "link", "see", "since"],
-                ["author", "copyright", "license"],
-                ["category", "package", "subpackage"],
-                ["property", "property-read", "property-write"],
-                ["param", "return"]
+                [
+                    "deprecated",
+                    "link",
+                    "see",
+                    "since"
+                ],
+                [
+                    "author",
+                    "copyright",
+                    "license"
+                ],
+                [
+                    "category",
+                    "package",
+                    "subpackage"
+                ],
+                [
+                    "property",
+                    "property-read",
+                    "property-write"
+                ],
+                [
+                    "param",
+                    "return"
+                ]
             ]
         },
         "phpdoc_single_line_var_spacing": true,
@@ -161,11 +199,14 @@
         "types_spaces": true,
         "unary_operator_spaces": true,
         "visibility_required": {
-            "elements": ["method", "property"]
+            "elements": [
+                "method",
+                "property"
+            ]
         },
         "whitespace_after_comma_in_array": true
     },
-    "notPath" :[
+    "notPath": [
         "stubs/tool.stub.php"
     ]
 }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -194,7 +194,7 @@ class InstallCommand extends Command
 
     private function hyperlink(string $label, string $url): string
     {
-        return "\033]8;;$url\007$label\033]8;;\033\\";
+        return "\033]8;;{$url}\007{$label}\033]8;;\033\\";
     }
 
     /**
@@ -428,7 +428,7 @@ class InstallCommand extends Command
         foreach ($this->selectedTargetAgents as $agent) {
             $agentName = class_basename($agent);
             $displayAgentName = str_pad($agentName, $longestAgentName);
-            $this->output->write("  $displayAgentName... ");
+            $this->output->write("  {$displayAgentName}... ");
 
             try {
                 (new GuidelineWriter($agent))
@@ -449,7 +449,7 @@ class InstallCommand extends Command
                 count($failed) === 1 ? '' : 's'
             ));
             foreach ($failed as $agentName => $error) {
-                $this->line("  - $agentName: $error");
+                $this->line("  - {$agentName}: {$error}");
             }
         }
     }
@@ -488,7 +488,7 @@ class InstallCommand extends Command
         foreach ($this->selectedTargetIdes as $ide) {
             $ideName = class_basename($ide);
             $ideDisplay = str_pad($ideName, $longestIdeName);
-            $this->output->write("  $ideDisplay... ");
+            $this->output->write("  {$ideDisplay}... ");
             $results = [];
 
             // Install Laravel Boost MCP if enabled
@@ -539,7 +539,7 @@ class InstallCommand extends Command
             $this->error(sprintf('%s Some MCP servers failed to install:', $this->redCross));
             foreach ($failed as $ideName => $errors) {
                 foreach ($errors as $server => $error) {
-                    $this->line("  - $ideName ($server): $error");
+                    $this->line("  - {$ideName} ({$server}): {$error}");
                 }
             }
         }

--- a/src/Mcp/Tools/DatabaseSchema.php
+++ b/src/Mcp/Tools/DatabaseSchema.php
@@ -44,7 +44,7 @@ class DatabaseSchema extends Tool
     {
         $connection = $arguments['database'] ?? config('database.default');
         $filter = $arguments['filter'] ?? '';
-        $cacheKey = "boost:mcp:database-schema:$connection:$filter";
+        $cacheKey = "boost:mcp:database-schema:{$connection}:{$filter}";
 
         $schema = Cache::remember($cacheKey, 20, function () use ($connection, $filter) {
             return $this->getDatabaseStructure($connection, $filter);

--- a/src/Mcp/Tools/GetConfig.php
+++ b/src/Mcp/Tools/GetConfig.php
@@ -34,7 +34,7 @@ class GetConfig extends Tool
         $key = $arguments['key'];
 
         if (! Config::has($key)) {
-            return ToolResult::error("Config key '$key' not found.");
+            return ToolResult::error("Config key '{$key}' not found.");
         }
 
         return ToolResult::json([

--- a/src/Mcp/Tools/LastError.php
+++ b/src/Mcp/Tools/LastError.php
@@ -73,7 +73,7 @@ class LastError extends Tool
         $logFile = $this->resolveLogFilePath();
 
         if (! file_exists($logFile)) {
-            return ToolResult::error("Log file not found at $logFile");
+            return ToolResult::error("Log file not found at {$logFile}");
         }
 
         $entry = $this->readLastErrorEntry($logFile);

--- a/src/Mcp/Tools/ListAvailableEnvVars.php
+++ b/src/Mcp/Tools/ListAvailableEnvVars.php
@@ -41,7 +41,7 @@ class ListAvailableEnvVars extends Tool
         }
 
         if (! file_exists($filePath)) {
-            return ToolResult::error("File not found at '$filePath'");
+            return ToolResult::error("File not found at '{$filePath}'");
         }
 
         $envLines = file_get_contents($filePath);

--- a/src/Mcp/Tools/ReadLogEntries.php
+++ b/src/Mcp/Tools/ReadLogEntries.php
@@ -44,7 +44,7 @@ class ReadLogEntries extends Tool
         $logFile = $this->resolveLogFilePath();
 
         if (! file_exists($logFile)) {
-            return ToolResult::error("Log file not found at $logFile");
+            return ToolResult::error("Log file not found at {$logFile}");
         }
 
         $entries = $this->readLastLogEntries($logFile, $maxEntries);

--- a/tests/Unit/Install/GuidelineWriterTest.php
+++ b/tests/Unit/Install/GuidelineWriterTest.php
@@ -258,7 +258,7 @@ test('it retries file locking on contention', function () {
 
     // Create a process that holds the lock
     $lockingProcess = proc_open("php -r \"
-        \$handle = fopen('$tempFile', 'c+');
+        \$handle = fopen('{$tempFile}', 'c+');
         flock(\$handle, LOCK_EX);
         sleep(1);
         fclose(\$handle);


### PR DESCRIPTION
# What & Why
Adds pint rule to enforce curly braces in string interpolation

My personal preference is to have explicit curly braces in string interpolation: `$name = 'Dood'; echo "Howdy {$name}!";`

But it also follows the [framework's approach](https://github.com/laravel/framework/blob/12.x/src/Illuminate/Validation/Rules/File.php#L288),  [Joe's code in wayfinder](https://github.com/laravel/wayfinder/blob/main/src/Route.php#L100), and [Spatie's guidelines](https://spatie.be/guidelines/laravel-php#content-strings) :ok_hand: