### PR TITLE
fix: correct syntax in Tailwind v4 import code snippet

### DIFF
--- a/.ai/tailwindcss/4/core.blade.php
+++ b/.ai/tailwindcss/4/core.blade.php
@@ -4,7 +4,7 @@
 - `corePlugins` is not supported in Tailwind v4.
 - In Tailwind v4, you import Tailwind using a regular CSS `@import` statement, not using the `@tailwind` directives used in v3:
 @verbatim
-<code-snippet name="Tailwind v4 Import Tailwind Diff" lang="diff"
+<code-snippet name="Tailwind v4 Import Tailwind Diff" lang="diff">
    - @tailwind base;
    - @tailwind components;
    - @tailwind utilities;


### PR DESCRIPTION
This pull request makes a minor formatting update to the Tailwind v4 documentation in `.ai/tailwindcss/4/core.blade.php`. The change corrects the syntax for the `code-snippet` tag, ensuring proper rendering of the Tailwind import example.