### PR TITLE
Feat: Detect env changes by default, fixes 130

### DIFF
--- a/src/Mcp/ToolExecutor.php
+++ b/src/Mcp/ToolExecutor.php
@@ -30,13 +30,7 @@ class ToolExecutor
 
     protected function executeInProcess(string $toolClass, array $arguments): ToolResult
     {
-        $command = [
-            PHP_BINARY,
-            base_path('artisan'),
-            'boost:execute-tool',
-            $toolClass,
-            base64_encode(json_encode($arguments)),
-        ];
+        $command = $this->buildCommand($toolClass, $arguments);
 
         $process = new Process($command);
         $process->setTimeout($this->getTimeout());
@@ -134,5 +128,23 @@ class ToolExecutor
         }
 
         return ToolResult::text('');
+    }
+
+    /**
+     * Build the command array for executing a tool in a subprocess.
+     *
+     * @param string $toolClass
+     * @param array<string, mixed> $arguments
+     * @return array<string>
+     */
+    protected function buildCommand(string $toolClass, array $arguments): array
+    {
+        return [
+            PHP_BINARY,
+            base_path('artisan'),
+            'boost:execute-tool',
+            $toolClass,
+            base64_encode(json_encode($arguments)),
+        ];
     }
 }

--- a/src/Mcp/ToolExecutor.php
+++ b/src/Mcp/ToolExecutor.php
@@ -13,14 +13,8 @@ class ToolExecutor
 {
     public function __construct()
     {
-        //
     }
 
-    /**
-     * Execute a tool with the given arguments.
-     *
-     * @param array<string, mixed> $arguments
-     */
     public function execute(string $toolClass, array $arguments = []): ToolResult
     {
         if (! ToolRegistry::isToolAllowed($toolClass)) {
@@ -34,11 +28,6 @@ class ToolExecutor
         return $this->executeInline($toolClass, $arguments);
     }
 
-    /**
-     * Execute tool in a separate process for isolation.
-     *
-     * @param array<string, mixed> $arguments
-     */
     protected function executeInProcess(string $toolClass, array $arguments): ToolResult
     {
         $command = [
@@ -77,14 +66,10 @@ class ToolExecutor
         }
     }
 
-    /**
-     * Execute tool inline (current process).
-     *
-     * @param array<string, mixed> $arguments
-     */
     protected function executeInline(string $toolClass, array $arguments): ToolResult
     {
         try {
+            /** @var \Laravel\Mcp\Server\Tool $tool */
             $tool = app($toolClass);
 
             return $tool->handle($arguments);
@@ -93,22 +78,15 @@ class ToolExecutor
         }
     }
 
-    /**
-     * Check if process isolation should be used.
-     */
     protected function shouldUseProcessIsolation(): bool
     {
-        // Never use process isolation in testing environment
         if (app()->environment('testing')) {
             return false;
         }
 
-        return config('boost.process_isolation.enabled', false);
+        return config('boost.process_isolation.enabled', true);
     }
 
-    /**
-     * Get the execution timeout.
-     */
     protected function getTimeout(): int
     {
         return config('boost.process_isolation.timeout', 180);

--- a/tests/Feature/Mcp/ToolExecutorTest.php
+++ b/tests/Feature/Mcp/ToolExecutorTest.php
@@ -2,6 +2,8 @@
 
 use Laravel\Boost\Mcp\ToolExecutor;
 use Laravel\Boost\Mcp\Tools\ApplicationInfo;
+use Laravel\Boost\Mcp\Tools\GetConfig;
+use Laravel\Boost\Mcp\Tools\Tinker;
 use Laravel\Mcp\Server\Tools\ToolResult;
 
 test('can execute tool inline', function () {
@@ -14,10 +16,136 @@ test('can execute tool inline', function () {
     expect($result)->toBeInstanceOf(ToolResult::class);
 });
 
-test('rejects unregistered tools', function () {
-    $executor = app(ToolExecutor::class);
-    $result = $executor->execute('NonExistentToolClass', []);
+test('can execute tool with process isolation', function () {
+    // Enable process isolation for this test
+    config(['boost.process_isolation.enabled' => true]);
+
+    // Create a mock that overrides buildCommand to work with testbench
+    $executor = Mockery::mock(ToolExecutor::class)->makePartial()
+        ->shouldAllowMockingProtectedMethods();
+    $executor->shouldReceive('buildCommand')
+        ->once()
+        ->andReturnUsing(fn ($toolClass, $arguments) => buildSubprocessCommand($toolClass, $arguments));
+
+    $result = $executor->execute(GetConfig::class, ['key' => 'app.name']);
 
     expect($result)->toBeInstanceOf(ToolResult::class);
-    expect($result->isError)->toBeTrue();
+
+    // If there's an error, extract the text content properly
+    if ($result->isError) {
+        $errorText = $result->content[0]->text ?? 'Unknown error';
+        expect(false)->toBeTrue("Tool execution failed with error: {$errorText}");
+    }
+
+    expect($result->isError)->toBeFalse();
+    expect($result->content)->toBeArray();
+
+    // The content should contain the app name (which should be "Laravel" in testbench)
+    $textContent = $result->content[0]->text ?? '';
+    expect($textContent)->toContain('Laravel');
 });
+
+test('rejects unregistered tools', function () {
+    $executor = app(ToolExecutor::class);
+    $result = $executor->execute('NonExistentToolClass');
+
+    expect($result)->toBeInstanceOf(ToolResult::class)
+        ->and($result->isError)->toBeTrue();
+});
+
+test('subprocess proves fresh process isolation', function () {
+    config(['boost.process_isolation.enabled' => true]);
+
+    $executor = Mockery::mock(ToolExecutor::class)->makePartial()
+        ->shouldAllowMockingProtectedMethods();
+    $executor->shouldReceive('buildCommand')
+        ->andReturnUsing(fn ($toolClass, $arguments) => buildSubprocessCommand($toolClass, $arguments));
+
+    $result1 = $executor->execute(Tinker::class, ['code' => 'return getmypid();']);
+    $result2 = $executor->execute(Tinker::class, ['code' => 'return getmypid();']);
+
+    expect($result1->isError)->toBeFalse();
+    expect($result2->isError)->toBeFalse();
+
+    $pid1 = json_decode($result1->content[0]->text, true)['result'];
+    $pid2 = json_decode($result2->content[0]->text, true)['result'];
+
+    expect($pid1)->toBeInt()->not->toBe(getmypid());
+    expect($pid2)->toBeInt()->not->toBe(getmypid());
+    expect($pid1)->not()->toBe($pid2);
+});
+
+test('subprocess sees modified autoloaded code changes', function () {
+    config(['boost.process_isolation.enabled' => true]);
+
+    $executor = Mockery::mock(ToolExecutor::class)->makePartial()
+        ->shouldAllowMockingProtectedMethods();
+    $executor->shouldReceive('buildCommand')
+        ->andReturnUsing(fn ($toolClass, $arguments) => buildSubprocessCommand($toolClass, $arguments));
+
+    // Path to the GetConfig tool that we'll temporarily modify
+    // TODO: Improve for parallelisation
+    $toolPath = dirname(__DIR__, 3).'/src/Mcp/Tools/GetConfig.php';
+    $originalContent = file_get_contents($toolPath);
+
+    $cleanup = function () use ($toolPath, $originalContent) {
+        file_put_contents($toolPath, $originalContent);
+    };
+
+    try {
+        $result1 = $executor->execute(GetConfig::class, ['key' => 'app.name']);
+
+        expect($result1->isError)->toBeFalse();
+        $response1 = json_decode($result1->content[0]->text, true);
+        expect($response1['value'])->toBe('Laravel'); // Normal testbench app name
+
+        // Modify GetConfig.php to return a different hardcoded value
+        $modifiedContent = str_replace(
+            "'value' => Config::get(\$key),",
+            "'value' => 'MODIFIED_BY_TEST',",
+            $originalContent
+        );
+        file_put_contents($toolPath, $modifiedContent);
+
+        $result2 = $executor->execute(GetConfig::class, ['key' => 'app.name']);
+        $response2 = json_decode($result2->content[0]->text, true);
+
+        expect($result2->isError)->toBeFalse();
+        expect($response2['value'])->toBe('MODIFIED_BY_TEST'); // Using updated code, not cached
+    } finally {
+        $cleanup();
+    }
+});
+
+/**
+ * Build a subprocess command that bootstraps testbench and executes an MCP tool via artisan.
+ */
+function buildSubprocessCommand(string $toolClass, array $arguments): array
+{
+    $argumentsEncoded = base64_encode(json_encode($arguments));
+    $testScript = sprintf(
+        'require_once "%s/vendor/autoload.php"; '.
+        'use Orchestra\Testbench\Foundation\Application as Testbench; '.
+        'use Orchestra\Testbench\Foundation\Config as TestbenchConfig; '.
+        'use Illuminate\Support\Facades\Artisan; '.
+        'use Symfony\Component\Console\Output\BufferedOutput; '.
+        // Bootstrap testbench like all.php does
+        '$app = Testbench::createFromConfig(new TestbenchConfig([]), options: ["enables_package_discoveries" => false]); '.
+        'Illuminate\Container\Container::setInstance($app); '.
+        '$kernel = $app->make("Illuminate\Contracts\Console\Kernel"); '.
+        '$kernel->bootstrap(); '.
+        // Register the ExecuteToolCommand
+        '$kernel->registerCommand(new \Laravel\Boost\Console\ExecuteToolCommand()); '.
+        '$output = new BufferedOutput(); '.
+        '$result = Artisan::call("boost:execute-tool", ['.
+        '  "tool" => "%s", '.
+        '  "arguments" => "%s" '.
+        '], $output); '.
+        'echo $output->fetch();',
+        dirname(__DIR__, 3), // Go up from tests/Feature/Mcp to project root
+        addslashes($toolClass),
+        $argumentsEncoded
+    );
+
+    return [PHP_BINARY, '-r', $testScript];
+}


### PR DESCRIPTION
- Fixes: #130 and #194

# What & Why
- Default process isolation to `true` - this gives the best experience and is stable
- Adds tests to ensure process isolation works as expected

# How I tested

### Claude Code
These all worked as expected

**Does the list-artisan-commands tool see new tools?**
```
Can you help me debug an issue with the boost MCP? this requires a couple steps:

  1. Call list artisan commands, take note of them
  2. Add a new artisan command
  3. Call list artisan commands, see if it shows the new command
  4. Remove the artisan command
  5. Call list artisan commands, see if it's gone
```

**Does the tinker tool see new classes?**
```
Now I need to test the 'tinker' tool

  1. Create a new helper class with a static function that returns a string
  2. Use tinker to var_dump that class's static function return                                                                                                                                                                   This should verify if tinker has access to new code and isn't using cached bytecode right?
```

**Does the tinker tool see new methods?**
```
Let's test the 'tinker' tool again to see if it detects new methods.
1. Create a new helper class with a method that returns a string
2. Use tinker to var_dump the method's return
3. Update the helper class to change the method name and string returned
4. Use tinker to var_dump using new method name, verify it succeeds & the string is different
```

**Does list env/config see new env and config values?**
```
Let's test the list env and list config tools:
1. List config & env vars, keep a note of them
2. Use a shell tool to append a new ENV var to .env
3. Create a new config file with a config value that uses the new ENV var, with a very different default if it doesn't exist
4. Call list config & env vars
5. Does our new env key show up?
6. Does our new config key show up?
7. Is the config value the value from .env?
```

# Notes/thoughts
  - I'd like the tests to be cleaner soon, but I'm glad they're there and showing it working