### PR TITLE
Enhance MCP commands for WSL compatibility

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -559,19 +559,12 @@ class InstallCommand extends Command
     }
 
     /**
-     * Checks if the current script is running inside a Windows Subsystem for Linux (WSL) environment.
-     *
-     * This is more specific as it differentiates between a native Linux installation and WSL.
-     *
-     * @return bool True if the environment is WSL, false otherwise.
+     * Are we running inside a Windows Subsystem for Linux (WSL) environment?
+     * This differentiates between a regular Linux installation and a WSL.
      */
     private function isRunningInWsl(): bool
     {
         // Check for WSL-specific environment variables.
-        if (! empty(getenv('WSL_DISTRO_NAME')) || ! empty(getenv('IS_WSL'))) {
-            return true;
-        }
-
-        return false;
+        return ! empty(getenv('WSL_DISTRO_NAME')) || ! empty(getenv('IS_WSL'));
     }
 }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -567,7 +567,6 @@ class InstallCommand extends Command
      */
     private function isRunningInWsl(): bool
     {
-
         // Check for WSL-specific environment variables.
         if (! empty(getenv('WSL_DISTRO_NAME')) || ! empty(getenv('IS_WSL'))) {
             return true;

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -488,14 +488,20 @@ class InstallCommand extends Command
             $results = [];
 
             if ($this->shouldInstallMcp()) {
-                $php = $mcpClient->getPhpPath($this->isRunningInWsl());
-                $artisan = $mcpClient->getArtisanPath($this->isRunningInWsl());
+                $inWsl = $this->isRunningInWsl();
+                $mcp = array_filter([
+                    'laravel-boost',
+                    $inWsl ? 'wsl' : false,
+                    $mcpClient->getPhpPath($inWsl),
+                    $mcpClient->getArtisanPath($inWsl),
+                    'boost:mcp',
+                ]);
                 try {
-                    if ($this->isRunningInWsl()) {
-                        $result = $mcpClient->installMcp('laravel-boost', 'wsl', [$php, $artisan, 'boost:mcp']);
-                    } else {
-                        $result = $mcpClient->installMcp('laravel-boost', $php, [$artisan, 'boost:mcp']);
-                    }
+                    $result = $mcpClient->installMcp(
+                        array_shift($mcp),
+                        array_shift($mcp),
+                        $mcp
+                    );
 
                     if ($result) {
                         $results[] = $this->greenTick.' Boost';

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -487,14 +487,13 @@ class InstallCommand extends Command
             $this->output->write("  {$ideDisplay}... ");
             $results = [];
 
-            $php = $mcpClient->getPhpPath();
             if ($this->shouldInstallMcp()) {
+                $php = $mcpClient->getPhpPath($this->isRunningInWsl());
+                $artisan = $mcpClient->getArtisanPath($this->isRunningInWsl());
                 try {
                     if ($this->isRunningInWsl()) {
-                        $artisan = $mcpClient->getArtisanPath(true);
                         $result = $mcpClient->installMcp('laravel-boost', 'wsl', [$php, $artisan, 'boost:mcp']);
                     } else {
-                        $artisan = $mcpClient->getArtisanPath();
                         $result = $mcpClient->installMcp('laravel-boost', $php, [$artisan, 'boost:mcp']);
                     }
 
@@ -512,6 +511,7 @@ class InstallCommand extends Command
 
             // Install Herd MCP if enabled
             if ($this->shouldInstallHerdMcp()) {
+                $php = $mcpClient->getPhpPath();
                 try {
                     $result = $mcpClient->installMcp(
                         key: 'herd',

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -490,8 +490,13 @@ class InstallCommand extends Command
             $php = $mcpClient->getPhpPath();
             if ($this->shouldInstallMcp()) {
                 try {
-                    $artisan = $mcpClient->getArtisanPath();
-                    $result = $mcpClient->installMcp('laravel-boost', $php, [$artisan, 'boost:mcp']);
+                    if ($this->isRunningInWsl()) {
+                        $artisan = $mcpClient->getArtisanPath(true);
+                        $result = $mcpClient->installMcp('laravel-boost', 'wsl', [$php, $artisan, 'boost:mcp']);
+                    } else {
+                        $artisan = $mcpClient->getArtisanPath();
+                        $result = $mcpClient->installMcp('laravel-boost', $php, [$artisan, 'boost:mcp']);
+                    }
 
                     if ($result) {
                         $results[] = $this->greenTick.' Boost';
@@ -551,5 +556,23 @@ class InstallCommand extends Command
 
         /** @phpstan-ignore-next-line  */
         return $actuallyUsing && is_dir(base_path('lang'));
+    }
+
+    /**
+     * Checks if the current script is running inside a Windows Subsystem for Linux (WSL) environment.
+     *
+     * This is more specific as it differentiates between a native Linux installation and WSL.
+     *
+     * @return bool True if the environment is WSL, false otherwise.
+     */
+    private function isRunningInWsl(): bool
+    {
+
+        // Check for WSL-specific environment variables.
+        if (! empty(getenv('WSL_DISTRO_NAME')) || ! empty(getenv('IS_WSL'))) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Contracts/McpClient.php
+++ b/src/Contracts/McpClient.php
@@ -22,12 +22,12 @@ interface McpClient
     /**
      * Get the PHP executable path for this MCP client.
      */
-    public function getPhpPath($forceAbsolutePath = false): string;
+    public function getPhpPath(bool $forceAbsolutePath = false): string;
 
     /**
      * Get the artisan path for this MCP client.
      */
-    public function getArtisanPath($forceAbsolutePath = false): string;
+    public function getArtisanPath(bool $forceAbsolutePath = false): string;
 
     /**
      * Install an MCP server configuration in this IDE.

--- a/src/Contracts/McpClient.php
+++ b/src/Contracts/McpClient.php
@@ -27,7 +27,7 @@ interface McpClient
     /**
      * Get the artisan path for this MCP client.
      */
-    public function getArtisanPath(): string;
+    public function getArtisanPath($forceAbsolutePath = false): string;
 
     /**
      * Install an MCP server configuration in this IDE.

--- a/src/Contracts/McpClient.php
+++ b/src/Contracts/McpClient.php
@@ -22,7 +22,7 @@ interface McpClient
     /**
      * Get the PHP executable path for this MCP client.
      */
-    public function getPhpPath(): string;
+    public function getPhpPath($forceAbsolutePath = false): string;
 
     /**
      * Get the artisan path for this MCP client.

--- a/src/Install/CodeEnvironment/CodeEnvironment.php
+++ b/src/Install/CodeEnvironment/CodeEnvironment.php
@@ -38,12 +38,12 @@ abstract class CodeEnvironment
         return $this->useAbsolutePathForMcp;
     }
 
-    public function getPhpPath($forceAbsolutePath = false): string
+    public function getPhpPath(bool $forceAbsolutePath = false): string
     {
         return ($this->useAbsolutePathForMcp() || $forceAbsolutePath) ? PHP_BINARY : 'php';
     }
 
-    public function getArtisanPath($forceAbsolutePath = false): string
+    public function getArtisanPath(bool $forceAbsolutePath = false): string
     {
         return ($this->useAbsolutePathForMcp() || $forceAbsolutePath) ? base_path('artisan') : 'artisan';
     }

--- a/src/Install/CodeEnvironment/CodeEnvironment.php
+++ b/src/Install/CodeEnvironment/CodeEnvironment.php
@@ -38,9 +38,9 @@ abstract class CodeEnvironment
         return $this->useAbsolutePathForMcp;
     }
 
-    public function getPhpPath(): string
+    public function getPhpPath($forceAbsolutePath = false): string
     {
-        return $this->useAbsolutePathForMcp() ? PHP_BINARY : 'php';
+        return ($this->useAbsolutePathForMcp() || $forceAbsolutePath) ? PHP_BINARY : 'php';
     }
 
     public function getArtisanPath($forceAbsolutePath = false): string

--- a/src/Install/CodeEnvironment/CodeEnvironment.php
+++ b/src/Install/CodeEnvironment/CodeEnvironment.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Laravel\Boost\Install\CodeEnvironment;
 
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
-use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Process;
 use Laravel\Boost\Contracts\Agent;
 use Laravel\Boost\Contracts\McpClient;
@@ -44,9 +43,9 @@ abstract class CodeEnvironment
         return $this->useAbsolutePathForMcp() ? PHP_BINARY : 'php';
     }
 
-    public function getArtisanPath(): string
+    public function getArtisanPath($forceAbsolutePath = false): string
     {
-        return $this->useAbsolutePathForMcp() ? base_path('artisan') : 'artisan';
+        return ($this->useAbsolutePathForMcp() || $forceAbsolutePath) ? base_path('artisan') : 'artisan';
     }
 
     /**

--- a/tests/Feature/Console/InstallCommandWslTest.php
+++ b/tests/Feature/Console/InstallCommandWslTest.php
@@ -4,60 +4,55 @@ declare(strict_types=1);
 
 use Laravel\Boost\Console\InstallCommand;
 
-test('isRunningInWsl returns true when WSL_DISTRO_NAME is set', function () {
+test('isRunningInWsl returns true when WSL_DISTRO_NAME is set', function (): void {
     putenv('WSL_DISTRO_NAME=Ubuntu');
 
-    $command = new InstallCommand();
+    $command = new InstallCommand;
     $reflection = new ReflectionClass($command);
     $method = $reflection->getMethod('isRunningInWsl');
-    $method->setAccessible(true);
 
     expect($method->invoke($command))->toBeTrue();
 });
 
-test('isRunningInWsl returns true when IS_WSL is set', function () {
+test('isRunningInWsl returns true when IS_WSL is set', function (): void {
     putenv('IS_WSL=1');
 
-    $command = new InstallCommand();
+    $command = new InstallCommand;
     $reflection = new ReflectionClass($command);
     $method = $reflection->getMethod('isRunningInWsl');
-    $method->setAccessible(true);
 
     expect($method->invoke($command))->toBeTrue();
 });
 
-test('isRunningInWsl returns true when both WSL env vars are set', function () {
+test('isRunningInWsl returns true when both WSL env vars are set', function (): void {
     putenv('WSL_DISTRO_NAME=Ubuntu');
     putenv('IS_WSL=true');
 
-    $command = new InstallCommand();
+    $command = new InstallCommand;
     $reflection = new ReflectionClass($command);
     $method = $reflection->getMethod('isRunningInWsl');
-    $method->setAccessible(true);
 
     expect($method->invoke($command))->toBeTrue();
 });
 
-test('isRunningInWsl returns false when no WSL env vars are set', function () {
+test('isRunningInWsl returns false when no WSL env vars are set', function (): void {
     putenv('WSL_DISTRO_NAME');
     putenv('IS_WSL');
 
-    $command = new InstallCommand();
+    $command = new InstallCommand;
     $reflection = new ReflectionClass($command);
     $method = $reflection->getMethod('isRunningInWsl');
-    $method->setAccessible(true);
 
     expect($method->invoke($command))->toBeFalse();
 });
 
-test('isRunningInWsl returns false when WSL env vars are empty strings', function () {
+test('isRunningInWsl returns false when WSL env vars are empty strings', function (): void {
     putenv('WSL_DISTRO_NAME=');
     putenv('IS_WSL=');
 
-    $command = new InstallCommand();
+    $command = new InstallCommand;
     $reflection = new ReflectionClass($command);
     $method = $reflection->getMethod('isRunningInWsl');
-    $method->setAccessible(true);
 
     expect($method->invoke($command))->toBeFalse();
 });

--- a/tests/Feature/Console/InstallCommandWslTest.php
+++ b/tests/Feature/Console/InstallCommandWslTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Console\InstallCommand;
+
+test('isRunningInWsl returns true when WSL_DISTRO_NAME is set', function () {
+    putenv('WSL_DISTRO_NAME=Ubuntu');
+
+    $command = new InstallCommand();
+    $reflection = new ReflectionClass($command);
+    $method = $reflection->getMethod('isRunningInWsl');
+    $method->setAccessible(true);
+
+    expect($method->invoke($command))->toBeTrue();
+});
+
+test('isRunningInWsl returns true when IS_WSL is set', function () {
+    putenv('IS_WSL=1');
+
+    $command = new InstallCommand();
+    $reflection = new ReflectionClass($command);
+    $method = $reflection->getMethod('isRunningInWsl');
+    $method->setAccessible(true);
+
+    expect($method->invoke($command))->toBeTrue();
+});
+
+test('isRunningInWsl returns true when both WSL env vars are set', function () {
+    putenv('WSL_DISTRO_NAME=Ubuntu');
+    putenv('IS_WSL=true');
+
+    $command = new InstallCommand();
+    $reflection = new ReflectionClass($command);
+    $method = $reflection->getMethod('isRunningInWsl');
+    $method->setAccessible(true);
+
+    expect($method->invoke($command))->toBeTrue();
+});
+
+test('isRunningInWsl returns false when no WSL env vars are set', function () {
+    putenv('WSL_DISTRO_NAME');
+    putenv('IS_WSL');
+
+    $command = new InstallCommand();
+    $reflection = new ReflectionClass($command);
+    $method = $reflection->getMethod('isRunningInWsl');
+    $method->setAccessible(true);
+
+    expect($method->invoke($command))->toBeFalse();
+});
+
+test('isRunningInWsl returns false when WSL env vars are empty strings', function () {
+    putenv('WSL_DISTRO_NAME=');
+    putenv('IS_WSL=');
+
+    $command = new InstallCommand();
+    $reflection = new ReflectionClass($command);
+    $method = $reflection->getMethod('isRunningInWsl');
+    $method->setAccessible(true);
+
+    expect($method->invoke($command))->toBeFalse();
+});

--- a/tests/Feature/Install/CodeEnvironment/CodeEnvironmentPathResolutionTest.php
+++ b/tests/Feature/Install/CodeEnvironment/CodeEnvironmentPathResolutionTest.php
@@ -38,7 +38,7 @@ test('Cursor returns relative artisan path', function (): void {
     expect($cursor->getArtisanPath())->toBe('artisan');
 });
 
-test('CodeEnvironment returns absolute paths when forceAbsolutePath is true', function () {
+test('CodeEnvironment returns absolute paths when forceAbsolutePath is true', function (): void {
     $strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
     $cursor = new Cursor($strategyFactory);
 
@@ -47,7 +47,7 @@ test('CodeEnvironment returns absolute paths when forceAbsolutePath is true', fu
         ->and($cursor->getArtisanPath(true))->not()->toBe('artisan');
 });
 
-test('CodeEnvironment maintains relative paths when forceAbsolutePath is false', function () {
+test('CodeEnvironment maintains relative paths when forceAbsolutePath is false', function (): void {
     $strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
     $cursor = new Cursor($strategyFactory);
 
@@ -55,7 +55,7 @@ test('CodeEnvironment maintains relative paths when forceAbsolutePath is false',
     expect($cursor->getArtisanPath(false))->toBe('artisan');
 });
 
-test('PhpStorm paths remain absolute regardless of forceAbsolutePath parameter', function () {
+test('PhpStorm paths remain absolute regardless of forceAbsolutePath parameter', function (): void {
     $strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
     $phpStorm = new PhpStorm($strategyFactory);
 

--- a/tests/Feature/Install/CodeEnvironment/CodeEnvironmentPathResolutionTest.php
+++ b/tests/Feature/Install/CodeEnvironment/CodeEnvironmentPathResolutionTest.php
@@ -37,3 +37,35 @@ test('Cursor returns relative artisan path', function (): void {
 
     expect($cursor->getArtisanPath())->toBe('artisan');
 });
+
+test('CodeEnvironment returns absolute paths when forceAbsolutePath is true', function () {
+    $strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
+    $cursor = new Cursor($strategyFactory);
+
+    expect($cursor->getPhpPath(true))->toBe(PHP_BINARY);
+    expect($cursor->getArtisanPath(true))->toEndWith('artisan')
+        ->and($cursor->getArtisanPath(true))->not()->toBe('artisan');
+});
+
+test('CodeEnvironment maintains relative paths when forceAbsolutePath is false', function () {
+    $strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
+    $cursor = new Cursor($strategyFactory);
+
+    expect($cursor->getPhpPath(false))->toBe('php');
+    expect($cursor->getArtisanPath(false))->toBe('artisan');
+});
+
+test('PhpStorm paths remain absolute regardless of forceAbsolutePath parameter', function () {
+    $strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
+    $phpStorm = new PhpStorm($strategyFactory);
+
+    // PhpStorm always uses absolute paths, so forceAbsolutePath shouldn't change behavior
+    expect($phpStorm->getPhpPath(true))->toBe(PHP_BINARY);
+    expect($phpStorm->getPhpPath(false))->toBe(PHP_BINARY);
+
+    $artisanPath = $phpStorm->getArtisanPath(true);
+    expect($artisanPath)->toEndWith('artisan')
+        ->and($artisanPath)->not()->toBe('artisan');
+
+    expect($phpStorm->getArtisanPath(false))->toBe($artisanPath);
+});

--- a/tests/Unit/Install/CodeEnvironment/CodeEnvironmentTest.php
+++ b/tests/Unit/Install/CodeEnvironment/CodeEnvironmentTest.php
@@ -410,12 +410,12 @@ test('installFileMcp works with existing config file using JSON 5', function ():
         ->and($capturedContent)->toBe(fixture('mcp-expected.json5'));
 });
 
-test('getPhpPath uses absolute paths when forceAbsolutePath is true', function () {
+test('getPhpPath uses absolute paths when forceAbsolutePath is true', function (): void {
     $environment = new TestCodeEnvironment($this->strategyFactory);
     expect($environment->getPhpPath(true))->toBe(PHP_BINARY);
 });
 
-test('getPhpPath maintains default behavior when forceAbsolutePath is false', function () {
+test('getPhpPath maintains default behavior when forceAbsolutePath is false', function (): void {
     $environment = new TestCodeEnvironment($this->strategyFactory);
     expect($environment->getPhpPath(false))->toBe('php');
 });

--- a/tests/Unit/Install/CodeEnvironment/CodeEnvironmentTest.php
+++ b/tests/Unit/Install/CodeEnvironment/CodeEnvironmentTest.php
@@ -409,3 +409,13 @@ test('installFileMcp works with existing config file using JSON 5', function ():
         ->and($capturedPath)->toBe($vscode->mcpConfigPath())
         ->and($capturedContent)->toBe(fixture('mcp-expected.json5'));
 });
+
+test('getPhpPath uses absolute paths when forceAbsolutePath is true', function () {
+    $environment = new TestCodeEnvironment($this->strategyFactory);
+    expect($environment->getPhpPath(true))->toBe(PHP_BINARY);
+});
+
+test('getPhpPath maintains default behavior when forceAbsolutePath is false', function () {
+    $environment = new TestCodeEnvironment($this->strategyFactory);
+    expect($environment->getPhpPath(false))->toBe('php');
+});


### PR DESCRIPTION
### Description:

This PR updates Laravel Boost’s MCP server command configuration to ensure compatibility when running inside WSL. Instead of relying on PhpStorm to directly execute the WSL PHP binary (which fails due to path and process resolution differences), the changes adjust the `mcp.json` command to invoke PHP in a way that works in both native and WSL environments.

**Key changes:**

* Added a **`isRunningInWsl()`**.
* When running under WSL, set the MCP `command` to `"wsl"` instead of `"php"`, and pass the PHP binary path as the first argument.
* Introduced a **`$forceAbsolutePath`** option to ensure the PHP binary/artisan path is absolute when in WSL mode.
* Preserved the original `"php"` command for non-WSL environments to maintain backward compatibility.


> While this issue was reproduced in PhpStorm, the fix applies to any IDE that runs the MCP command directly without WSL resolution.


Fixes #120