### PR TITLE
Improve `InjectBoost` middleware for response-type handling

### DIFF
--- a/src/Middleware/InjectBoost.php
+++ b/src/Middleware/InjectBoost.php
@@ -36,12 +36,12 @@ class InjectBoost
 
     private function shouldInject(Response $response): bool
     {
-       $responseTypes = [
-           StreamedResponse::class,
-           BinaryFileResponse::class,
-           JsonResponse::class,
-           RedirectResponse::class,
-       ];
+        $responseTypes = [
+            StreamedResponse::class,
+            BinaryFileResponse::class,
+            JsonResponse::class,
+            RedirectResponse::class,
+        ];
         foreach ($responseTypes as $type) {
             if ($response instanceof $type) {
                 return false;

--- a/src/Middleware/InjectBoost.php
+++ b/src/Middleware/InjectBoost.php
@@ -5,16 +5,20 @@ declare(strict_types=1);
 namespace Laravel\Boost\Middleware;
 
 use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
 use Laravel\Boost\Services\BrowserLogger;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class InjectBoost
 {
     public function handle(Request $request, Closure $next): Response
     {
-        /** @var \Symfony\Component\HttpFoundation\Response $response */
+        /** @var Response $response */
         $response = $next($request);
 
         if ($this->shouldInject($response)) {
@@ -32,7 +36,19 @@ class InjectBoost
 
     private function shouldInject(Response $response): bool
     {
-        if (str_contains($response->headers->get('content-type', ''), 'html') === false) {
+       $responseTypes = [
+           StreamedResponse::class,
+           BinaryFileResponse::class,
+           JsonResponse::class,
+           RedirectResponse::class,
+       ];
+        foreach ($responseTypes as $type) {
+            if ($response instanceof $type) {
+                return false;
+            }
+        }
+
+        if (! str_contains($response->headers->get('content-type', ''), 'html')) {
             return false;
         }
 

--- a/tests/Feature/Middleware/InjectBoostTest.php
+++ b/tests/Feature/Middleware/InjectBoostTest.php
@@ -2,26 +2,90 @@
 
 declare(strict_types=1);
 
-namespace Tests\Feature\Middleware;
-
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Route;
 use Laravel\Boost\Middleware\InjectBoost;
-use Tests\TestCase;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
-class InjectBoostTest extends TestCase
+beforeEach(function () {
+    $this->app['view']->addNamespace('test', __DIR__.'/../../fixtures');
+});
+
+function createMiddlewareResponse($response): SymfonyResponse
 {
-    public function test_it_preserves_the_original_view_response_type(): void
-    {
-        $this->app['view']->addNamespace('test', __DIR__.'/../../fixtures');
+    $middleware = new InjectBoost();
+    $request = new Request();
+    $next = fn ($request) => $response;
 
-        Route::get('injection-test', function () {
-            return view('test::injection-test');
-        })->middleware(InjectBoost::class);
-
-        $response = $this->get('injection-test');
-
-        $response->assertViewIs('test::injection-test')
-            ->assertSee('browser-logger-active')
-            ->assertSee('Browser logger active (MCP server detected).');
-    }
+    return $middleware->handle($request, $next);
 }
+
+it('preserves the original view response type', function () {
+    Route::get('injection-test', function () {
+        return view('test::injection-test');
+    })->middleware(InjectBoost::class);
+
+    $response = $this->get('injection-test');
+
+    $response->assertViewIs('test::injection-test')
+        ->assertSee('browser-logger-active')
+        ->assertSee('Browser logger active (MCP server detected).');
+});
+
+it('does not inject for special response types', function ($responseType, $responseFactory) {
+    $response = $responseFactory();
+    $result = createMiddlewareResponse($response);
+
+    expect($result)->toBeInstanceOf($responseType);
+})->with([
+    'streamed' => [StreamedResponse::class, fn () => new StreamedResponse()],
+    'json' => [JsonResponse::class, fn () => new JsonResponse(['data' => 'test'])],
+    'redirect' => [RedirectResponse::class, fn () => new RedirectResponse('http://example.com')],
+    'binary' => [BinaryFileResponse::class, function () {
+        $tempFile = tempnam(sys_get_temp_dir(), 'test');
+        file_put_contents($tempFile, 'test content');
+
+        return new BinaryFileResponse(new SplFileInfo($tempFile));
+    }],
+]);
+
+it('does not inject when conditions are not met', function ($scenario, $responseFactory, $assertion) {
+    $response = $responseFactory();
+    $result = createMiddlewareResponse($response);
+
+    $assertion($result);
+})->with([
+    'non-html content type' => [
+        'scenario',
+        fn () => (new Response('test'))->withHeaders(['content-type' => 'application/json']),
+        fn ($result) => expect($result->getContent())->toBe('test'),
+    ],
+    'missing html skeleton' => [
+        'scenario',
+        fn () => (new Response('test'))->withHeaders(['content-type' => 'text/html']),
+        fn ($result) => expect($result->getContent())->toBe('test'),
+    ],
+    'already injected' => [
+        'scenario',
+        fn () => (new Response('<html><head><title>Test</title></head><body><div class="browser-logger-active"></div></body></html>'))
+            ->withHeaders(['content-type' => 'text/html']),
+        fn ($result) => expect($result->getContent())->toContain('browser-logger-active'),
+    ],
+]);
+
+it('injects script in html responses', function ($html) {
+    $response = new Response($html);
+    $response->headers->set('content-type', 'text/html');
+
+    $result = createMiddlewareResponse($response);
+
+    expect($result->getContent())->toContain('<script id="browser-logger-active">');
+})->with([
+    'with head and body tags' => '<html><head><title>Test</title></head><body></body></html>',
+    'without head/body tags' => '<html>Test</html>',
+]);


### PR DESCRIPTION
#### Summary
This MR  Improves the InjectBoost middleware to apply boost selectively based on
response types, ensuring boost is only applied to normal HTTP responses
rather than all response types.

#### Testing
Tested with https://github.com/pushpak1300/ai-chat - confirmed the fix
works as expected after implementation.

  
  Resolves #175 