### PR TITLE
fix #49: disable boost inject if HTML isn't expected

### DIFF
--- a/src/Middleware/InjectBoost.php
+++ b/src/Middleware/InjectBoost.php
@@ -17,7 +17,7 @@ class InjectBoost
         /** @var \Symfony\Component\HttpFoundation\Response $response */
         $response = $next($request);
 
-        if ($this->shouldInject($response->getContent())) {
+        if ($this->shouldInject($response)) {
             $originalView = $response->original ?? null;
             $injectedContent = $this->injectScript($response->getContent());
             $response->setContent($injectedContent);
@@ -30,8 +30,13 @@ class InjectBoost
         return $response;
     }
 
-    private function shouldInject(string $content): bool
+    private function shouldInject(Response $response): bool
     {
+        if (str_contains($response->headers->get('content-type'), 'html') === false) {
+            return false;
+        }
+
+        $content = $response->getContent();
         // Check if it's HTML
         if (! str_contains($content, '<html') && ! str_contains($content, '<head')) {
             return false;


### PR DESCRIPTION
Fixes Livewire /update endpoints getting JS injected and breaking parsing

Now we only InjectBoost if we're returning HTML