### PR TITLE
fix: do not autoload classes while boost:install

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -148,7 +148,7 @@ class InstallCommand extends Command
 
         foreach ($finder as $toolFile) {
             $fullyClassifiedClassName = 'Laravel\\Boost\\Mcp\\Tools\\'.$toolFile->getBasename('.php');
-            if (class_exists($fullyClassifiedClassName)) {
+            if (class_exists($fullyClassifiedClassName, false)) {
                 $tools[$fullyClassifiedClassName] = Str::headline($toolFile->getBasename('.php'));
             }
         }

--- a/src/Install/GuidelineAssist.php
+++ b/src/Install/GuidelineAssist.php
@@ -7,6 +7,7 @@ namespace Laravel\Boost\Install;
 use Illuminate\Database\Eloquent\Model;
 use ReflectionClass;
 use Symfony\Component\Finder\Finder;
+use Throwable;
 
 class GuidelineAssist
 {
@@ -86,10 +87,10 @@ class GuidelineAssist
                         continue;
                     }
 
-                    if (class_exists($className)) {
+                    if (class_exists($className, false)) {
                         self::$classes[$className] = $path;
                     }
-                } catch (\Throwable) {
+                } catch (Throwable) {
                     // Ignore exceptions and errors from class loading/reflection
                 }
             }


### PR DESCRIPTION
This MR fixes class autoloading issues during installation by adding `false` parameter to `class_exists()` calls in `InstallCommand` and `GuidelineAssist`. This ensures the install process only checks for already loaded classes, avoiding potential failures when dependencies aren't fully set up yet.

**Files changed:** `InstallCommand.php`, `GuidelineAssist.php`

Resolves #149 