### PR TITLE
feat(install): add Trae as a supported code environment

### DIFF
--- a/src/Install/CodeEnvironment/Trae.php
+++ b/src/Install/CodeEnvironment/Trae.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install\CodeEnvironment;
+
+use Laravel\Boost\Contracts\Agent;
+use Laravel\Boost\Contracts\McpClient;
+use Laravel\Boost\Install\Enums\Platform;
+
+class Trae extends CodeEnvironment implements Agent, McpClient
+{
+    public function name(): string
+    {
+        return 'trae';
+    }
+
+    public function displayName(): string
+    {
+        return 'Trae';
+    }
+
+    public function systemDetectionConfig(Platform $platform): array
+    {
+        return match ($platform) {
+            Platform::Darwin => [
+                'paths' => ['/Applications/Trae.app'],
+            ],
+            Platform::Windows => [
+                'paths' => [
+                    '%ProgramFiles%\\Trae',
+                    '%LOCALAPPDATA%\\Programs\\Trae',
+                ],
+            ],
+            Platform::Linux => [
+                // Trae is not supported on Linux
+            ],
+        };
+    }
+
+    public function projectDetectionConfig(): array
+    {
+        return [
+            'paths' => ['.trae'],
+        ];
+    }
+
+    public function guidelinesPath(): string
+    {
+        return '.trae/rules/project_rules.md';
+    }
+
+    public function frontmatter(): bool
+    {
+        return false;
+    }
+
+    public function mcpConfigPath(): string
+    {
+        return match (Platform::current()) {
+            Platform::Darwin => '~/Library/Application Support/Trae/User/mcp.json',
+            Platform::Windows => '%APPDATA%\\Trae\\User\\mcp.json',
+            Platform::Linux => '', // Not supported
+        };
+    }
+
+    public function mcpConfigKey(): string
+    {
+        return 'mcpServers';
+    }
+}

--- a/src/Install/CodeEnvironmentsDetector.php
+++ b/src/Install/CodeEnvironmentsDetector.php
@@ -11,6 +11,7 @@ use Laravel\Boost\Install\CodeEnvironment\CodeEnvironment;
 use Laravel\Boost\Install\CodeEnvironment\Copilot;
 use Laravel\Boost\Install\CodeEnvironment\Cursor;
 use Laravel\Boost\Install\CodeEnvironment\PhpStorm;
+use Laravel\Boost\Install\CodeEnvironment\Trae;
 use Laravel\Boost\Install\CodeEnvironment\VSCode;
 use Laravel\Boost\Install\Enums\Platform;
 
@@ -23,6 +24,7 @@ class CodeEnvironmentsDetector
         'cursor' => Cursor::class,
         'claudecode' => ClaudeCode::class,
         'copilot' => Copilot::class,
+        'trae' => Trae::class,
     ];
 
     public function __construct(


### PR DESCRIPTION
This PR adds support for installing the guidelines into the [Trae IDE](https://www.trae.ai).

My only concern is the MCP path for Windows -- I don't have a PC so cannot test if it is the right location, but I did a bit of research and I think this is where it should go.