### PR TITLE
Fix MCP server crashes with configurable Tinker timeout

### DIFF
--- a/config/boost.php
+++ b/config/boost.php
@@ -40,7 +40,7 @@ return [
     */
 
     'process_isolation' => [
-        'enabled' => env('BOOST_PROCESS_ISOLATION', false), // Default OFF for better performance
+        'enabled' => env('BOOST_PROCESS_ISOLATION', true),  // Default ON to prevent MCP server crashes
         'timeout' => env('BOOST_PROCESS_TIMEOUT', 120),     // 2 minutes default
     ],
 

--- a/config/boost.php
+++ b/config/boost.php
@@ -29,4 +29,19 @@ return [
 
     'browser_logs_watcher' => env('BOOST_BROWSER_LOGS_WATCHER', true),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Process Isolation for Tools
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, tools like Tinker will run in isolated processes to prevent
+    | timeouts from affecting the main MCP server. This provides better stability
+    | and protection against runaway code execution.
+    */
+
+    'process_isolation' => [
+        'enabled' => env('BOOST_PROCESS_ISOLATION', false), // Default OFF for better performance
+        'timeout' => env('BOOST_PROCESS_TIMEOUT', 120),     // 2 minutes default
+    ],
+
 ];

--- a/config/boost.php
+++ b/config/boost.php
@@ -41,7 +41,7 @@ return [
 
     'process_isolation' => [
         'enabled' => env('BOOST_PROCESS_ISOLATION', true),  // Default ON to prevent MCP server crashes
-        'timeout' => env('BOOST_PROCESS_TIMEOUT', 120),     // 2 minutes default
+        'timeout' => env('BOOST_PROCESS_TIMEOUT', 180),     // 5 minutes default
     ],
 
 ];

--- a/src/Mcp/Tools/Tinker.php
+++ b/src/Mcp/Tools/Tinker.php
@@ -25,14 +25,12 @@ DESCRIPTION;
 
     public function schema(ToolInputSchema $schema): ToolInputSchema
     {
-        $configTimeout = config('boost.process_isolation.timeout');
-
         return $schema
             ->string('code')
             ->description('PHP code to execute (without opening <?php tags)')
             ->required()
             ->integer('timeout')
-            ->description("Maximum execution time in seconds (default: {$configTimeout})");
+            ->description('Maximum execution time in seconds (default: 30)');
     }
 
     /**
@@ -44,14 +42,14 @@ DESCRIPTION;
     {
         $code = str_replace(['<?php', '?>'], '', (string) Arr::get($arguments, 'code'));
 
-        $configTimeout = config('boost.process_isolation.timeout');
-        $timeout = max($configTimeout, min(600, (int) (Arr::get($arguments, 'timeout', $configTimeout))));
+        $timeout = min(180, (int) (Arr::get($arguments, 'timeout', 30)));
 
         // Only set time limit if process isolation is disabled
         // When process isolation is enabled, the ToolExecutor handles timeouts
         if (! config('boost.process_isolation.enabled', false)) {
             set_time_limit($timeout);
         }
+
         ini_set('memory_limit', '128M');
 
         // Use PCNTL alarm for additional timeout control if available (Unix only)

--- a/src/Mcp/Tools/Tinker.php
+++ b/src/Mcp/Tools/Tinker.php
@@ -47,7 +47,11 @@ DESCRIPTION;
         $configTimeout = config('boost.process_isolation.timeout');
         $timeout = max($configTimeout, min(600, (int) (Arr::get($arguments, 'timeout', $configTimeout))));
 
-        set_time_limit($timeout);
+        // Only set time limit if process isolation is disabled
+        // When process isolation is enabled, the ToolExecutor handles timeouts
+        if (! config('boost.process_isolation.enabled', false)) {
+            set_time_limit($timeout);
+        }
         ini_set('memory_limit', '128M');
 
         // Use PCNTL alarm for additional timeout control if available (Unix only)


### PR DESCRIPTION
## Problem
The MCP server was crashing with timeout errors when executing long-running Tinker commands. The hardcoded 30-second timeout was insufficient for complex operations, causing the entire MCP server process to terminate unexpectedly.

## Solution
This PR introduces configurable timeout management for the Tinker tool with proper bounds and optional process isolation support. Fixes #129

## Changes Made

### 1. **New Configuration** (`config/boost.php`)
```php
'process_isolation' => [
    'enabled' => env('BOOST_PROCESS_ISOLATION', false), // Default OFF for better performance
    'timeout' => env('BOOST_PROCESS_TIMEOUT', 120),     // 2 minutes new default instead 5 minutes
],
```

### 2. **Enhanced Tinker Tool**
- **Configurable timeout**: Uses `BOOST_PROCESS_TIMEOUT` instead of hardcoded 30 seconds
- **Smart bounds**: Config value acts as minimum, 600 seconds maximum
- **Dynamic schema**: Shows current config value in tool documentation
- **Improved PCNTL cleanup**: Uses `finally` block for better error handling

```php
// Before
$timeout = min(180, (int) (Arr::get($arguments, 'timeout', 30)));

// After  
$configTimeout = config('boost.process_isolation.timeout');
$timeout = max($configTimeout, min(600, (int) (Arr::get($arguments, 'timeout', $configTimeout))));
```

## Environment Variables

### `BOOST_PROCESS_TIMEOUT` (Default: 120)
Sets the **minimum** timeout for Tinker operations:
- Acts as the baseline timeout when no specific timeout is requested
- Users can request higher timeouts up to 600 seconds maximum
- Values below config setting are bumped up to config value

### `BOOST_PROCESS_ISOLATION` (Default: false)
Controls whether tools run in isolated processes:
- **When `true`**: Tools run in separate processes, protecting the main MCP server
- **When `false`**: Tools run in the main process (better performance, but crash risk)

## Timeout Behavior Examples

| Scenario | Config (120s) | Input | Final Result |
|----------|---------------|-------|--------------|
| Default execution | 120 | none | **120 seconds** |
| Short timeout request | 120 | `timeout: 30` | **120 seconds** (config minimum enforced) |
| Medium timeout request | 120 | `timeout: 200` | **200 seconds** |
| Long timeout request | 120 | `timeout: 800` | **600 seconds** (maximum enforced) |

## Process Isolation vs Risk

### ⚠️ **Without Process Isolation** (`BOOST_PROCESS_ISOLATION=false`)
- **Risk**: MCP server may crash if operations exceed the configured timeout
- **Probability**: Very low chance of operations taking longer than 2 minutes
- **Benefit**: Better performance, direct execution
- **Recommendation**: Safe for most development environments

### ✅ **With Process Isolation** (`BOOST_PROCESS_ISOLATION=true`) 
- **Protection**: Main MCP server remains stable regardless of tool execution time
- **Use Case**: Production environments or when running complex operations
- **Trade-off**: Slight performance overhead for enhanced stability
- **Recommendation**: Enable for production or when reliability is critical


## Risk Assessment

**Crash Risk Without Isolation**: While the chance of operations exceeding 2 minutes is very low in typical usage, certain scenarios can trigger longer executions:
- Large database queries or migrations
- Complex model operations with extensive relationships  
- File processing or external API calls within Tinker
- Memory-intensive operations

**The 2-minute default provides a good balance** between allowing sufficient time for normal operations while minimizing crash risk.


## Tests
Replace 1-second timeout test with configurable timeout validation
The original test used a 1-second timeout which is no longer possible due to the new 120-second minimum timeout limit. Updated to test configurable timeout behavior instead.