### PR TITLE
Dynamic NPM Package Runner

### DIFF
--- a/.ai/foundation.blade.php
+++ b/.ai/foundation.blade.php
@@ -27,7 +27,7 @@ Application purpose: {!! config('boost.purpose') !!}
 - Do not change the application's dependencies without approval.
 
 ## Frontend Bundling
-- If the user doesn't see a frontend change reflected in the UI, it could mean they need to run `npm run build`, `npm run dev`, or `composer run dev`. Ask them.
+- If the user doesn't see a frontend change reflected in the UI, it could mean they need to run `{{ $assist->nodePackageManager() }} run build`, `{{ $assist->nodePackageManager() }} run dev`, or `composer run dev`. Ask them.
 
 ## Replies
 - Be concise in your explanations - focus on what's important rather than explaining obvious details.

--- a/.ai/laravel/core.blade.php
+++ b/.ai/laravel/core.blade.php
@@ -39,4 +39,4 @@
 - When creating tests, make use of `php artisan make:test [options] <name>` to create a feature test, and pass `--unit` to create a unit test. Most tests should be feature tests.
 
 ### Vite Error
-- If you receive an "Illuminate\Foundation\ViteException: Unable to locate file in Vite manifest" error, you can run `npm run build` or ask the user to run `npm run dev` or `composer run dev`.
+- If you receive an "Illuminate\Foundation\ViteException: Unable to locate file in Vite manifest" error, you can run `{{ $assist->nodePackageManager() }} run build` or ask the user to run `{{ $assist->nodePackageManager() }} run dev` or `composer run dev`.

--- a/src/Install/GuidelineAssist.php
+++ b/src/Install/GuidelineAssist.php
@@ -156,4 +156,15 @@ class GuidelineAssist
 
         return file_get_contents(current($this->enumPaths));
     }
+
+    public function nodePackageManager(): string
+    {
+        return match (true) {
+            file_exists(base_path('package-lock.json')) => 'npm',
+            file_exists(base_path('pnpm-lock.yaml')) => 'pnpm',
+            file_exists(base_path('yarn.lock')) => 'yarn',
+            file_exists(base_path('bun.lockb')) => 'bun',
+            default => 'npm',
+        };
+    }
 }

--- a/tests/Feature/Install/GuidelineAssistTest.php
+++ b/tests/Feature/Install/GuidelineAssistTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Install\GuidelineAssist;
+
+beforeEach(function () {
+    $lockFiles = [
+        base_path('package-lock.json'),
+        base_path('pnpm-lock.yaml'),
+        base_path('yarn.lock'),
+        base_path('bun.lockb'),
+    ];
+
+    foreach ($lockFiles as $file) {
+        if (file_exists($file)) {
+            unlink($file);
+        }
+    }
+});
+
+afterEach(function () {
+    $lockFiles = [
+        base_path('package-lock.json'),
+        base_path('pnpm-lock.yaml'),
+        base_path('yarn.lock'),
+        base_path('bun.lockb'),
+    ];
+
+    foreach ($lockFiles as $file) {
+        if (file_exists($file)) {
+            unlink($file);
+        }
+    }
+});
+
+test('it detects npm when package-lock.json exists', function () {
+    file_put_contents(base_path('package-lock.json'), '{}');
+
+    $assist = new GuidelineAssist();
+    expect($assist->nodePackageManager())->toBe('npm');
+});
+
+test('it detects pnpm when pnpm-lock.yaml exists', function () {
+    file_put_contents(base_path('pnpm-lock.yaml'), 'lockfileVersion: 6.0');
+
+    $assist = new GuidelineAssist();
+    expect($assist->nodePackageManager())->toBe('pnpm');
+});
+
+test('it detects yarn when yarn.lock exists', function () {
+    file_put_contents(base_path('yarn.lock'), '# This is yarn lock file');
+
+    $assist = new GuidelineAssist();
+    expect($assist->nodePackageManager())->toBe('yarn');
+});
+
+test('it detects bun when bun.lockb exists', function () {
+    file_put_contents(base_path('bun.lockb'), 'bun binary lock file');
+
+    $assist = new GuidelineAssist();
+    expect($assist->nodePackageManager())->toBe('bun');
+});
+
+test('it defaults to npm when no lock files exist', function () {
+    $assist = new GuidelineAssist();
+    expect($assist->nodePackageManager())->toBe('npm');
+});


### PR DESCRIPTION
This PR adds a helper that determines which NPM package manager should be used to run any given script out of npm, pnpm, yarn and bun. This should help AI use the correct CLI tools to use when running npm commands based on the project's existing dependencies.