### PR TITLE
docs: add docker mcpServer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ Laravel Boost includes AI guidelines for the following packages and frameworks. 
 | Laravel Folio | core |
 | Enforce Tests | conditional |
 
-
 ## Available Documentation
 
 | Package | Versions Supported |
@@ -90,7 +89,6 @@ Laravel Boost includes AI guidelines for the following packages and frameworks. 
 | Livewire | 1.x, 2.x, 3.x |
 | Pest | 3.x, 4.x |
 | Tailwind CSS | 3.x, 4.x |
-
 
 ## Adding Custom AI Guidelines
 
@@ -113,6 +111,22 @@ JSON Example:
         "laravel-boost": {
             "command": "php",
             "args": ["./artisan", "boost:mcp"]
+        }
+    }
+}
+```
+
+If using sail, then you can use the following:
+
+```json
+{
+    "mcpServers": {
+        "laravel-boost": {
+            "command": "vendor/bin/sail",
+            "args": [
+                "artisan",
+                "boost:mcp"
+            ]
         }
     }
 }


### PR DESCRIPTION
Hello!

This adds an example for when using boost inside of a docker container.

From: https://github.com/laravel/boost/issues/36#issuecomment-3184361793

Thanks!