### PR TITLE
feat: add code environment support for Cascade - Windsurf's AI Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Next, install the MCP server and coding guidelines:
 php artisan boost:install
 ```
 
-Once Laravel Boost has been installed, you're ready to start coding with Cursor, Claude Code, or your AI agent of choice.
+Once Laravel Boost has been installed, you're ready to start coding with Cursor, Claude Code, Windsurf, or your AI agent of choice.
 
 ## Available MCP Tools
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -295,7 +295,7 @@ class InstallCommand extends Command
     private function getSelectionConfig(string $contractClass): array
     {
         return match ($contractClass) {
-            Agent::class => ['scroll' => 4, 'required' => false, 'displayMethod' => 'agentName'],
+            Agent::class => ['scroll' => 5, 'required' => false, 'displayMethod' => 'agentName'],
             McpClient::class => ['scroll' => 5, 'required' => true, 'displayMethod' => 'displayName'],
             default => throw new InvalidArgumentException("Unsupported contract class: {$contractClass}"),
         };

--- a/src/Install/CodeEnvironment/Windsurf.php
+++ b/src/Install/CodeEnvironment/Windsurf.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install\CodeEnvironment;
+
+use Laravel\Boost\Contracts\Agent;
+use Laravel\Boost\Install\Enums\Platform;
+
+class Windsurf extends CodeEnvironment implements Agent
+{
+    public function name(): string
+    {
+        return 'windsurf';
+    }
+
+    public function displayName(): string
+    {
+        return 'Windsurf';
+    }
+
+    public function systemDetectionConfig(Platform $platform): array
+    {
+        return match ($platform) {
+            Platform::Darwin => [
+                'paths' => ['/Applications/Windsurf.app'],
+            ],
+            Platform::Linux => [
+                'paths' => [
+                    '/opt/windsurf',
+                    '/usr/local/bin/windsurf',
+                    '~/.local/bin/windsurf',
+                    '/snap/bin/windsurf',
+                ],
+            ],
+            Platform::Windows => [
+                'paths' => [
+                    '%ProgramFiles%\\Windsurf',
+                    '%LOCALAPPDATA%\\Programs\\Windsurf',
+                    '%APPDATA%\\Windsurf',
+                ],
+            ],
+        };
+    }
+
+    public function projectDetectionConfig(): array
+    {
+        return [
+            'paths' => ['.windsurf'],
+        ];
+    }
+
+    public function agentName(): string
+    {
+        return 'Cascade';
+    }
+
+    public function guidelinesPath(): string
+    {
+        return '.windsurf/rules/laravel-boost.md';
+    }
+}

--- a/src/Install/CodeEnvironmentsDetector.php
+++ b/src/Install/CodeEnvironmentsDetector.php
@@ -12,6 +12,7 @@ use Laravel\Boost\Install\CodeEnvironment\Copilot;
 use Laravel\Boost\Install\CodeEnvironment\Cursor;
 use Laravel\Boost\Install\CodeEnvironment\PhpStorm;
 use Laravel\Boost\Install\CodeEnvironment\VSCode;
+use Laravel\Boost\Install\CodeEnvironment\Windsurf;
 use Laravel\Boost\Install\Enums\Platform;
 
 class CodeEnvironmentsDetector
@@ -23,6 +24,7 @@ class CodeEnvironmentsDetector
         'cursor' => Cursor::class,
         'claudecode' => ClaudeCode::class,
         'copilot' => Copilot::class,
+        'windsurf' => Windsurf::class,
     ];
 
     public function __construct(

--- a/tests/Unit/Install/CodeEnvironmentsDetectorTest.php
+++ b/tests/Unit/Install/CodeEnvironmentsDetectorTest.php
@@ -41,6 +41,7 @@ test('discoverSystemInstalledCodeEnvironments returns detected programs', functi
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Cursor::class, fn () => $program3);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\ClaudeCode::class, fn () => $otherProgram);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Copilot::class, fn () => $otherProgram);
+    $container->bind(\Laravel\Boost\Install\CodeEnvironment\Windsurf::class, fn () => $otherProgram);
 
     $detector = new CodeEnvironmentsDetector($container);
     $detected = $detector->discoverSystemInstalledCodeEnvironments();
@@ -65,6 +66,7 @@ test('discoverSystemInstalledCodeEnvironments returns empty array when no progra
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Cursor::class, fn () => $otherProgram);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\ClaudeCode::class, fn () => $otherProgram);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Copilot::class, fn () => $otherProgram);
+    $container->bind(\Laravel\Boost\Install\CodeEnvironment\Windsurf::class, fn () => $otherProgram);
 
     $detector = new CodeEnvironmentsDetector($container);
     $detected = $detector->discoverSystemInstalledCodeEnvironments();
@@ -213,6 +215,20 @@ test('discoverProjectInstalledCodeEnvironments detects cursor with cursor direct
 
     // Cleanup
     rmdir($tempDir.'/.cursor');
+    rmdir($tempDir);
+});
+
+test('discoverProjectInstalledCodeEnvironments detects windsurf with windsurf directory', function () {
+    $tempDir = sys_get_temp_dir().'/boost_test_'.uniqid();
+    mkdir($tempDir);
+    mkdir($tempDir.'/.windsurf');
+
+    $detected = $this->detector->discoverProjectInstalledCodeEnvironments($tempDir);
+
+    expect($detected)->toContain('windsurf');
+
+    // Cleanup
+    rmdir($tempDir.'/.windsurf');
     rmdir($tempDir);
 });
 

--- a/tests/Unit/Install/WindsurfTest.php
+++ b/tests/Unit/Install/WindsurfTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Install;
+
+use Laravel\Boost\Contracts\Agent;
+use Laravel\Boost\Contracts\McpClient;
+use Laravel\Boost\Install\CodeEnvironment\Windsurf;
+use Laravel\Boost\Install\Detection\DetectionStrategyFactory;
+use Laravel\Boost\Install\Enums\Platform;
+use Mockery;
+
+beforeEach(function () {
+    $this->strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
+    $this->windsurf = new Windsurf($this->strategyFactory);
+});
+
+afterEach(function () {
+    Mockery::close();
+});
+
+test('windsurf implements Agent interface', function () {
+    expect($this->windsurf)->toBeInstanceOf(Agent::class);
+});
+
+test('windsurf does not implement McpClient interface', function () {
+    expect($this->windsurf)->not->toBeInstanceOf(McpClient::class);
+});
+
+test('windsurf returns correct name', function () {
+    expect($this->windsurf->name())->toBe('windsurf');
+});
+
+test('windsurf returns correct display name', function () {
+    expect($this->windsurf->displayName())->toBe('Windsurf');
+});
+
+test('windsurf returns correct agent name', function () {
+    expect($this->windsurf->agentName())->toBe('Cascade');
+});
+
+test('windsurf returns correct guidelines path', function () {
+    expect($this->windsurf->guidelinesPath())->toBe('.windsurf/rules/laravel-boost.md');
+});
+
+test('windsurf returns correct project detection config', function () {
+    $config = $this->windsurf->projectDetectionConfig();
+
+    expect($config)->toBe([
+        'paths' => ['.windsurf'],
+    ]);
+});
+
+test('windsurf returns correct system detection config for Darwin', function () {
+    $config = $this->windsurf->systemDetectionConfig(Platform::Darwin);
+
+    expect($config)->toBe([
+        'paths' => ['/Applications/Windsurf.app'],
+    ]);
+});
+
+test('windsurf returns correct system detection config for Linux', function () {
+    $config = $this->windsurf->systemDetectionConfig(Platform::Linux);
+
+    expect($config)->toBe([
+        'paths' => [
+            '/opt/windsurf',
+            '/usr/local/bin/windsurf',
+            '~/.local/bin/windsurf',
+            '/snap/bin/windsurf',
+        ],
+    ]);
+});
+
+test('windsurf returns correct system detection config for Windows', function () {
+    $config = $this->windsurf->systemDetectionConfig(Platform::Windows);
+
+    expect($config)->toBe([
+        'paths' => [
+            '%ProgramFiles%\\Windsurf',
+            '%LOCALAPPDATA%\\Programs\\Windsurf',
+            '%APPDATA%\\Windsurf',
+        ],
+    ]);
+});
+
+test('windsurf is detected as agent', function () {
+    expect($this->windsurf->IsAgent())->toBeTrue();
+});
+
+test('windsurf is not detected as mcp client', function () {
+    expect($this->windsurf->isMcpClient())->toBeFalse();
+});
+
+test('windsurf returns null for mcp client name', function () {
+    expect($this->windsurf->mcpClientName())->toBe('Windsurf');
+});
+
+test('windsurf returns null for mcp config path', function () {
+    expect($this->windsurf->mcpConfigPath())->toBeNull();
+});
+
+test('windsurf does not require frontmatter', function () {
+    expect($this->windsurf->frontmatter())->toBeFalse();
+});


### PR DESCRIPTION
# Add Windsurf IDE Support

## Description

This PR adds support for **Windsurf IDE** to Laravel Boost, enabling Windsurf users to receive Laravel-specific AI guidelines through Cascade (Windsurf's AI assistant).

## Motivation

Windsurf is gaining traction as a powerful AI-first IDE, and Laravel developers using Windsurf should have access to Laravel Boost's AI guidelines to improve their development experience. Currently, Windsurf users are excluded from the automated guideline installation process.

## Implementation

### Agent-Only Architecture

Windsurf is implemented as an **Agent-only** code environment:

- ✅ **Implements [Agent](cci:2://file:///Users/oluwatobi/Herd/laravel/boost/src/Contracts/Agent.php:9:0-31:1) interface** - Provides AI guidelines
- ❌ **Does NOT implement [McpClient](cci:2://file:///Users/oluwatobi/Herd/laravel/boost/src/Contracts/McpClient.php:9:0-28:1) interface** - No automated MCP configuration

### Technical Rationale

Unlike other supported IDEs (Cursor, PhpStorm, VSCode), Windsurf handles MCP server configuration differently:

| IDE | MCP Configuration | Laravel Boost Approach |
|-----|------------------|------------------------|
| Cursor | `.cursor/mcp.json` (per-project) | ✅ Automated via [McpClient](cci:2://file:///Users/oluwatobi/Herd/laravel/boost/src/Contracts/McpClient.php:9:0-28:1) |
| PhpStorm | `.junie/mcp/mcp.json` (per-project) | ✅ Automated via [McpClient](cci:2://file:///Users/oluwatobi/Herd/laravel/boost/src/Contracts/McpClient.php:9:0-28:1) |
| VSCode | `.vscode/mcp.json` (per-project) | ✅ Automated via [McpClient](cci:2://file:///Users/oluwatobi/Herd/laravel/boost/src/Contracts/McpClient.php:9:0-28:1) |
| **Windsurf** | `~/.codeium/windsurf/mcp_config.json` (global) | ❌ Manual configuration only |

**Since Windsurf only supports **global MCP configuration**, Laravel Boost respects the principle of not modifying users' global settings automatically. However, users can manually configure the MCP server if desired.**

## Configuration Details

```php
// Windsurf Configuration
Agent Name: "Cascade"
Guidelines Path: ".windsurf/rules/laravel-boost.md"
Project Detection: ".windsurf" directory
System Detection: Standard paths across macOS/Linux/Windows

## User Experience

### Automated Installation
When running `php artisan boost:install`, Windsurf users will now:

1. See Windsurf as an available option for AI guidelines
2. Receive Laravel-specific guidelines in `.windsurf/rules/laravel-boost.md`
3. Have Cascade automatically discover and apply these guidelines
```


## Screenshots from my usage :)


### Installation
<img width="779" height="1017" alt="Screenshot 2025-08-13 at 19 57 53" src="https://github.com/user-attachments/assets/21cab30c-56aa-4d44-9d9a-55674c102b8b" />


### Boost's Discovery in Cascade
<img width="543" height="577" alt="Screenshot 2025-08-13 at 19 56 56" src="https://github.com/user-attachments/assets/5de35a9c-a93e-4c64-9d8c-17f8001b442c" />


### Cascade In Action 
<img width="528" height="582" alt="Screenshot 2025-08-13 at 19 56 37" src="https://github.com/user-attachments/assets/0ebd3dc2-be17-4973-9f95-61f6521f92f3" />