### PR TITLE
Fix Tailwind CSS title on README.md for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Laravel Boost includes AI guidelines for the following packages and frameworks. 
 | Pest | core, 4.x |
 | PHPUnit | core |
 | Pint | core |
-| TailwindCSS | core, 3.x, 4.x |
+| Tailwind CSS | core, 3.x, 4.x |
 | Livewire Volt | core |
 | Laravel Folio | core |
 | Enforce Tests | conditional |


### PR DESCRIPTION
- This simple PR changes **TailwindCSS** to the correct **Tailwind CSS** naming in the README.md for consistency.