### PR TITLE
feat: add Roocode code environment detection and integration

### DIFF
--- a/src/Install/CodeEnvironment/Roocode.php
+++ b/src/Install/CodeEnvironment/Roocode.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install\CodeEnvironment;
+
+use Laravel\Boost\Contracts\Agent;
+use Laravel\Boost\Install\Enums\Platform;
+
+class Roocode extends CodeEnvironment implements Agent
+{
+    public function name(): string
+    {
+        return 'roocode';
+    }
+
+    public function displayName(): string
+    {
+        return 'Roocode';
+    }
+
+    public function systemDetectionConfig(Platform $platform): array
+    {
+        // Roocode doesn't have system-wide detection as it's a VS Code extension
+        return [
+            'files' => [],
+        ];
+    }
+
+    public function projectDetectionConfig(): array
+    {
+        return [
+            'paths' => ['.roo'],
+            'files' => ['.roorules'],
+        ];
+    }
+
+    public function detectOnSystem(Platform $platform): bool
+    {
+        return false;
+    }
+
+    public function mcpClientName(): ?string
+    {
+        return null;
+    }
+
+    public function guidelinesPath(): string
+    {
+        return '.roo/rules/laravel-boost.md';
+    }
+}

--- a/src/Install/CodeEnvironmentsDetector.php
+++ b/src/Install/CodeEnvironmentsDetector.php
@@ -11,6 +11,7 @@ use Laravel\Boost\Install\CodeEnvironment\CodeEnvironment;
 use Laravel\Boost\Install\CodeEnvironment\Copilot;
 use Laravel\Boost\Install\CodeEnvironment\Cursor;
 use Laravel\Boost\Install\CodeEnvironment\PhpStorm;
+use Laravel\Boost\Install\CodeEnvironment\Roocode;
 use Laravel\Boost\Install\CodeEnvironment\VSCode;
 use Laravel\Boost\Install\Enums\Platform;
 
@@ -23,6 +24,7 @@ class CodeEnvironmentsDetector
         'cursor' => Cursor::class,
         'claudecode' => ClaudeCode::class,
         'copilot' => Copilot::class,
+        'roocode' => Roocode::class,
     ];
 
     public function __construct(

--- a/tests/Unit/Install/CodeEnvironmentsDetectorTest.php
+++ b/tests/Unit/Install/CodeEnvironmentsDetectorTest.php
@@ -41,6 +41,7 @@ test('discoverSystemInstalledCodeEnvironments returns detected programs', functi
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Cursor::class, fn () => $program3);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\ClaudeCode::class, fn () => $otherProgram);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Copilot::class, fn () => $otherProgram);
+    $container->bind(\Laravel\Boost\Install\CodeEnvironment\Roocode::class, fn () => $otherProgram);
 
     $detector = new CodeEnvironmentsDetector($container);
     $detected = $detector->discoverSystemInstalledCodeEnvironments();
@@ -65,6 +66,7 @@ test('discoverSystemInstalledCodeEnvironments returns empty array when no progra
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Cursor::class, fn () => $otherProgram);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\ClaudeCode::class, fn () => $otherProgram);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Copilot::class, fn () => $otherProgram);
+    $container->bind(\Laravel\Boost\Install\CodeEnvironment\Roocode::class, fn () => $otherProgram);
 
     $detector = new CodeEnvironmentsDetector($container);
     $detected = $detector->discoverSystemInstalledCodeEnvironments();
@@ -213,6 +215,34 @@ test('discoverProjectInstalledCodeEnvironments detects cursor with cursor direct
 
     // Cleanup
     rmdir($tempDir.'/.cursor');
+    rmdir($tempDir);
+});
+
+test('discoverProjectInstalledCodeEnvironments detects roocode with roo directory', function () {
+    $tempDir = sys_get_temp_dir().'/boost_test_'.uniqid();
+    mkdir($tempDir);
+    mkdir($tempDir.'/.roo');
+
+    $detected = $this->detector->discoverProjectInstalledCodeEnvironments($tempDir);
+
+    expect($detected)->toContain('roocode');
+
+    // Cleanup
+    rmdir($tempDir.'/.roo');
+    rmdir($tempDir);
+});
+
+test('discoverProjectInstalledCodeEnvironments detects roocode with roorules file', function () {
+    $tempDir = sys_get_temp_dir().'/boost_test_'.uniqid();
+    mkdir($tempDir);
+    file_put_contents($tempDir.'/.roorules', 'test rules');
+
+    $detected = $this->detector->discoverProjectInstalledCodeEnvironments($tempDir);
+
+    expect($detected)->toContain('roocode');
+
+    // Cleanup
+    unlink($tempDir.'/.roorules');
     rmdir($tempDir);
 });
 


### PR DESCRIPTION
## Summary
Adds support for Roocode AI coding assistant integration to Laravel Boost's install system.

## Technical Details
- **Detection Logic**: Looks for `.roo/` directory or `.roorules` file in project root
- **Guidelines Path**: `.roo/rules/laravel-boost.md`
- **MCP Support**: None (returns `null` for `mcpClientName()`)
- **System Detection**: Always returns `false` (VS Code extension based)

## Related
- Roocode is a fork of Cline (#3 on OpenRouter usage stats with 979B tokens/month)
- Part of supporting top AI coding assistants in Laravel Boost