### PR TITLE
Put user-defined project guidelines at the top of the generated guidelines file

### DIFF
--- a/src/Install/GuidelineComposer.php
+++ b/src/Install/GuidelineComposer.php
@@ -84,6 +84,14 @@ class GuidelineComposer
     protected function find(): Collection
     {
         $guidelines = collect();
+
+        $userGuidelines = $this->guidelineFilesInDir(base_path($this->userGuidelineDir));
+
+        foreach ($userGuidelines as $guideline) {
+            $guidelineKey = '.ai/'.$guideline->getBasename('.blade.php');
+            $guidelines->put($guidelineKey, $this->guideline($guideline->getPathname()));
+        }
+
         $guidelines->put('foundation', $this->guideline('foundation'));
         $guidelines->put('boost', $this->guideline('boost/core'));
 
@@ -128,13 +136,6 @@ class GuidelineComposer
 
         if ($this->config->enforceTests) {
             $guidelines->put('tests', $this->guideline('enforce-tests'));
-        }
-
-        $userGuidelines = $this->guidelineFilesInDir(base_path($this->userGuidelineDir));
-
-        foreach ($userGuidelines as $guideline) {
-            $guidelineKey = '.ai/'.$guideline->getBasename('.blade.php');
-            $guidelines->put($guidelineKey, $this->guideline($guideline->getPathname()));
         }
 
         return $guidelines


### PR DESCRIPTION
Potentially solves #146 

Just raising this as an easy merge if you agree that user guidelines should take more precedence than the Boost presets, but happy to do another approach if liked