### PR TITLE
fix: don't inject if the content is false

### DIFF
--- a/src/Middleware/InjectBoost.php
+++ b/src/Middleware/InjectBoost.php
@@ -37,6 +37,10 @@ class InjectBoost
         }
 
         $content = $response->getContent();
+        if ($content === false) {
+            return false;
+        }
+
         // Check if it's HTML
         if (! str_contains($content, '<html') && ! str_contains($content, '<head')) {
             return false;


### PR DESCRIPTION
Don't inject Boost Browser streaming if content is false