### PR TITLE
update laravel/roster version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "illuminate/support": "^10.0|^11.0|^12.0",
         "laravel/mcp": "^0.1.0",
         "laravel/prompts": "^0.1.9|^0.3",
-        "laravel/roster": "^0.2.2"
+        "laravel/roster": "^0.2"
     },
     "require-dev": {
         "laravel/pint": "^1.14|^1.23",


### PR DESCRIPTION
Fixes #40 by updating laravel/roster to 0.2.3, now laravel/roster specifies it requires symfony/yaml