### PR TITLE
Support `false` as the content argument

### DIFF
--- a/src/Middleware/InjectBoost.php
+++ b/src/Middleware/InjectBoost.php
@@ -30,8 +30,13 @@ class InjectBoost
         return $response;
     }
 
-    private function shouldInject(string $content): bool
+    private function shouldInject(string|false $content): bool
     {
+        // Check if there is content at all
+        if ($content === false) {
+            return false;
+        }
+
         // Check if it's HTML
         if (! str_contains($content, '<html') && ! str_contains($content, '<head')) {
             return false;


### PR DESCRIPTION
This previously broke for responses that have the (valid!) `false` value content attribute value, which happens for `StreamedResponse` objects, for example.


