### PR TITLE
fix: defer InjectBoost middleware registration until app is booted

### DIFF
--- a/src/BoostServiceProvider.php
+++ b/src/BoostServiceProvider.php
@@ -180,10 +180,6 @@ class BoostServiceProvider extends ServiceProvider
 
     private function hookIntoResponses(Router $router): void
     {
-        // In Kernel-based apps (pre-Laravel 11 bootstrap), middleware groups can be
-        // defined or overwritten later in the boot cycle, which could remove any
-        // middleware we push here if we do it too early. Deferring this until the
-        // application is fully booted ensures our middleware stays appended.
         $this->app->booted(function () use ($router) {
             $router->pushMiddlewareToGroup('web', InjectBoost::class);
         });

--- a/src/BoostServiceProvider.php
+++ b/src/BoostServiceProvider.php
@@ -180,7 +180,13 @@ class BoostServiceProvider extends ServiceProvider
 
     private function hookIntoResponses(Router $router): void
     {
-        $router->pushMiddlewareToGroup('web', InjectBoost::class);
+        // In Kernel-based apps (pre-Laravel 11 bootstrap), middleware groups can be
+        // defined or overwritten later in the boot cycle, which could remove any
+        // middleware we push here if we do it too early. Deferring this until the
+        // application is fully booted ensures our middleware stays appended.
+        $this->app->booted(function () use ($router) {
+            $router->pushMiddlewareToGroup('web', InjectBoost::class);
+        });
     }
 
     private function shouldRun(): bool


### PR DESCRIPTION
This PR fixes an issue where the `InjectBoost` middleware was not reliably appended to the web middleware group in the old Kernel based app configuration.

By deferring the call with `$this->app->booted(...)`, we ensure the middleware is always appended to the final web group definition.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
