### PR TITLE
Fix: MCP Environment Variable Caching Issue

### DIFF
--- a/src/Console/ExecuteToolCommand.php
+++ b/src/Console/ExecuteToolCommand.php
@@ -18,6 +18,9 @@ class ExecuteToolCommand extends Command
 
     public function handle(): int
     {
+        // Refresh environment variables
+        $this->refreshEnvironmentVariables();
+
         $toolClass = $this->argument('tool');
         $argumentsEncoded = $this->argument('arguments');
 
@@ -53,5 +56,25 @@ class ExecuteToolCommand extends Command
 
             return 1;
         }
+    }
+
+    /**
+     * Refresh environment variables and configuration.
+     */
+    protected function refreshEnvironmentVariables(): void
+    {
+        // Clear any cached config file
+        $configPath = app()->getCachedConfigPath();
+        if (file_exists($configPath)) {
+            unlink($configPath);
+        }
+
+        // Reload environment variables
+        $envLoader = new \Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables();
+        $envLoader->bootstrap(app());
+
+        // Force reload configuration from files
+        $configLoader = new \Illuminate\Foundation\Bootstrap\LoadConfiguration();
+        $configLoader->bootstrap(app());
     }
 }


### PR DESCRIPTION
# Problem
MCP server runs as a long-lived process that inherits environment variables at startup. When users change .env values, child processes spawned for tool execution inherit the parent's stale environment variables instead of reading fresh values from the updated .env file.

# Root Cause
MCP server loads .env values into $_ENV at startup
Child processes inherit parent's environment variables
Laravel's LoadEnvironmentVariables doesn't re-read .env if variables already exist in environment
Process isolation alone doesn't solve this due to environment inheritance

# Solution
Refresh environment variables ExecuteToolCommand 
Fix #130 