### PR TITLE
feat: don't run Boost during testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/contracts": "^10.0|^11.0|^12.0",
         "illuminate/routing": "^10.0|^11.0|^12.0",
         "illuminate/support": "^10.0|^11.0|^12.0",
-        "laravel/mcp": "^0.1.0",
+        "laravel/mcp": "^0.1.1",
         "laravel/prompts": "^0.1.9|^0.3",
         "laravel/roster": "^0.2"
     },

--- a/src/BoostServiceProvider.php
+++ b/src/BoostServiceProvider.php
@@ -19,12 +19,17 @@ use Laravel\Roster\Roster;
 
 class BoostServiceProvider extends ServiceProvider
 {
+
     public function register(): void
     {
         $this->mergeConfigFrom(
             __DIR__.'/../config/boost.php',
             'boost'
         );
+
+        if (! $this->shouldRun()) {
+            return;
+        }
 
         $this->app->singleton(Roster::class, function () {
             $lockFiles = [
@@ -55,24 +60,21 @@ class BoostServiceProvider extends ServiceProvider
 
     public function boot(Router $router): void
     {
-        if (! config('boost.enabled', true)) {
+        if (! $this->shouldRun()) {
             return;
         }
 
-        // Only enable Boost on local environments
-        if (! app()->environment(['local', 'testing']) && config('app.debug', false) !== true) {
-            return;
-        }
-
-        // @phpstan-ignore-next-line
         Mcp::local('laravel-boost', Boost::class);
 
         $this->registerPublishing();
         $this->registerCommands();
         $this->registerRoutes();
-        $this->registerBrowserLogger();
-        $this->callAfterResolving('blade.compiler', fn (BladeCompiler $bladeCompiler) => $this->registerBladeDirectives($bladeCompiler));
-        $this->hookIntoResponses($router);
+
+        if (config('boost.browser_logs_watcher', true)) {
+            $this->registerBrowserLogger();
+            $this->callAfterResolving('blade.compiler', fn (BladeCompiler $bladeCompiler) => $this->registerBladeDirectives($bladeCompiler));
+            $this->hookIntoResponses($router);
+        }
     }
 
     private function registerPublishing(): void
@@ -179,10 +181,24 @@ class BoostServiceProvider extends ServiceProvider
 
     private function hookIntoResponses(Router $router): void
     {
-        if (! config('boost.browser_logs_watcher', true)) {
-            return;
+        $router->pushMiddlewareToGroup('web', InjectBoost::class);
+    }
+
+    private function shouldRun(): bool
+    {
+        if (! config('boost.enabled', true)) {
+            return false;
         }
 
-        $router->pushMiddlewareToGroup('web', InjectBoost::class);
+        if (app()->runningUnitTests()) {
+            return false;
+        }
+
+        // Only enable Boost on local environments or when debug is true
+        if (! app()->environment('local') && config('app.debug', false) !== true) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/BoostServiceProvider.php
+++ b/src/BoostServiceProvider.php
@@ -19,7 +19,6 @@ use Laravel\Roster\Roster;
 
 class BoostServiceProvider extends ServiceProvider
 {
-
     public function register(): void
     {
         $this->mergeConfigFrom(

--- a/tests/Feature/BoostServiceProviderTest.php
+++ b/tests/Feature/BoostServiceProviderTest.php
@@ -13,23 +13,23 @@ beforeEach(function () {
 describe('boost.enabled configuration', function () {
     it('does not boot boost when disabled', function () {
         Config::set('boost.enabled', false);
-        app()->detectEnvironment(fn() => 'local');
-        
+        app()->detectEnvironment(fn () => 'local');
+
         $provider = new BoostServiceProvider(app());
         $provider->register();
         $provider->boot(app('router'));
-        
+
         $this->artisan('list')->expectsOutputToContain('boost:install');
     });
 
     it('boots boost when enabled in local environment', function () {
         Config::set('boost.enabled', true);
-        app()->detectEnvironment(fn() => 'local');
-        
+        app()->detectEnvironment(fn () => 'local');
+
         $provider = new BoostServiceProvider(app());
         $provider->register();
         $provider->boot(app('router'));
-        
+
         expect(app()->bound(Laravel\Roster\Roster::class))->toBeTrue();
         expect(config('logging.channels.browser'))->not->toBeNull();
     });
@@ -39,12 +39,12 @@ describe('environment restrictions', function () {
     it('does not boot boost in production even when enabled', function () {
         Config::set('boost.enabled', true);
         Config::set('app.debug', false);
-        app()->detectEnvironment(fn() => 'production');
-        
+        app()->detectEnvironment(fn () => 'production');
+
         $provider = new BoostServiceProvider(app());
         $provider->register();
         $provider->boot(app('router'));
-        
+
         expect(config('logging.channels.browser'))->toBeNull();
     });
 
@@ -52,24 +52,24 @@ describe('environment restrictions', function () {
         it('does not boot boost when debug is false', function () {
             Config::set('boost.enabled', true);
             Config::set('app.debug', false);
-            app()->detectEnvironment(fn() => 'testing');
-            
+            app()->detectEnvironment(fn () => 'testing');
+
             $provider = new BoostServiceProvider(app());
             $provider->register();
             $provider->boot(app('router'));
-            
+
             expect(config('logging.channels.browser'))->toBeNull();
         });
 
         it('does not boot boost when debug is true', function () {
             Config::set('boost.enabled', true);
             Config::set('app.debug', true);
-            app()->detectEnvironment(fn() => 'testing');
-            
+            app()->detectEnvironment(fn () => 'testing');
+
             $provider = new BoostServiceProvider(app());
             $provider->register();
             $provider->boot(app('router'));
-            
+
             expect(config('logging.channels.browser'))->toBeNull();
         });
     });

--- a/tests/Feature/BoostServiceProviderTest.php
+++ b/tests/Feature/BoostServiceProviderTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Config;
+use Laravel\Boost\BoostServiceProvider;
+
+beforeEach(function () {
+    $this->refreshApplication();
+    Config::set('logging.channels.browser', null);
+});
+
+describe('boost.enabled configuration', function () {
+    it('does not boot boost when disabled', function () {
+        Config::set('boost.enabled', false);
+        app()->detectEnvironment(fn() => 'local');
+        
+        $provider = new BoostServiceProvider(app());
+        $provider->register();
+        $provider->boot(app('router'));
+        
+        $this->artisan('list')->expectsOutputToContain('boost:install');
+    });
+
+    it('boots boost when enabled in local environment', function () {
+        Config::set('boost.enabled', true);
+        app()->detectEnvironment(fn() => 'local');
+        
+        $provider = new BoostServiceProvider(app());
+        $provider->register();
+        $provider->boot(app('router'));
+        
+        expect(app()->bound(Laravel\Roster\Roster::class))->toBeTrue();
+        expect(config('logging.channels.browser'))->not->toBeNull();
+    });
+});
+
+describe('environment restrictions', function () {
+    it('does not boot boost in production even when enabled', function () {
+        Config::set('boost.enabled', true);
+        Config::set('app.debug', false);
+        app()->detectEnvironment(fn() => 'production');
+        
+        $provider = new BoostServiceProvider(app());
+        $provider->register();
+        $provider->boot(app('router'));
+        
+        expect(config('logging.channels.browser'))->toBeNull();
+    });
+
+    describe('testing environment', function () {
+        it('does not boot boost when debug is false', function () {
+            Config::set('boost.enabled', true);
+            Config::set('app.debug', false);
+            app()->detectEnvironment(fn() => 'testing');
+            
+            $provider = new BoostServiceProvider(app());
+            $provider->register();
+            $provider->boot(app('router'));
+            
+            expect(config('logging.channels.browser'))->toBeNull();
+        });
+
+        it('does not boot boost when debug is true', function () {
+            Config::set('boost.enabled', true);
+            Config::set('app.debug', true);
+            app()->detectEnvironment(fn() => 'testing');
+            
+            $provider = new BoostServiceProvider(app());
+            $provider->register();
+            $provider->boot(app('router'));
+            
+            expect(config('logging.channels.browser'))->toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
Adds tests for Boost booting: `boost.enabled`, testing, and environment check