### PR TITLE
Add Kiro IDE support for automatic MCP configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ composer.lock
 /phpunit.xml
 .phpunit.result.cache
 all.md
+.vscode
+.kiro

--- a/README.md
+++ b/README.md
@@ -96,9 +96,20 @@ Laravel Boost includes AI guidelines for the following packages and frameworks. 
 
 To augment Laravel Boost with your own custom AI guidelines, add `.blade.php` files to your application's `.ai/guidelines/*` directory. These files will automatically be included with Laravel Boost's guidelines when you run `boost:install`.
 
+## Supported IDEs and Editors
+
+Laravel Boost automatically detects and configures MCP servers for the following development environments:
+
+- **Cursor** - AI-powered code editor
+- **VSCode** - Visual Studio Code
+- **PhpStorm** - JetBrains PHP IDE
+- **Claude Code** - Anthropic's code editor
+- **GitHub Copilot** - AI pair programmer
+- **Kiro** - AI assistant and IDE
+
 ## Manually Registering the Boost MCP Server
 
-Sometimes you may need to manually register the Laravel Boost MCP server with your editor of choice. You should register the MCP server using the following details:
+If your editor isn't automatically detected or you need to manually register the Laravel Boost MCP server, you should register the MCP server using the following details:
 
 <table>
 <tr><td><strong>Command</strong></td><td><code>php</code></td></tr>
@@ -117,6 +128,8 @@ JSON Example:
     }
 }
 ```
+
+For **Kiro IDE**, the configuration file should be placed at `.kiro/settings/mcp.json` in your project root.
 
 ## Contributing
 

--- a/src/Install/CodeEnvironment/Kiro.php
+++ b/src/Install/CodeEnvironment/Kiro.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install\CodeEnvironment;
+
+use Laravel\Boost\Contracts\Agent;
+use Laravel\Boost\Contracts\McpClient;
+use Laravel\Boost\Install\Enums\Platform;
+
+class Kiro extends CodeEnvironment implements Agent, McpClient
+{
+    public function name(): string
+    {
+        return 'kiro';
+    }
+
+    public function displayName(): string
+    {
+        return 'Kiro';
+    }
+
+    public function systemDetectionConfig(Platform $platform): array
+    {
+        return match ($platform) {
+            Platform::Darwin => [
+                'paths' => [
+                    '/Applications/Kiro.app',
+                    '~/Applications/Kiro.app',
+                ],
+            ],
+            Platform::Linux => [
+                'paths' => [
+                    '/opt/kiro',
+                    '/usr/local/bin/kiro',
+                    '~/.local/bin/kiro',
+                    '/snap/bin/kiro',
+                ],
+            ],
+            Platform::Windows => [
+                'paths' => [
+                    '%ProgramFiles%\\Kiro',
+                    '%LOCALAPPDATA%\\Programs\\Kiro',
+                    '%APPDATA%\\Kiro',
+                ],
+            ],
+        };
+    }
+
+    public function projectDetectionConfig(): array
+    {
+        return [
+            'paths' => ['.kiro'],
+        ];
+    }
+
+    public function mcpConfigPath(): string
+    {
+        return '.kiro/settings/mcp.json';
+    }
+
+    public function guidelinesPath(): string
+    {
+        return '.kiro/steering/laravel-boost.md';
+    }
+
+    public function frontmatter(): bool
+    {
+        return true;
+    }
+}

--- a/src/Install/CodeEnvironmentsDetector.php
+++ b/src/Install/CodeEnvironmentsDetector.php
@@ -10,6 +10,7 @@ use Laravel\Boost\Install\CodeEnvironment\ClaudeCode;
 use Laravel\Boost\Install\CodeEnvironment\CodeEnvironment;
 use Laravel\Boost\Install\CodeEnvironment\Copilot;
 use Laravel\Boost\Install\CodeEnvironment\Cursor;
+use Laravel\Boost\Install\CodeEnvironment\Kiro;
 use Laravel\Boost\Install\CodeEnvironment\PhpStorm;
 use Laravel\Boost\Install\CodeEnvironment\VSCode;
 use Laravel\Boost\Install\Enums\Platform;
@@ -23,6 +24,7 @@ class CodeEnvironmentsDetector
         'cursor' => Cursor::class,
         'claudecode' => ClaudeCode::class,
         'copilot' => Copilot::class,
+        'kiro' => Kiro::class,
     ];
 
     public function __construct(

--- a/tests/Feature/Install/CodeEnvironmentsDetectorTest.php
+++ b/tests/Feature/Install/CodeEnvironmentsDetectorTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Install\CodeEnvironment\Kiro;
+use Laravel\Boost\Install\CodeEnvironmentsDetector;
+
+it('includes kiro in available code environments', function () {
+    $detector = app(CodeEnvironmentsDetector::class);
+    $environments = $detector->getCodeEnvironments();
+
+    expect($environments)->toHaveKey('kiro');
+    expect($environments->get('kiro'))->toBeInstanceOf(Kiro::class);
+});
+
+it('can detect kiro in project when .kiro directory exists', function () {
+    $detector = app(CodeEnvironmentsDetector::class);
+
+    // Since we're in a project with .kiro directory, it should be detected
+    $projectEnvironments = $detector->discoverProjectInstalledCodeEnvironments(base_path());
+
+    expect($projectEnvironments)->toContain('kiro');
+});

--- a/tests/Feature/Install/CodeEnvironmentsDetectorTest.php
+++ b/tests/Feature/Install/CodeEnvironmentsDetectorTest.php
@@ -16,8 +16,16 @@ it('includes kiro in available code environments', function () {
 it('can detect kiro in project when .kiro directory exists', function () {
     $detector = app(CodeEnvironmentsDetector::class);
 
-    // Since we're in a project with .kiro directory, it should be detected
-    $projectEnvironments = $detector->discoverProjectInstalledCodeEnvironments(base_path());
+    // Create a temporary directory with .kiro folder
+    $tempDir = sys_get_temp_dir() . '/boost_test_' . uniqid();
+    mkdir($tempDir);
+    mkdir($tempDir . '/.kiro');
+
+    $projectEnvironments = $detector->discoverProjectInstalledCodeEnvironments($tempDir);
 
     expect($projectEnvironments)->toContain('kiro');
+
+    // Cleanup
+    rmdir($tempDir . '/.kiro');
+    rmdir($tempDir);
 });

--- a/tests/Feature/Install/KiroCodeEnvironmentTest.php
+++ b/tests/Feature/Install/KiroCodeEnvironmentTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Install\CodeEnvironment\Kiro;
+use Laravel\Boost\Install\Detection\DetectionStrategyFactory;
+use Laravel\Boost\Install\Enums\Platform;
+
+it('can detect kiro on system', function () {
+    $kiro = new Kiro(app(DetectionStrategyFactory::class));
+
+    expect($kiro->name())->toBe('kiro');
+    expect($kiro->displayName())->toBe('Kiro');
+    expect($kiro->mcpClientName())->toBe('Kiro');
+    expect($kiro->agentName())->toBe('Kiro');
+});
+
+it('has correct system detection paths for different platforms', function () {
+    $kiro = new Kiro(app(DetectionStrategyFactory::class));
+
+    $darwinConfig = $kiro->systemDetectionConfig(Platform::Darwin);
+    expect($darwinConfig['paths'])->toContain('/Applications/Kiro.app');
+
+    $linuxConfig = $kiro->systemDetectionConfig(Platform::Linux);
+    expect($linuxConfig['paths'])->toContain('/opt/kiro');
+
+    $windowsConfig = $kiro->systemDetectionConfig(Platform::Windows);
+    expect($windowsConfig['paths'])->toContain('%ProgramFiles%\\Kiro');
+});
+
+it('has correct project detection config', function () {
+    $kiro = new Kiro(app(DetectionStrategyFactory::class));
+
+    $config = $kiro->projectDetectionConfig();
+    expect($config['paths'])->toContain('.kiro');
+});
+
+it('has correct mcp config path', function () {
+    $kiro = new Kiro(app(DetectionStrategyFactory::class));
+
+    expect($kiro->mcpConfigPath())->toBe('.kiro/settings/mcp.json');
+});
+
+it('has correct guidelines path', function () {
+    $kiro = new Kiro(app(DetectionStrategyFactory::class));
+
+    expect($kiro->guidelinesPath())->toBe('.kiro/steering/laravel-boost.md');
+});
+
+it('implements required contracts', function () {
+    $kiro = new Kiro(app(DetectionStrategyFactory::class));
+
+    expect($kiro)->toBeInstanceOf(\Laravel\Boost\Contracts\Agent::class);
+    expect($kiro)->toBeInstanceOf(\Laravel\Boost\Contracts\McpClient::class);
+});
+
+it('uses frontmatter for guidelines', function () {
+    $kiro = new Kiro(app(DetectionStrategyFactory::class));
+
+    expect($kiro->frontmatter())->toBeTrue();
+});


### PR DESCRIPTION
- Add Kiro code environment class with system and project detection
- Update CodeEnvironmentsDetector to include Kiro in supported IDEs
- Add comprehensive tests for Kiro integration
- Update README to document Kiro support
- Enable automatic MCP server configuration at .kiro/settings/mcp.json
- Add AI guidelines support at .kiro/steering/laravel-boost.md

Resolves automatic detection and configuration for Kiro IDE users

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
