### PR TITLE
chore: removes non necessary php version constrant

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "source": "https://github.com/laravel/boost"
     },
     "require": {
-        "php": "^8.1|^8.2",
+        "php": "^8.1",
         "guzzlehttp/guzzle": "^7.9",
         "illuminate/console": "^10.0|^11.0|^12.0",
         "illuminate/contracts": "^10.0|^11.0|^12.0",


### PR DESCRIPTION
Because we already have ""^8.1", we don't actually need ""^8.2".