### PR TITLE
[1.x] Add enabled option to `config/boost.php`.

### DIFF
--- a/config/boost.php
+++ b/config/boost.php
@@ -3,6 +3,18 @@
 declare(strict_types=1);
 
 return [
+    /*
+    |--------------------------------------------------------------------------
+    | Boost Master Switch
+    |--------------------------------------------------------------------------
+    |
+    | This option may be used to disable all Boost functionality, which
+    | simply provides a single and convenient way to enable or disable
+    | Boost's AI development tools.
+    |
+    */
+
+    'enabled' => env('BOOST_ENABLED', true),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/BoostServiceProvider.php
+++ b/src/BoostServiceProvider.php
@@ -55,6 +55,10 @@ class BoostServiceProvider extends ServiceProvider
 
     public function boot(Router $router): void
     {
+        if (! config('boost.enabled', true)) {
+            return;
+        }
+
         // Only enable Boost on local environments
         if (! app()->environment(['local', 'testing']) && config('app.debug', false) !== true) {
             return;


### PR DESCRIPTION
This PR adds a master switch to control if it should be enabled or not (similar to other laravel packages).

This is specially useful when running browser unit tests, since boost adds console logs and when asserting there are no console.logs the test fails.
