### PR TITLE
Update Pint Guideline to Use `--dirty` Flag

### DIFF
--- a/.ai/pint/core.blade.php
+++ b/.ai/pint/core.blade.php
@@ -1,4 +1,4 @@
 ## Laravel Pint Code Formatter
 
-- You must run `vendor/bin/pint` before finalizing changes to ensure your code matches the project's expected style.
+- You must run `vendor/bin/pint --dirty` before finalizing changes to ensure your code matches the project's expected style.
 - Do not run `vendor/bin/pint --test`, simply run `vendor/bin/pint` to fix any formatting issues.


### PR DESCRIPTION
Updates `.ai/pint/core.blade.php` to prefer usage of Pint with the `--dirty` flag for cleaner diffs/PRs. 
