### PR TITLE
fix: prevent unwanted "null" file creation on Windows during installation

### DIFF
--- a/src/Install/CodeEnvironment/ClaudeCode.php
+++ b/src/Install/CodeEnvironment/ClaudeCode.php
@@ -28,7 +28,7 @@ class ClaudeCode extends CodeEnvironment implements Agent, McpClient
                 'command' => 'which claude',
             ],
             Platform::Windows => [
-                'command' => 'where claude 2>null',
+                'command' => 'where claude 2>nul',
             ],
         };
     }


### PR DESCRIPTION
## Summary
Fixes a bug where `php artisan boost:install` creates an unwanted "null" file in the project root on Windows systems.

## Description
The Windows command for detecting Claude Code installation incorrectly uses `2>null` instead of `2>nul`, causing Windows to create a physical file named "null" in the project directory instead of redirecting stderr to the null device.
Windows uses `nul` (one 'l') as the null device, not `null` (two 'l's). 

Fix #119 #106 