### PR TITLE
fix: use app name as project name instead of directory name

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -86,7 +86,7 @@ class InstallCommand extends Command
         $this->selectedTargetAgents = collect();
         $this->selectedTargetMcpClient = collect();
 
-        $this->projectName = basename(base_path());
+        $this->projectName = config('app.name');
     }
 
     private function displayBoostHeader(): void


### PR DESCRIPTION
Hello!

When running inside of Docker, boost thinks the project name is `html` which is a little strange:


<img width="1334" height="821" alt="image" src="https://github.com/user-attachments/assets/a9cdd228-8c61-4004-ac43-b22dcb29e46b" />
