### PR TITLE
fix #53 - make sure we boot our service provider on local envs

### DIFF
--- a/src/BoostServiceProvider.php
+++ b/src/BoostServiceProvider.php
@@ -55,7 +55,7 @@ class BoostServiceProvider extends ServiceProvider
 
     public function boot(Router $router): void
     {
-        if (! app()->environment('local', 'testing')) {
+        if (config('app.debug', false) === false) {
             return;
         }
 


### PR DESCRIPTION
BoostServiceProvider isn't booting on some people's projects as their env isn't `local` or `testing`.

This PR changes the check mechanism to rely on APP_DEBUG instead