### PR TITLE
feat: add Cline code environment detection and integration

### DIFF
--- a/src/Install/CodeEnvironment/Cline.php
+++ b/src/Install/CodeEnvironment/Cline.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install\CodeEnvironment;
+
+use Laravel\Boost\Contracts\Agent;
+use Laravel\Boost\Install\Enums\Platform;
+
+class Cline extends CodeEnvironment implements Agent
+{
+    public function name(): string
+    {
+        return 'cline';
+    }
+
+    public function displayName(): string
+    {
+        return 'Cline';
+    }
+
+    public function systemDetectionConfig(Platform $platform): array
+    {
+        // Cline doesn't have system-wide detection as it's a VS Code extension
+        return [
+            'files' => [],
+        ];
+    }
+
+    public function projectDetectionConfig(): array
+    {
+        return [
+            'paths' => ['.clinerules'],
+            'files' => ['.clinerules'],
+        ];
+    }
+
+    public function detectOnSystem(Platform $platform): bool
+    {
+        return false;
+    }
+
+    public function mcpClientName(): ?string
+    {
+        return null;
+    }
+
+    public function guidelinesPath(): string
+    {
+        return '.clinerules/laravel-boost.md';
+    }
+}

--- a/src/Install/CodeEnvironmentsDetector.php
+++ b/src/Install/CodeEnvironmentsDetector.php
@@ -7,6 +7,7 @@ namespace Laravel\Boost\Install;
 use Illuminate\Container\Container;
 use Illuminate\Support\Collection;
 use Laravel\Boost\Install\CodeEnvironment\ClaudeCode;
+use Laravel\Boost\Install\CodeEnvironment\Cline;
 use Laravel\Boost\Install\CodeEnvironment\CodeEnvironment;
 use Laravel\Boost\Install\CodeEnvironment\Copilot;
 use Laravel\Boost\Install\CodeEnvironment\Cursor;
@@ -23,6 +24,7 @@ class CodeEnvironmentsDetector
         'cursor' => Cursor::class,
         'claudecode' => ClaudeCode::class,
         'copilot' => Copilot::class,
+        'cline' => Cline::class,
     ];
 
     public function __construct(

--- a/tests/Unit/Install/CodeEnvironmentsDetectorTest.php
+++ b/tests/Unit/Install/CodeEnvironmentsDetectorTest.php
@@ -41,6 +41,7 @@ test('discoverSystemInstalledCodeEnvironments returns detected programs', functi
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Cursor::class, fn () => $program3);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\ClaudeCode::class, fn () => $otherProgram);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Copilot::class, fn () => $otherProgram);
+    $container->bind(\Laravel\Boost\Install\CodeEnvironment\Cline::class, fn () => $otherProgram);
 
     $detector = new CodeEnvironmentsDetector($container);
     $detected = $detector->discoverSystemInstalledCodeEnvironments();
@@ -65,6 +66,7 @@ test('discoverSystemInstalledCodeEnvironments returns empty array when no progra
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Cursor::class, fn () => $otherProgram);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\ClaudeCode::class, fn () => $otherProgram);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Copilot::class, fn () => $otherProgram);
+    $container->bind(\Laravel\Boost\Install\CodeEnvironment\Cline::class, fn () => $otherProgram);
 
     $detector = new CodeEnvironmentsDetector($container);
     $detected = $detector->discoverSystemInstalledCodeEnvironments();
@@ -92,6 +94,9 @@ test('discoverProjectInstalledCodeEnvironments detects programs in project', fun
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\VSCode::class, fn () => $program1);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\PhpStorm::class, fn () => $program2);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\ClaudeCode::class, fn () => $program3);
+    $container->bind(\Laravel\Boost\Install\CodeEnvironment\Cursor::class, fn () => $program2);
+    $container->bind(\Laravel\Boost\Install\CodeEnvironment\Copilot::class, fn () => $program2);
+    $container->bind(\Laravel\Boost\Install\CodeEnvironment\Cline::class, fn () => $program2);
 
     $detector = new CodeEnvironmentsDetector($container);
     $detected = $detector->discoverProjectInstalledCodeEnvironments($basePath);
@@ -109,6 +114,11 @@ test('discoverProjectInstalledCodeEnvironments returns empty array when no progr
     // Bind mocked program to container
     $container = new \Illuminate\Container\Container;
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\VSCode::class, fn () => $program1);
+    $container->bind(\Laravel\Boost\Install\CodeEnvironment\PhpStorm::class, fn () => $program1);
+    $container->bind(\Laravel\Boost\Install\CodeEnvironment\ClaudeCode::class, fn () => $program1);
+    $container->bind(\Laravel\Boost\Install\CodeEnvironment\Cursor::class, fn () => $program1);
+    $container->bind(\Laravel\Boost\Install\CodeEnvironment\Copilot::class, fn () => $program1);
+    $container->bind(\Laravel\Boost\Install\CodeEnvironment\Cline::class, fn () => $program1);
 
     $detector = new CodeEnvironmentsDetector($container);
     $detected = $detector->discoverProjectInstalledCodeEnvironments($basePath);
@@ -213,6 +223,34 @@ test('discoverProjectInstalledCodeEnvironments detects cursor with cursor direct
 
     // Cleanup
     rmdir($tempDir.'/.cursor');
+    rmdir($tempDir);
+});
+
+test('discoverProjectInstalledCodeEnvironments detects cline with clinerules directory', function () {
+    $tempDir = sys_get_temp_dir().'/boost_test_'.uniqid();
+    mkdir($tempDir);
+    mkdir($tempDir.'/.clinerules');
+
+    $detected = $this->detector->discoverProjectInstalledCodeEnvironments($tempDir);
+
+    expect($detected)->toContain('cline');
+
+    // Cleanup
+    rmdir($tempDir.'/.clinerules');
+    rmdir($tempDir);
+});
+
+test('discoverProjectInstalledCodeEnvironments detects cline with clinerules file', function () {
+    $tempDir = sys_get_temp_dir().'/boost_test_'.uniqid();
+    mkdir($tempDir);
+    file_put_contents($tempDir.'/.clinerules', 'test rules');
+
+    $detected = $this->detector->discoverProjectInstalledCodeEnvironments($tempDir);
+
+    expect($detected)->toContain('cline');
+
+    // Cleanup
+    unlink($tempDir.'/.clinerules');
     rmdir($tempDir);
 });
 


### PR DESCRIPTION
## Summary
Adds support for Cline AI coding assistant integration to Laravel Boost's install system.

## Technical Details
- **Detection Logic**: Looks for `.clinerules/` directory or `.clinerules` file in project root
- **Guidelines Path**: `.clinerules/laravel-boost.md`


## Related
- Cline is very popular VS Code extension (#.2 on OpenRouter usage stats)
