### PR TITLE
fix: use claude code project scope instead of local

### DIFF
--- a/src/Install/CodeEnvironment/ClaudeCode.php
+++ b/src/Install/CodeEnvironment/ClaudeCode.php
@@ -48,7 +48,7 @@ class ClaudeCode extends CodeEnvironment implements McpClient, Agent
 
     public function shellMcpCommand(): string
     {
-        return 'claude mcp add -s local -t stdio {key} "{command}" {args} {env}';
+        return 'claude mcp add -s project -t stdio {key} "{command}" {args} {env}';
     }
 
     public function guidelinesPath(): string


### PR DESCRIPTION
Hello!

This closes #50 by using the `project` scope instead of trying to write to the user's `~/.claude.json` file

Thanks!
