### PR TITLE
Add auto-detection and guidelines support for nwidart/laravel-modules

### DIFF
--- a/.ai/nwidart-laravel-modules/12/core.blade.php
+++ b/.ai/nwidart-laravel-modules/12/core.blade.php
@@ -1,0 +1,72 @@
+## Laravel Modules v12 Specific Features
+
+### Enhanced Laravel 11/12 Compatibility
+- Full support for Laravel 11 and 12 features and conventions.
+- Improved Artisan command integration with Laravel 11/12 command architecture.
+- Better integration with Laravel's service container and dependency injection.
+
+### Version 12 Improvements
+- Enhanced module auto-discovery capabilities.
+- Improved module service provider registration.
+- Better support for Laravel 11/12's directory structure changes.
+- Optimized module loading performance.
+
+### Modern Laravel Features Support
+- Full support for Laravel 11/12 route model binding within modules.
+- Integration with Laravel 11/12's improved validation features.
+- Support for Laravel 11/12's enhanced broadcasting and queuing features.
+
+### Updated Command Set
+- All module commands are fully compatible with Laravel 11/12.
+- Enhanced `module:make` commands with better template generation.
+- Improved module scaffolding with modern Laravel conventions.
+
+### Configuration Improvements
+- Better integration with Laravel 11/12's configuration caching.
+- Enhanced module configuration publishing and merging.
+- Improved environment-specific module configuration support.
+
+### Testing Enhancements  
+- Better integration with Laravel 11/12's testing framework.
+- Enhanced module-specific test discovery and execution.
+- Improved support for feature and unit tests within modules.
+
+### Asset Management
+- Enhanced asset publishing for Laravel 11/12.
+- Better integration with Vite and modern asset compilation.
+- Improved module asset organization and management.
+
+## Advanced Module Features in v12
+
+### Enhanced Facade Methods
+Version 12 includes improved facade methods with better performance:
+- `Module::scan()` - Enhanced module auto-discovery
+- `Module::optimize()` - Performance optimizations
+- `Module::cache()` - Improved caching mechanisms
+
+### Modern Generator Commands
+- All generator commands now support Laravel 11/12 conventions
+- Enhanced templates with modern Laravel features
+- Better integration with Laravel's directory structure changes
+
+### Improved Service Provider Registration
+- Automatic service provider discovery
+- Better integration with Laravel's service container
+- Enhanced dependency injection support
+
+### Module Console Commands v12
+- Full compatibility with Laravel 11/12 command architecture
+- Enhanced command registration and discovery
+- Better integration with Laravel's console kernel
+
+### Testing Enhancements v12
+- Better integration with Laravel 11/12's testing framework
+- Enhanced module-specific test discovery
+- Improved support for Pest testing framework
+- Better factory and seeder integration
+
+### Configuration Management v12
+- Enhanced configuration caching support
+- Better environment-specific configurations
+- Improved module configuration merging
+- Support for Laravel 11/12's config publishing improvements

--- a/.ai/nwidart-laravel-modules/core.blade.php
+++ b/.ai/nwidart-laravel-modules/core.blade.php
@@ -1,0 +1,262 @@
+## Laravel Modules Core (v6+)
+
+- Use the `search-docs` tool to find Laravel Modules specific documentation when needed.
+- Use the `php artisan module:make [ModuleName]` command to create new modules.
+- Use the `php artisan module:make-controller [ControllerName] [ModuleName]` command to create controllers within modules.
+- Use the `php artisan module:make-model [ModelName] [ModuleName]` command to create models within modules.
+- Use the `php artisan module:make-migration [migration_name] [ModuleName]` command to create migrations within modules.
+- Each module should be self-contained with its own routes, controllers, models, views, and migrations.
+- Modules are located in the `Modules/` directory by default.
+
+## Laravel Modules Best Practices
+
+### Module Structure
+- Follow the standard module structure: Controllers, Models, Views, Routes, Migrations, Database (seeders/factories), Config, etc.
+- Keep module dependencies minimal - avoid tight coupling between modules.
+- Use proper namespacing: `Modules\[ModuleName]\Http\Controllers`, `Modules\[ModuleName]\Entities`, etc.
+
+### Routing
+- Define routes in `Modules/[ModuleName]/Routes/web.php` for web routes.
+- Define API routes in `Modules/[ModuleName]/Routes/api.php` for API routes.
+- Use route groups with proper prefixes and namespaces:
+@verbatim
+```php
+Route::prefix('modulename')->group(function() {
+    Route::get('/', [ModuleController::class, 'index']);
+});
+```
+@endverbatim
+
+### Models and Entities
+- Place models in `Modules/[ModuleName]/Models/` directory.
+- Use proper namespace: `Modules\[ModuleName]\Models\[ModelName]`.
+- Follow Laravel model conventions within the module context.
+
+### Controllers
+- Place controllers in `Modules/[ModuleName]/Http/Controllers/` directory.
+- Use proper namespace: `Modules\[ModuleName]\Http\Controllers\[ControllerName]`.
+- Import models from the correct module namespace.
+
+### Views
+- Place views in `Modules/[ModuleName]/Resources/views/` directory.
+- Reference views with module prefix: `modulename::viewname`.
+- Create layouts specific to modules when needed.
+
+### Migrations
+- Run `php artisan module:migrate [ModuleName]` to run migrations for a specific module.
+- Run `php artisan module:migrate` to run migrations for all modules.
+- Place migrations in `Modules/[ModuleName]/Database/Migrations/` directory.
+
+### Module Service Providers
+- Each module has its own service provider in `Modules/[ModuleName]/Providers/[ModuleName]ServiceProvider.php`.
+- Register module-specific services, routes, and views in the service provider.
+- Use the service provider to publish module assets and configuration.
+
+### Configuration
+- Place module configuration in `Modules/[ModuleName]/Config/config.php`.
+- Access module config with: `config('modulename.key')`.
+
+### Module Commands
+
+#### Basic Module Management
+- `php artisan module:make [ModuleName]` - Create a new module
+- `php artisan module:list` - List all modules
+- `php artisan module:enable [ModuleName]` - Enable a module
+- `php artisan module:disable [ModuleName]` - Disable a module  
+- `php artisan module:use [ModuleName]` - Set active module context
+- `php artisan module:unuse` - Clear active module context
+- `php artisan module:update [ModuleName]` - Update a module
+- `php artisan module:seed [ModuleName]` - Seed a specific module
+
+#### Migration Commands
+- `php artisan module:migrate [ModuleName]` - Run module migrations
+- `php artisan module:migrate-rollback [ModuleName]` - Rollback module migrations
+- `php artisan module:migrate-refresh [ModuleName]` - Refresh module migrations
+- `php artisan module:migrate-reset [ModuleName]` - Reset module migrations
+- `php artisan module:publish-migration [ModuleName]` - Publish module migrations
+
+#### Publishing Commands
+- `php artisan module:publish-config [ModuleName]` - Publish module configuration
+- `php artisan module:publish-translation [ModuleName]` - Publish translation files
+
+#### Generator Commands
+- `php artisan module:make-command [CommandName] [ModuleName]` - Create console command
+- `php artisan module:make-controller [ControllerName] [ModuleName]` - Create controller
+- `php artisan module:make-model [ModelName] [ModuleName]` - Create model
+- `php artisan module:make-migration [MigrationName] [ModuleName]` - Create migration
+- `php artisan module:make-seed [SeederName] [ModuleName]` - Create seeder
+- `php artisan module:make-provider [ProviderName] [ModuleName]` - Create service provider
+- `php artisan module:make-middleware [MiddlewareName] [ModuleName]` - Create middleware
+- `php artisan module:make-mail [MailName] [ModuleName]` - Create mail class
+- `php artisan module:make-notification [NotificationName] [ModuleName]` - Create notification
+- `php artisan module:make-listener [ListenerName] [ModuleName]` - Create event listener
+- `php artisan module:make-request [RequestName] [ModuleName]` - Create form request
+- `php artisan module:make-event [EventName] [ModuleName]` - Create event
+- `php artisan module:make-job [JobName] [ModuleName]` - Create job
+- `php artisan module:make-factory [FactoryName] [ModuleName]` - Create model factory
+- `php artisan module:make-policy [PolicyName] [ModuleName]` - Create policy
+- `php artisan module:make-rule [RuleName] [ModuleName]` - Create validation rule
+- `php artisan module:make-resource [ResourceName] [ModuleName]` - Create API resource
+- `php artisan module:make-test [TestName] [ModuleName]` - Create test
+- `php artisan module:route-provider [ModuleName]` - Create route service provider
+
+### Testing Modules
+- Place tests in `Modules/[ModuleName]/Tests/` directory.
+- Use proper namespace for test classes.
+- Test module functionality in isolation when possible.
+- Use Laravel's testing features with proper module context.
+
+### Module Publishing
+- Use `php artisan module:publish [ModuleName]` to publish module assets.
+- Configure publishable assets in the module's service provider.
+- Keep published assets organized and documented.
+
+## Module Facade Methods
+The `Module` facade provides methods for programmatic module management:
+
+### Module Discovery
+- `Module::all()` - Get all modules
+- `Module::find('blog')` - Find a specific module by name
+- `Module::has('blog')` - Check if a module exists
+- `Module::count()` - Get total number of modules
+
+### Module Status Management
+- `Module::allEnabled()` - Get all enabled modules
+- `Module::allDisabled()` - Get all disabled modules
+- `Module::getByStatus(1)` - Get modules by active/inactive status
+
+### Module Operations
+- `Module::register()` - Register modules
+- `Module::boot()` - Boot all available modules
+- `Module::install('module-name')` - Install a specific module
+- `Module::update('module-name')` - Update module dependencies
+
+### Path and Asset Methods
+- `Module::getPath()` - Get module path
+- `Module::assetPath('name')` - Get assets path for a module
+- `Module::asset('module:path')` - Get asset URL from a specific module
+
+### Advanced Methods
+- `Module::macro()` - Add custom methods to module repository
+- `Module::getRequirements('module')` - Get required modules for a specific module
+
+## Module Instance Methods
+When working with a specific module instance, use these methods:
+
+### Module Information
+@verbatim
+```php
+$module = Module::find('blog');
+$module->getName();        // Get module name
+$module->getLowerName();   // Get lowercase name
+$module->getStudlyName();  // Get StudlyCase name
+```
+@endverbatim
+
+### Module Paths
+@verbatim
+```php
+$module->getPath();                // Get module path
+$module->getExtraPath('Assets');   // Get additional module paths
+```
+@endverbatim
+
+### Module State Management
+@verbatim
+```php
+$module->enable();   // Enable the module
+$module->disable();  // Disable the module
+$module->delete();   // Delete the module
+```
+@endverbatim
+
+### Module Dependencies
+@verbatim
+```php
+$module->getRequires();  // Get array of module requirements (aliases)
+```
+@endverbatim
+
+## Module Events and Listeners
+Create and manage events within modules:
+
+### Creating Events and Listeners
+@verbatim
+```php
+// Create an event
+php artisan module:make-event BlogPostWasUpdated Blog
+
+// Create a listener
+php artisan module:make-listener NotifyAdminOfNewPost Blog
+```
+@endverbatim
+
+### Registering Events
+
+#### Method 1: Manual Registration in Service Provider
+@verbatim
+```php
+$this->app['events']->listen(
+    BlogPostWasUpdated::class, 
+    NotifyAdminOfNewPost::class
+);
+```
+@endverbatim
+
+#### Method 2: Create EventServiceProvider
+@verbatim
+```php
+<?php
+namespace Modules\Blog\Providers;
+
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+
+class EventServiceProvider extends ServiceProvider
+{
+    protected $listen = [
+        BlogPostWasUpdated::class => [
+            NotifyAdminOfNewPost::class,
+        ],
+    ];
+}
+```
+@endverbatim
+
+## Publishing Modules as Packages
+Distribute modules as Composer packages:
+
+### Setup Requirements
+1. Install required packages:
+   - `nwidart/laravel-modules`
+   - `joshbrw/laravel-module-installer`
+
+### Package Configuration
+Configure `composer.json`:
+@verbatim
+```json
+{
+    "type": "laravel-module",
+    "extra": {
+        "module-dir": "Custom"  // Optional custom directory
+    }
+}
+```
+@endverbatim
+
+### Repository Naming Convention
+- Use format: `<namespace>/<name>-module`
+- Example: `https://github.com/nWidart/article-module`
+- Installs to: `Module/Article` directory
+
+### Installation Command
+@verbatim
+```bash
+composer require nwidart/article-module
+```
+@endverbatim
+
+## Inter-Module Communication
+- Use Laravel's event system for loose coupling between modules.
+- Avoid direct dependencies between modules when possible.
+- Use contracts/interfaces for module interaction when needed.
+- Consider using service containers for shared functionality.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Laravel Boost includes AI guidelines for the following packages and frameworks. 
 | Tailwind CSS | core, 3.x, 4.x |
 | Livewire Volt | core |
 | Laravel Folio | core |
+| Laravel Modules (nwidart) | core, 12.x |
 | Enforce Tests | conditional |
 
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -59,6 +59,8 @@ class InstallCommand extends Command
 
     private bool $enforceTests = true;
 
+    private const LARAVEL_MODULES_PACKAGE = 'nwidart/laravel-modules';
+
     const MIN_TEST_COUNT = 6;
 
     private string $greenTick;
@@ -384,6 +386,7 @@ class InstallCommand extends Command
         $guidelineConfig->laravelStyle = $this->shouldInstallStyleGuidelines();
         $guidelineConfig->caresAboutLocalization = $this->detectLocalization();
         $guidelineConfig->hasAnApi = false;
+        $guidelineConfig->usesLaravelModules = $this->projectUsesLaravelModules();
 
         $composer = app(GuidelineComposer::class)->config($guidelineConfig);
         $guidelines = $composer->guidelines();
@@ -435,6 +438,28 @@ class InstallCommand extends Command
 
     private function shouldInstallStyleGuidelines(): bool
     {
+        return false;
+    }
+
+    /**
+     * Check if the project uses Laravel Modules.
+     */
+    private function projectUsesLaravelModules(): bool
+    {
+        $composerLock = base_path('composer.lock');
+
+        if (! file_exists($composerLock)) {
+            return false;
+        }
+
+        $lockContent = json_decode(file_get_contents($composerLock), true);
+
+        foreach ($lockContent['packages'] ?? [] as $package) {
+            if ($package['name'] === self::LARAVEL_MODULES_PACKAGE) {
+                return true;
+            }
+        }
+
         return false;
     }
 

--- a/src/Install/GuidelineComposer.php
+++ b/src/Install/GuidelineComposer.php
@@ -110,6 +110,16 @@ class GuidelineComposer
             // In future, if using NextJS localization/etc.. then have a diff. rule here
         }
 
+        if ($this->config->usesLaravelModules) {
+            $guidelines->put('nwidart-laravel-modules/core', $this->guideline('nwidart-laravel-modules/core'));
+
+            // Add version-specific guidelines if available
+            $version12Path = $this->guidelinesDir('nwidart-laravel-modules/12');
+            if (is_dir($version12Path)) {
+                $guidelines->put('nwidart-laravel-modules/12', $version12Path);
+            }
+        }
+
         // Add all core and version specific docs for Roster supported packages
         // We don't add guidelines for packages unsupported by Roster right now
         foreach ($this->roster->packages() as $package) {

--- a/src/Install/GuidelineConfig.php
+++ b/src/Install/GuidelineConfig.php
@@ -13,4 +13,6 @@ class GuidelineConfig
     public bool $caresAboutLocalization = false;
 
     public bool $hasAnApi = false;
+
+    public bool $usesLaravelModules = false;
 }


### PR DESCRIPTION
 This PR introduces automatic detection and AI guidelines support for the nwidart/laravel-modules package,
  following the same pattern established for other packages.

 ### **Motivation:**

The [nwidart/laravel-modules](https://packagist.org/packages/nwidart/laravel-modules) package is widely used (11M+ installs) in the Laravel ecosystem for managing large applications through a modular structure. In my experience, it's essential in the 3 main projects I work on daily, making this integration highly valuable for developers working with modular Laravel applications.

### **What's included:**

  - Auto-detection logic: Automatically detects if nwidart/laravel-modules is installed by scanning composer.lock
  - Comprehensive AI guidelines: Added detailed guidelines covering:
    - Complete Artisan commands reference (30+ commands organized by category)
    - Module Facade methods and Module instance methods
    - Events and listeners management within modules
    - Publishing modules as Composer packages
    - Best practices and module structure conventions
  - Version-specific support: Includes both core guidelines and Laravel Modules specific features
  - Zero configuration: When nwidart/laravel-modules is detected, guidelines are automatically included without
  user intervention

### **Implementation details:**

  - Added projectUsesLaravelModules() method in InstallCommand that scans composer.lock
  - Extended GuidelineConfig with usesLaravelModules property
  - Enhanced GuidelineComposer to conditionally include Laravel Modules guidelines
  - Created comprehensive documentation in .ai/nwidart-laravel-modules/ following the established structure

### **Files changed:**

  - src/Console/InstallCommand.php - Added auto-detection logic
  - src/Install/GuidelineConfig.php - Added configuration property
  - src/Install/GuidelineComposer.php - Added conditional guideline inclusion
  - .ai/nwidart-laravel-modules/core.blade.php - Core guidelines (v6+)
  - .ai/nwidart-laravel-modules/12/core.blade.php - Version 12 specific enhancements

  ---
### **Question:**
  Is this the appropriate place for this PR? I'd like to understand if Laravel Boost will focus exclusively on
  official Laravel packages or if it will also support popular third-party packages like nwidart/laravel-modules.

  If the policy is to support only official Laravel packages, I'm happy to create this as an extension to the
  official library instead. I just want to ensure I'm contributing in the right direction for the project's vision.
