### PR TITLE
feat: add KiloCode environment detection and integration

### DIFF
--- a/src/Install/CodeEnvironment/KiloCode.php
+++ b/src/Install/CodeEnvironment/KiloCode.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install\CodeEnvironment;
+
+use Laravel\Boost\Contracts\Agent;
+use Laravel\Boost\Install\Enums\Platform;
+
+class KiloCode extends CodeEnvironment implements Agent
+{
+    public function name(): string
+    {
+        return 'kilocode';
+    }
+
+    public function displayName(): string
+    {
+        return 'Kilo Code';
+    }
+
+    public function systemDetectionConfig(Platform $platform): array
+    {
+        // Kilo Code doesn't have system-wide detection as it's a VS Code extension
+        return [
+            'files' => [],
+        ];
+    }
+
+    public function projectDetectionConfig(): array
+    {
+        return [
+            'paths' => ['.kilocode'],
+            'files' => ['.kilocoderules'],
+        ];
+    }
+
+    public function detectOnSystem(Platform $platform): bool
+    {
+        return false;
+    }
+
+    public function mcpClientName(): ?string
+    {
+        return null;
+    }
+
+    public function guidelinesPath(): string
+    {
+        return '.kilocode/rules/laravel-boost.md';
+    }
+}

--- a/src/Install/CodeEnvironmentsDetector.php
+++ b/src/Install/CodeEnvironmentsDetector.php
@@ -10,6 +10,7 @@ use Laravel\Boost\Install\CodeEnvironment\ClaudeCode;
 use Laravel\Boost\Install\CodeEnvironment\CodeEnvironment;
 use Laravel\Boost\Install\CodeEnvironment\Copilot;
 use Laravel\Boost\Install\CodeEnvironment\Cursor;
+use Laravel\Boost\Install\CodeEnvironment\KiloCode;
 use Laravel\Boost\Install\CodeEnvironment\PhpStorm;
 use Laravel\Boost\Install\CodeEnvironment\VSCode;
 use Laravel\Boost\Install\Enums\Platform;
@@ -23,6 +24,7 @@ class CodeEnvironmentsDetector
         'cursor' => Cursor::class,
         'claudecode' => ClaudeCode::class,
         'copilot' => Copilot::class,
+        'kilocode' => KiloCode::class,
     ];
 
     public function __construct(

--- a/tests/Unit/Install/CodeEnvironmentsDetectorTest.php
+++ b/tests/Unit/Install/CodeEnvironmentsDetectorTest.php
@@ -41,6 +41,7 @@ test('discoverSystemInstalledCodeEnvironments returns detected programs', functi
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Cursor::class, fn () => $program3);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\ClaudeCode::class, fn () => $otherProgram);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Copilot::class, fn () => $otherProgram);
+    $container->bind(\Laravel\Boost\Install\CodeEnvironment\KiloCode::class, fn () => $otherProgram);
 
     $detector = new CodeEnvironmentsDetector($container);
     $detected = $detector->discoverSystemInstalledCodeEnvironments();
@@ -65,6 +66,7 @@ test('discoverSystemInstalledCodeEnvironments returns empty array when no progra
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Cursor::class, fn () => $otherProgram);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\ClaudeCode::class, fn () => $otherProgram);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Copilot::class, fn () => $otherProgram);
+    $container->bind(\Laravel\Boost\Install\CodeEnvironment\KiloCode::class, fn () => $otherProgram);
 
     $detector = new CodeEnvironmentsDetector($container);
     $detected = $detector->discoverSystemInstalledCodeEnvironments();
@@ -215,6 +217,35 @@ test('discoverProjectInstalledCodeEnvironments detects cursor with cursor direct
     rmdir($tempDir.'/.cursor');
     rmdir($tempDir);
 });
+
+test('discoverProjectInstalledCodeEnvironments detects kilocode with kilocode directory', function () {
+    $tempDir = sys_get_temp_dir().'/boost_test_'.uniqid();
+    mkdir($tempDir);
+    mkdir($tempDir.'/.kilocode');
+
+    $detected = $this->detector->discoverProjectInstalledCodeEnvironments($tempDir);
+
+    expect($detected)->toContain('kilocode');
+
+    // Cleanup
+    rmdir($tempDir.'/.kilocode');
+    rmdir($tempDir);
+});
+
+test('discoverProjectInstalledCodeEnvironments detects kilocode with kilocoderules file', function () {
+    $tempDir = sys_get_temp_dir().'/boost_test_'.uniqid();
+    mkdir($tempDir);
+    file_put_contents($tempDir.'/.kilocoderules', 'test rules');
+
+    $detected = $this->detector->discoverProjectInstalledCodeEnvironments($tempDir);
+
+    expect($detected)->toContain('kilocode');
+
+    // Cleanup
+    unlink($tempDir.'/.kilocoderules');
+    rmdir($tempDir);
+});
+
 
 test('discoverProjectInstalledCodeEnvironments handles multiple detections', function () {
     $tempDir = sys_get_temp_dir().'/boost_test_'.uniqid();


### PR DESCRIPTION
## Summary
Adds support for Kilo Code AI coding assistant integration to Laravel Boost's install system with extensive backward compatibility.

## Technical Details
- **Detection Logic**: Primary `.kilocode/rules/`  or `.kilocoderules` file
- **Guidelines Path**: `.kilocode/rules/laravel-boost.md`


## Related
- Kilo Code is a fork of Roo/Cline (#.1 on OpenRouter usage stats)
- Most popular AI coding assistant with extensive compatibility features