### PR TITLE
feat: add support for Warp

### DIFF
--- a/src/Install/CodeEnvironment/Warp.php
+++ b/src/Install/CodeEnvironment/Warp.php
@@ -29,7 +29,10 @@ class Warp extends CodeEnvironment implements Agent
                 ],
             ],
             Platform::Linux => [
-                'paths' => [],
+                'command' => [
+                    'which warp-terminal',
+                    'which warp-terminal-preview',
+                ],
             ],
             Platform::Windows => [
                 'paths' => [

--- a/src/Install/CodeEnvironment/Warp.php
+++ b/src/Install/CodeEnvironment/Warp.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install\CodeEnvironment;
+
+use Laravel\Boost\Contracts\Agent;
+use Laravel\Boost\Install\Enums\Platform;
+
+class Warp extends CodeEnvironment implements Agent
+{
+    public function name(): string
+    {
+        return 'warp';
+    }
+
+    public function displayName(): string
+    {
+        return 'Warp';
+    }
+
+    public function systemDetectionConfig(Platform $platform): array
+    {
+        return match ($platform) {
+            Platform::Darwin => [
+                'paths' => [
+                    '/Applications/Warp.app',
+                    '/Applications/WarpPreview.app',
+                ],
+            ],
+            Platform::Linux => [
+                'paths' => [],
+            ],
+            Platform::Windows => [
+                'paths' => [
+                    '%ProgramFiles%\\Warp',
+                    '%ProgramFiles%\\WarpPreview',
+                    '%LOCALAPPDATA%\\Programs\\Warp',
+                    '%LOCALAPPDATA%\\Programs\\WarpPreview',
+                ],
+            ],
+        };
+    }
+
+    public function projectDetectionConfig(): array
+    {
+        return [
+            'paths' => [],
+        ];
+    }
+
+    public function guidelinesPath(): string
+    {
+        return 'WARP.md';
+    }
+
+    public function frontmatter(): bool
+    {
+        return false;
+    }
+}

--- a/src/Install/CodeEnvironment/Warp.php
+++ b/src/Install/CodeEnvironment/Warp.php
@@ -45,7 +45,7 @@ class Warp extends CodeEnvironment implements Agent
     public function projectDetectionConfig(): array
     {
         return [
-            'paths' => [],
+            'files' => ['WARP.md'],
         ];
     }
 

--- a/src/Install/CodeEnvironmentsDetector.php
+++ b/src/Install/CodeEnvironmentsDetector.php
@@ -12,6 +12,7 @@ use Laravel\Boost\Install\CodeEnvironment\Copilot;
 use Laravel\Boost\Install\CodeEnvironment\Cursor;
 use Laravel\Boost\Install\CodeEnvironment\PhpStorm;
 use Laravel\Boost\Install\CodeEnvironment\VSCode;
+use Laravel\Boost\Install\CodeEnvironment\Warp;
 use Laravel\Boost\Install\Enums\Platform;
 
 class CodeEnvironmentsDetector
@@ -23,6 +24,7 @@ class CodeEnvironmentsDetector
         'cursor' => Cursor::class,
         'claudecode' => ClaudeCode::class,
         'copilot' => Copilot::class,
+        'warp' => Warp::class,
     ];
 
     public function __construct(

--- a/tests/Unit/Install/CodeEnvironmentsDetectorTest.php
+++ b/tests/Unit/Install/CodeEnvironmentsDetectorTest.php
@@ -146,6 +146,20 @@ test('discoverProjectInstalledCodeEnvironments detects applications with mixed t
     rmdir($tempDir);
 });
 
+test('discoverProjectInstalledCodeEnvironments detects warp with WARP.md file', function () {
+    $tempDir = sys_get_temp_dir().'/boost_test_'.uniqid();
+    mkdir($tempDir);
+    file_put_contents($tempDir.'/WARP.md', 'test');
+
+    $detected = $this->detector->discoverProjectInstalledCodeEnvironments($tempDir);
+
+    expect($detected)->toContain('warp');
+
+    // Cleanup
+    unlink($tempDir.'/WARP.md');
+    rmdir($tempDir);
+});
+
 test('discoverProjectInstalledCodeEnvironments detects copilot with nested file path', function () {
     $tempDir = sys_get_temp_dir().'/boost_test_'.uniqid();
     mkdir($tempDir);
@@ -224,17 +238,20 @@ test('discoverProjectInstalledCodeEnvironments handles multiple detections', fun
     mkdir($tempDir.'/.vscode');
     mkdir($tempDir.'/.cursor');
     file_put_contents($tempDir.'/CLAUDE.md', 'test');
+    file_put_contents($tempDir.'/WARP.md', 'test');
 
     $detected = $this->detector->discoverProjectInstalledCodeEnvironments($tempDir);
 
     expect($detected)->toContain('vscode');
     expect($detected)->toContain('cursor');
     expect($detected)->toContain('claudecode');
-    expect(count($detected))->toBeGreaterThanOrEqual(3);
+    expect($detected)->toContain('warp');
+    expect(count($detected))->toBeGreaterThanOrEqual(4);
 
     // Cleanup
     rmdir($tempDir.'/.vscode');
     rmdir($tempDir.'/.cursor');
     unlink($tempDir.'/CLAUDE.md');
+    unlink($tempDir.'/WARP.md');
     rmdir($tempDir);
 });

--- a/tests/Unit/Install/CodeEnvironmentsDetectorTest.php
+++ b/tests/Unit/Install/CodeEnvironmentsDetectorTest.php
@@ -41,6 +41,7 @@ test('discoverSystemInstalledCodeEnvironments returns detected programs', functi
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Cursor::class, fn () => $program3);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\ClaudeCode::class, fn () => $otherProgram);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Copilot::class, fn () => $otherProgram);
+    $container->bind(\Laravel\Boost\Install\CodeEnvironment\Warp::class, fn () => $otherProgram);
 
     $detector = new CodeEnvironmentsDetector($container);
     $detected = $detector->discoverSystemInstalledCodeEnvironments();
@@ -65,6 +66,7 @@ test('discoverSystemInstalledCodeEnvironments returns empty array when no progra
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Cursor::class, fn () => $otherProgram);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\ClaudeCode::class, fn () => $otherProgram);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Copilot::class, fn () => $otherProgram);
+    $container->bind(\Laravel\Boost\Install\CodeEnvironment\Warp::class, fn () => $otherProgram);
 
     $detector = new CodeEnvironmentsDetector($container);
     $detected = $detector->discoverSystemInstalledCodeEnvironments();


### PR DESCRIPTION
Warp has added support for project-scoped rules files, `WARP.md`, in its latest stable update[^1]. This PR adds Warp as an agent so it can generate `WARP.md` if Warp or WarpPreview is detected on a user's system.

Opening this as a draft because I'm currently not sure how to detect it on Linux systems, maybe the `.warp` config folder is an option. I have asked the team at Warp and am waiting for a response on the way to detect it on Linux.

As for `projectDetectionConfig`, there isn't one. Warp is system-wide, unless `WARP.md` could work there, or is an empty `paths` correct?

I have tested this PR on Mac, and it does auto-detect Warp and generates the correct file:

<img width="1033" height="464" alt="detects-warp" src="https://github.com/user-attachments/assets/622b133a-c155-41e4-871c-e14db8392a40" />

<img width="841" height="422" alt="successful-guideline-generation" src="https://github.com/user-attachments/assets/1b1dd990-be9e-4833-84f2-f179faaebc7b" />

[^1]: https://docs.warp.dev/getting-started/changelog#id-2025.08.13-v0.2025.08.13.08.12