### PR TITLE
fixes #80 - install Boost MCP into Claude via file instead of shell

### DIFF
--- a/src/Install/CodeEnvironment/ClaudeCode.php
+++ b/src/Install/CodeEnvironment/ClaudeCode.php
@@ -9,7 +9,7 @@ use Laravel\Boost\Contracts\McpClient;
 use Laravel\Boost\Install\Enums\McpInstallationStrategy;
 use Laravel\Boost\Install\Enums\Platform;
 
-class ClaudeCode extends CodeEnvironment implements McpClient, Agent
+class ClaudeCode extends CodeEnvironment implements Agent, McpClient
 {
     public function name(): string
     {
@@ -43,12 +43,12 @@ class ClaudeCode extends CodeEnvironment implements McpClient, Agent
 
     public function mcpInstallationStrategy(): McpInstallationStrategy
     {
-        return McpInstallationStrategy::SHELL;
+        return McpInstallationStrategy::FILE;
     }
 
-    public function shellMcpCommand(): string
+    public function mcpConfigPath(): string
     {
-        return 'claude mcp add -s project -t stdio {key} "{command}" {args} {env}';
+        return '.mcp.json';
     }
 
     public function guidelinesPath(): string


### PR DESCRIPTION
Claude Code sometimes fails to add the MCP server via `claude mcp add`, but when ran manually it works fine.

Moving to `file` MCP install makes it succeed all the time instead. This also works better for people using docker, win win.