### PR TITLE
Add Pest v4 guidelines

### DIFF
--- a/.ai/pest/4/core.blade.php
+++ b/.ai/pest/4/core.blade.php
@@ -7,10 +7,10 @@
 
 ### Browser Testing
 - You can use Laravel features like `Event::fake()`, `assertAuthenticated()`, and model factories within Pest v4 browser tests, as well as `RefreshDatabase` (when needed) to ensure a clean state for each test.
+- Interact with the page (click, type, scroll, select, submit, drag-and-drop, touch gestures, etc.) when appropriate to complete the test.
 - If requested, test on multiple browsers (Chrome, Firefox, Safari).
 - If requested, test on different devices and viewports (like iPhone 14 Pro, tablets, or custom breakpoints).
 - Switch color schemes (light/dark mode) when appropriate.
-- Interact with the page (click, type, scroll, select, submit, drag-and-drop, touch gestures, etc.) when appropriate to complete the test.
 - Take screenshots or pause tests for debugging when appropriate.
 
 ### Example Tests


### PR DESCRIPTION
- Linear: https://linear.app/laravel/issue/AI-77/add-pest-v4-guidelines


# What & Why
Pest 4 will be out soon and we want people using Boost to get a headstart.

# How I tested
  1. Installed Pest 4 into a test project
  2. Ran `boost:install`
  3. Used `claude` to ask:
      - "how do pest smoke tests work? What's the code for them? Dont' add one, just tell me" -> search-docs "pest smoke testing" where it showed me the exact code needed
      - "how do i shard my tests?"
      - "Add a browser test for the homepage, click on register, then register with faker() details, and make sure we get redirected to the dashboard"

# Notes
- Should we nudge browser tests to live in `tests/Browser/` or no?

# Demo
<img width="3490" height="982" alt="CleanShot 2025-08-12 at 21 07 34@2x" src="https://github.com/user-attachments/assets/6370848b-3adf-442e-a331-f57f0aafc80c" />

Using Pest docs to write a browser test, then running Pint to make sure the code is okay ❤️ 
<img width="2532" height="1016" alt="CleanShot 2025-08-12 at 21 08 51@2x" src="https://github.com/user-attachments/assets/afffbfa8-677f-436d-acbc-2bc4e3c250f5" />
