### PR TITLE
Add config to modify tinker memory limit

### DIFF
--- a/config/boost.php
+++ b/config/boost.php
@@ -29,4 +29,17 @@ return [
 
     'browser_logs_watcher' => env('BOOST_BROWSER_LOGS_WATCHER', true),
 
+    /*
+    |--------------------------------------------------------------------------
+    | MCP
+    |--------------------------------------------------------------------------
+    |
+    | This option may be used to configure the MCP settings for Boost.
+    |
+    */
+    'mcp' => [
+        'tinker' => [
+            'memory_limit' => env('BOOST_TINKER_MEMORY_LIMIT', '128M'),
+        ],
+    ]
 ];

--- a/src/Mcp/Tools/Tinker.php
+++ b/src/Mcp/Tools/Tinker.php
@@ -44,7 +44,8 @@ DESCRIPTION;
 
         $timeout = min(180, (int) (Arr::get($arguments, 'timeout', 30)));
         set_time_limit($timeout);
-        ini_set('memory_limit', '128M');
+        $memoryLimit = config('boost.mcp.tinker.memory_limit', '128M');
+        ini_set('memory_limit', $memoryLimit);
 
         // Use PCNTL alarm for additional timeout control if available (Unix only)
         if (function_exists('pcntl_async_signals') && function_exists('pcntl_signal')) {


### PR DESCRIPTION
Fixes: https://github.com/laravel/boost/issues/176

On a large project, it throws memory limit error while running tinker mcp tool.
<img width="2350" height="486" alt="image" src="https://github.com/user-attachments/assets/71536bcf-84c6-43e9-9d1c-e3e9bcc28eff" />

And since currently there is no option to configure memory limit, it is hard to fix it.
So, this PR adds config variable to update the memory limit.