### PR TITLE
fix: Prevent install command from breaking when `/tests` doesn't exist

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -59,7 +59,7 @@ class InstallCommand extends Command
 
     private bool $enforceTests = true;
 
-    const MIN_TEST_COUNT = 2;
+    const MIN_TEST_COUNT = 6;
 
     private string $greenTick;
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -204,7 +204,7 @@ class InstallCommand extends Command
         $hasMinimumTests = false;
 
         if (file_exists(base_path('vendor/bin/phpunit'))) {
-            $process = new Process(['php', 'artisan', 'test', '--list-tests']);
+            $process = new Process([PHP_BINARY, 'artisan', 'test', '--list-tests'], base_path());
             $process->run();
 
             /** Count the number of tests - they'll always have :: between the filename and test name */

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -208,7 +208,9 @@ class InstallCommand extends Command
             $process->run();
 
             /** Count the number of tests - they'll always have :: between the filename and test name */
-            $hasMinimumTests = collect(explode("\n", trim($process->getOutput())))
+            $hasMinimumTests = Str::of($process->getOutput())
+                ->trim()
+                ->explode("\n")
                 ->filter(fn ($line) => str_contains($line, '::'))
                 ->count() >= self::MIN_TEST_COUNT;
         }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -118,9 +118,9 @@ class InstallCommand extends Command
     private function collectInstallationPreferences(): void
     {
         $this->selectedBoostFeatures = $this->selectBoostFeatures();
-        $this->enforceTests = $this->determineTestEnforcement(ask: false);
         $this->selectedTargetMcpClient = $this->selectTargetMcpClients();
         $this->selectedTargetAgents = $this->selectTargetAgents();
+        $this->enforceTests = $this->determineTestEnforcement();
     }
 
     private function performInstallation(): void
@@ -196,23 +196,13 @@ class InstallCommand extends Command
      * won't have the CI setup to make use of them anyway, so we're just wasting their
      * tokens/money by enforcing them.
      */
-    protected function determineTestEnforcement(bool $ask = true): bool
+    protected function determineTestEnforcement(): bool
     {
-        $hasMinimumTests = Finder::create()
-            ->in(base_path('tests'))
-            ->files()
-            ->name('*.php')
-            ->count() > 6;
-
-        if (! $hasMinimumTests && $ask) {
-            $hasMinimumTests = select(
-                label: 'Should AI always create tests?',
-                options: ['Yes', 'No'],
-                default: 'Yes'
-            ) === 'Yes';
-        }
-
-        return $hasMinimumTests;
+        return select(
+            label: 'Should AI always create tests?',
+            options: ['Yes', 'No'],
+            default: 'Yes'
+        ) === 'Yes';
     }
 
     /**


### PR DESCRIPTION
Currently, on `v1.0.9`, `php artisan boost:install` will fail for any project that doesn't contain a `tests` directory at the root of the project.

```
~/Sites/central install-laravel-boost* 20s
❯ php artisan boost:install

 ██████╗   ██████╗   ██████╗  ███████╗ ████████╗
 ██╔══██╗ ██╔═══██╗ ██╔═══██╗ ██╔════╝ ╚══██╔══╝
 ██████╔╝ ██║   ██║ ██║   ██║ ███████╗    ██║
 ██╔══██╗ ██║   ██║ ██║   ██║ ╚════██║    ██║
 ██████╔╝ ╚██████╔╝ ╚██████╔╝ ███████║    ██║
 ╚═════╝   ╚═════╝   ╚═════╝  ╚══════╝    ╚═╝

  ✦ Laravel Boost :: Install :: We Must Ship ✦ 

 Let's give Redacted Project Name a Boost

Symfony\Component\Finder\Exception\DirectoryNotFoundException 

The "/Users/sagalbot/Sites/central/tests" directory does not exist.

at vendor/symfony/finder/Finder.php:646
  642▕             } elseif ($glob = glob($dir, (\defined('GLOB_BRACE') ? \GLOB_BRACE : 0) | \GLOB_ONLYDIR | \GLOB_NOSORT)) {
  643▕                 sort($glob);
  644▕                 $resolvedDirs[] = array_map($this->normalizeDir(...), $glob);
  645▕             } else {
➜ 646▕                 throw new DirectoryNotFoundException(\sprintf('The "%s" directory does not exist.', $dir));
  647▕             }
  648▕         }
  649▕ 
  650▕         $this->dirs = array_merge($this->dirs, ...$resolvedDirs);

    +15 vendor frames 

16  artisan:35
    Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
```

The installer looks for tests within the directory to determine if the user should be prompted about AI writing tests. The strategy here makes sense - remove an install step if no tests are found, but the current implementation will fail for many projects.

I think the simplest possible solution here is to just ask the user. Yes, it's one extra step, but it puts control in the hands of the user. If you're installing into a fresh Laravel project, the arbitrary 6 test threshold means you won't be asked about AI test guidelines.

If you do want to use the presence of tests as a way to determine if this question should be asked, you could call `phpunit --list-tests` and check if the output is >=6 lines. That should work for jest and phpunit regardless of test location.

## Changes
- removes check for `/tests` (fixes install failure)
- changes flow so asking is the last step

Resolves #45 