### PR TITLE
Fix: Prevent autoloading non class-like files during discovery to avoid "FatalError: Cannot redeclare function"

### DIFF
--- a/src/Install/GuidelineAssist.php
+++ b/src/Install/GuidelineAssist.php
@@ -112,7 +112,7 @@ class GuidelineAssist
             return $cache[$path];
         }
 
-        $code = @file_get_contents($path);
+        $code = file_get_contents($path);
         if ($code === false) {
             return $cache[$path] = false;
         }

--- a/src/Install/GuidelineAssist.php
+++ b/src/Install/GuidelineAssist.php
@@ -80,8 +80,14 @@ class GuidelineAssist
                 );
 
                 try {
+                    $path = $appPath.DIRECTORY_SEPARATOR.$relativePath;
+
+                    if (! $this->fileHasClassLike($path)) {
+                        continue;
+                    }
+
                     if (class_exists($className)) {
-                        self::$classes[$className] = $appPath.DIRECTORY_SEPARATOR.$relativePath;
+                        self::$classes[$className] = $path;
                     }
                 } catch (\Throwable) {
                     // Ignore exceptions and errors from class loading/reflection
@@ -96,6 +102,38 @@ class GuidelineAssist
         }
 
         return $classes;
+    }
+
+    public function fileHasClassLike(string $path): bool
+    {
+        static $cache = [];
+
+        if (isset($cache[$path])) {
+            return $cache[$path];
+        }
+
+        $code = @file_get_contents($path);
+        if ($code === false) {
+            return $cache[$path] = false;
+        }
+
+        if (stripos($code, 'class') === false
+            && stripos($code, 'interface') === false
+            && stripos($code, 'trait') === false
+            && stripos($code, 'enum') === false) {
+            return $cache[$path] = false;
+        }
+
+        $tokens = token_get_all($code);
+        foreach ($tokens as $token) {
+            if (is_array($token)) {
+                if (in_array($token[0], [T_CLASS, T_INTERFACE, T_TRAIT, T_ENUM], true)) {
+                    return $cache[$path] = true;
+                }
+            }
+        }
+
+        return $cache[$path] = false;
     }
 
     public function shouldEnforceStrictTypes(): bool


### PR DESCRIPTION
Description Summary
- This PR resolves some points discussed in #67 
- Add a lightweight guard (fileHasClassLike) before calling class_exists during app discovery.
- Skip files that do not contain a class/interface/trait/enum to prevent unintended autoloading of helpers or function-only files.

Motivation
- class_exists triggered Composer’s autoload for helper files that only declare functions, which could lead to double-inclusion and a Fatal error: Cannot redeclare function.
- Discovery only needs class-like types (Models, Controllers, Enums), so loading helpers is unnecessary and risky.

Changes
- Introduce fileHasClassLike($path) with:
    - static in-memory cache per path;
    - cheap keyword pre-check to avoid tokenization when possible;
    - token-based detection (T_CLASS, T_INTERFACE, T_TRAIT, T_ENUM) to avoid false positives.

- Use this guard in the discovery loop to skip non class-like files before invoking class_exists.

Fixes #67