### PR TITLE
Streamline ToolResult assertions in tests 

### DIFF
--- a/tests/Feature/Mcp/Tools/ApplicationInfoTest.php
+++ b/tests/Feature/Mcp/Tools/ApplicationInfoTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Laravel\Boost\Install\GuidelineAssist;
 use Laravel\Boost\Mcp\Tools\ApplicationInfo;
-use Laravel\Mcp\Server\Tools\ToolResult;
 use Laravel\Roster\Enums\Packages;
 use Laravel\Roster\Package;
 use Laravel\Roster\PackageCollection;
@@ -28,26 +27,24 @@ test('it returns application info with packages', function () {
     $tool = new ApplicationInfo($roster, $guidelineAssist);
     $result = $tool->handle([]);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
-
-    $data = $result->toArray();
-    expect($data['isError'])->toBeFalse();
-
-    $content = json_decode($data['content'][0]['text'], true);
-    expect($content['php_version'])->toBe(PHP_VERSION);
-    expect($content['laravel_version'])->toBe(app()->version());
-    expect($content['database_engine'])->toBe(config('database.default'));
-    expect($content['packages'])->toHaveCount(2);
-    expect($content['packages'][0]['roster_name'])->toBe('LARAVEL');
-    expect($content['packages'][0]['package_name'])->toBe('laravel/framework');
-    expect($content['packages'][0]['version'])->toBe('11.0.0');
-    expect($content['packages'][1]['roster_name'])->toBe('PEST');
-    expect($content['packages'][1]['package_name'])->toBe('pestphp/pest');
-    expect($content['packages'][1]['version'])->toBe('2.0.0');
-    expect($content['models'])->toBeArray();
-    expect($content['models'])->toHaveCount(2);
-    expect($content['models'])->toContain('App\\Models\\User');
-    expect($content['models'])->toContain('App\\Models\\Post');
+    expect($result)->isToolResult()
+        ->toolHasNoError()
+        ->toolJsonContent(function ($content) {
+            expect($content['php_version'])->toBe(PHP_VERSION)
+                ->and($content['laravel_version'])->toBe(app()->version())
+                ->and($content['database_engine'])->toBe(config('database.default'))
+                ->and($content['packages'])->toHaveCount(2)
+                ->and($content['packages'][0]['roster_name'])->toBe('LARAVEL')
+                ->and($content['packages'][0]['package_name'])->toBe('laravel/framework')
+                ->and($content['packages'][0]['version'])->toBe('11.0.0')
+                ->and($content['packages'][1]['roster_name'])->toBe('PEST')
+                ->and($content['packages'][1]['package_name'])->toBe('pestphp/pest')
+                ->and($content['packages'][1]['version'])->toBe('2.0.0')
+                ->and($content['models'])->toBeArray()
+                ->and($content['models'])->toHaveCount(2)
+                ->and($content['models'])->toContain('App\\Models\\User')
+                ->and($content['models'])->toContain('App\\Models\\Post');
+        });
 });
 
 test('it returns application info with no packages', function () {
@@ -60,17 +57,14 @@ test('it returns application info with no packages', function () {
     $tool = new ApplicationInfo($roster, $guidelineAssist);
     $result = $tool->handle([]);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
-    expect($result)->toBeInstanceOf(ToolResult::class);
-
-    $data = $result->toArray();
-    expect($data['isError'])->toBeFalse();
-
-    $content = json_decode($data['content'][0]['text'], true);
-    expect($content['php_version'])->toBe(PHP_VERSION);
-    expect($content['laravel_version'])->toBe(app()->version());
-    expect($content['database_engine'])->toBe(config('database.default'));
-    expect($content['packages'])->toHaveCount(0);
-    expect($content['models'])->toBeArray();
-    expect($content['models'])->toHaveCount(0);
+    expect($result)->isToolResult()
+        ->toolHasNoError()
+        ->toolJsonContent(function ($content) {
+            expect($content['php_version'])->toBe(PHP_VERSION)
+                ->and($content['laravel_version'])->toBe(app()->version())
+                ->and($content['database_engine'])->toBe(config('database.default'))
+                ->and($content['packages'])->toHaveCount(0)
+                ->and($content['models'])->toBeArray()
+                ->and($content['models'])->toHaveCount(0);
+        });
 });

--- a/tests/Feature/Mcp/Tools/ApplicationInfoTest.php
+++ b/tests/Feature/Mcp/Tools/ApplicationInfoTest.php
@@ -29,22 +29,27 @@ test('it returns application info with packages', function () {
 
     expect($result)->isToolResult()
         ->toolHasNoError()
-        ->toolJsonContent(function ($content) {
-            expect($content['php_version'])->toBe(PHP_VERSION)
-                ->and($content['laravel_version'])->toBe(app()->version())
-                ->and($content['database_engine'])->toBe(config('database.default'))
-                ->and($content['packages'])->toHaveCount(2)
-                ->and($content['packages'][0]['roster_name'])->toBe('LARAVEL')
-                ->and($content['packages'][0]['package_name'])->toBe('laravel/framework')
-                ->and($content['packages'][0]['version'])->toBe('11.0.0')
-                ->and($content['packages'][1]['roster_name'])->toBe('PEST')
-                ->and($content['packages'][1]['package_name'])->toBe('pestphp/pest')
-                ->and($content['packages'][1]['version'])->toBe('2.0.0')
-                ->and($content['models'])->toBeArray()
-                ->and($content['models'])->toHaveCount(2)
-                ->and($content['models'])->toContain('App\\Models\\User')
-                ->and($content['models'])->toContain('App\\Models\\Post');
-        });
+        ->toolJsonContentToMatchArray([
+            'php_version' => PHP_VERSION,
+            'laravel_version' => app()->version(),
+            'database_engine' => config('database.default'),
+            'packages' => [
+                [
+                    'roster_name' => 'LARAVEL',
+                    'package_name' => 'laravel/framework',
+                    'version' => '11.0.0',
+                ],
+                [
+                    'roster_name' => 'PEST',
+                    'package_name' => 'pestphp/pest',
+                    'version' => '2.0.0',
+                ],
+            ],
+            'models' => [
+                'App\\Models\\User',
+                'App\\Models\\Post',
+            ],
+        ]);
 });
 
 test('it returns application info with no packages', function () {
@@ -59,12 +64,11 @@ test('it returns application info with no packages', function () {
 
     expect($result)->isToolResult()
         ->toolHasNoError()
-        ->toolJsonContent(function ($content) {
-            expect($content['php_version'])->toBe(PHP_VERSION)
-                ->and($content['laravel_version'])->toBe(app()->version())
-                ->and($content['database_engine'])->toBe(config('database.default'))
-                ->and($content['packages'])->toHaveCount(0)
-                ->and($content['models'])->toBeArray()
-                ->and($content['models'])->toHaveCount(0);
-        });
+        ->toolJsonContentToMatchArray([
+            'php_version' => PHP_VERSION,
+            'laravel_version' => app()->version(),
+            'database_engine' => config('database.default'),
+            'packages' => [],
+            'models' => [],
+        ]);
 });

--- a/tests/Feature/Mcp/Tools/BrowserLogsTest.php
+++ b/tests/Feature/Mcp/Tools/BrowserLogsTest.php
@@ -205,8 +205,8 @@ HTML;
     $content = $result->getContent();
     expect($content)->toContain('browser-logger-active')
         ->and($content)->toContain('</head>')
+        // Should not inject twice
         ->and(substr_count($content, 'browser-logger-active'))->toBe(1);
-    // Should not inject twice
 });
 
 test('InjectBoost middleware does not inject into non-HTML responses', function () {

--- a/tests/Feature/Mcp/Tools/BrowserLogsTest.php
+++ b/tests/Feature/Mcp/Tools/BrowserLogsTest.php
@@ -10,7 +10,6 @@ use Illuminate\Support\Facades\Route;
 use Laravel\Boost\Mcp\Tools\BrowserLogs;
 use Laravel\Boost\Middleware\InjectBoost;
 use Laravel\Boost\Services\BrowserLogger;
-use Laravel\Mcp\Server\Tools\ToolResult;
 
 beforeEach(function () {
     // Clean up any existing browser.log file before each test
@@ -36,16 +35,13 @@ LOG;
     $tool = new BrowserLogs;
     $result = $tool->handle(['entries' => 2]);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
+    expect($result)->isToolResult()
+        ->toolHasNoError()
+        ->toolTextContains('browser.WARNING: Warning message', 'browser.ERROR: JavaScript error occurred')
+        ->toolTextDoesNotContain('browser.DEBUG: console log message');
 
     $data = $result->toArray();
-    expect($data['isError'])->toBeFalse();
     expect($data['content'][0]['type'])->toBe('text');
-
-    $text = $data['content'][0]['text'];
-    expect($text)->toContain('browser.WARNING: Warning message');
-    expect($text)->toContain('browser.ERROR: JavaScript error occurred');
-    expect($text)->not->toContain('browser.DEBUG: console log message');
 });
 
 test('it returns error when entries argument is invalid', function () {
@@ -53,30 +49,24 @@ test('it returns error when entries argument is invalid', function () {
 
     // Test with zero
     $result = $tool->handle(['entries' => 0]);
-    expect($result)->toBeInstanceOf(ToolResult::class);
-
-    $data = $result->toArray();
-    expect($data['isError'])->toBeTrue();
-    expect($data['content'][0]['text'])->toBe('The "entries" argument must be greater than 0.');
+    expect($result)->isToolResult()
+        ->toolHasError()
+        ->toolTextContains('The "entries" argument must be greater than 0.');
 
     // Test with negative
     $result = $tool->handle(['entries' => -5]);
-    expect($result)->toBeInstanceOf(ToolResult::class);
-
-    $data = $result->toArray();
-    expect($data['isError'])->toBeTrue();
-    expect($data['content'][0]['text'])->toBe('The "entries" argument must be greater than 0.');
+    expect($result)->isToolResult()
+        ->toolHasError()
+        ->toolTextContains('The "entries" argument must be greater than 0.');
 });
 
 test('it returns error when log file does not exist', function () {
     $tool = new BrowserLogs;
     $result = $tool->handle(['entries' => 10]);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
-
-    $data = $result->toArray();
-    expect($data['isError'])->toBeTrue();
-    expect($data['content'][0]['text'])->toBe('No log file found, probably means no logs yet.');
+    expect($result)->isToolResult()
+        ->toolHasError()
+        ->toolTextContains('No log file found, probably means no logs yet.');
 });
 
 test('it returns error when log file is empty', function () {
@@ -88,11 +78,9 @@ test('it returns error when log file is empty', function () {
     $tool = new BrowserLogs;
     $result = $tool->handle(['entries' => 5]);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
-
-    $data = $result->toArray();
-    expect($data['isError'])->toBeFalse();
-    expect($data['content'][0]['text'])->toBe('Unable to retrieve log entries, or no logs');
+    expect($result)->isToolResult()
+        ->toolHasNoError()
+        ->toolTextContains('Unable to retrieve log entries, or no logs');
 });
 
 test('@boostJs blade directive renders browser logger script', function () {
@@ -106,11 +94,11 @@ test('@boostJs blade directive renders browser logger script', function () {
 
     // Test that the script contains expected content
     $script = BrowserLogger::getScript();
-    expect($script)->toContain('browser-logger-active');
-    expect($script)->toContain('/_boost/browser-logs');
-    expect($script)->toContain('console.log');
-    expect($script)->toContain('console.error');
-    expect($script)->toContain('window.onerror');
+    expect($script)->toContain('browser-logger-active')
+        ->and($script)->toContain('/_boost/browser-logs')
+        ->and($script)->toContain('console.log')
+        ->and($script)->toContain('console.error')
+        ->and($script)->toContain('window.onerror');
 });
 
 test('browser logs endpoint processes logs correctly', function () {
@@ -215,9 +203,10 @@ HTML;
     });
 
     $content = $result->getContent();
-    expect($content)->toContain('browser-logger-active');
-    expect($content)->toContain('</head>');
-    expect(substr_count($content, 'browser-logger-active'))->toBe(1); // Should not inject twice
+    expect($content)->toContain('browser-logger-active')
+        ->and($content)->toContain('</head>')
+        ->and(substr_count($content, 'browser-logger-active'))->toBe(1);
+    // Should not inject twice
 });
 
 test('InjectBoost middleware does not inject into non-HTML responses', function () {
@@ -233,8 +222,8 @@ test('InjectBoost middleware does not inject into non-HTML responses', function 
     });
 
     $content = $result->getContent();
-    expect($content)->toBe($json);
-    expect($content)->not->toContain('browser-logger-active');
+    expect($content)->toBe($json)
+        ->and($content)->not->toContain('browser-logger-active');
 });
 
 test('InjectBoost middleware does not inject script twice', function () {
@@ -284,6 +273,6 @@ HTML;
     });
 
     $content = $result->getContent();
-    expect($content)->toContain('browser-logger-active');
-    expect($content)->toMatch('/<script[^>]*browser-logger-active[^>]*>.*<\/script>\s*<\/body>/s');
+    expect($content)->toContain('browser-logger-active')
+        ->and($content)->toMatch('/<script[^>]*browser-logger-active[^>]*>.*<\/script>\s*<\/body>/s');
 });

--- a/tests/Feature/Mcp/Tools/DatabaseConnectionsTest.php
+++ b/tests/Feature/Mcp/Tools/DatabaseConnectionsTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Laravel\Boost\Mcp\Tools\DatabaseConnections;
-use Laravel\Mcp\Server\Tools\ToolResult;
 
 beforeEach(function () {
     config()->set('database.default', 'mysql');
@@ -18,16 +17,15 @@ test('it returns database connections', function () {
     $tool = new DatabaseConnections;
     $result = $tool->handle([]);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
-    $data = $result->toArray();
-    expect($data['isError'])->toBe(false);
-
-    $content = json_decode($data['content'][0]['text'], true);
-    expect($content['default_connection'])->toBe('mysql');
-    expect($content['connections'])->toHaveCount(3);
-    expect($content['connections'])->toContain('mysql');
-    expect($content['connections'])->toContain('pgsql');
-    expect($content['connections'])->toContain('sqlite');
+    expect($result)->isToolResult()
+        ->toolHasNoError()
+        ->toolJsonContent(function ($content) {
+            expect($content['default_connection'])->toBe('mysql')
+                ->and($content['connections'])->toHaveCount(3)
+                ->and($content['connections'])->toContain('mysql')
+                ->and($content['connections'])->toContain('pgsql')
+                ->and($content['connections'])->toContain('sqlite');
+        });
 });
 
 test('it returns empty connections when none configured', function () {
@@ -36,11 +34,10 @@ test('it returns empty connections when none configured', function () {
     $tool = new DatabaseConnections;
     $result = $tool->handle([]);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
-    $data = $result->toArray();
-    expect($data['isError'])->toBe(false);
-
-    $content = json_decode($data['content'][0]['text'], true);
-    expect($content['default_connection'])->toBe('mysql');
-    expect($content['connections'])->toHaveCount(0);
+    expect($result)->isToolResult()
+        ->toolHasNoError()
+        ->toolJsonContent(function ($content) {
+            expect($content['default_connection'])->toBe('mysql')
+                ->and($content['connections'])->toHaveCount(0);
+        });
 });

--- a/tests/Feature/Mcp/Tools/DatabaseConnectionsTest.php
+++ b/tests/Feature/Mcp/Tools/DatabaseConnectionsTest.php
@@ -19,13 +19,10 @@ test('it returns database connections', function () {
 
     expect($result)->isToolResult()
         ->toolHasNoError()
-        ->toolJsonContent(function ($content) {
-            expect($content['default_connection'])->toBe('mysql')
-                ->and($content['connections'])->toHaveCount(3)
-                ->and($content['connections'])->toContain('mysql')
-                ->and($content['connections'])->toContain('pgsql')
-                ->and($content['connections'])->toContain('sqlite');
-        });
+        ->toolJsonContentToMatchArray([
+            'default_connection' => 'mysql',
+            'connections' => ['mysql', 'pgsql', 'sqlite'],
+        ]);
 });
 
 test('it returns empty connections when none configured', function () {
@@ -36,8 +33,8 @@ test('it returns empty connections when none configured', function () {
 
     expect($result)->isToolResult()
         ->toolHasNoError()
-        ->toolJsonContent(function ($content) {
-            expect($content['default_connection'])->toBe('mysql')
-                ->and($content['connections'])->toHaveCount(0);
-        });
+        ->toolJsonContentToMatchArray([
+            'default_connection' => 'mysql',
+            'connections' => [],
+        ]);
 });

--- a/tests/Feature/Mcp/Tools/DatabaseSchemaTest.php
+++ b/tests/Feature/Mcp/Tools/DatabaseSchemaTest.php
@@ -40,36 +40,30 @@ test('it returns structured database schema', function () {
     $response = $tool->handle([]);
 
     expect($response)->isToolResult()
-        ->toolHasNoError();
+        ->toolHasNoError()
+        ->toolJsonContent(function ($schemaArray) {
+            expect($schemaArray)->toHaveKey('engine')
+                ->and($schemaArray['engine'])->toBe('sqlite')
+                ->and($schemaArray)->toHaveKey('tables')
+                ->and($schemaArray['tables'])->toHaveKey('examples');
 
-    $responseArray = $response->toArray();
+            $exampleTable = $schemaArray['tables']['examples'];
+            expect($exampleTable)->toHaveKey('columns')
+                ->and($exampleTable['columns'])->toHaveKey('id')
+                ->and($exampleTable['columns'])->toHaveKey('name')
+                ->and($exampleTable['columns']['id']['type'])->toBe('integer')
+                ->and($exampleTable['columns']['name']['type'])->toBe('varchar')
+                ->and($exampleTable)->toHaveKey('indexes')
+                ->and($exampleTable)->toHaveKey('foreign_keys')
+                ->and($exampleTable)->toHaveKey('triggers')
+                ->and($exampleTable)->toHaveKey('check_constraints');
 
-    $schemaArray = json_decode($responseArray['content'][0]['text'], true);
-
-    expect($schemaArray)->toHaveKey('engine');
-    expect($schemaArray['engine'])->toBe('sqlite');
-
-    expect($schemaArray)->toHaveKey('tables');
-    expect($schemaArray['tables'])->toHaveKey('examples');
-
-    $exampleTable = $schemaArray['tables']['examples'];
-    expect($exampleTable)->toHaveKey('columns');
-    expect($exampleTable['columns'])->toHaveKey('id');
-    expect($exampleTable['columns'])->toHaveKey('name');
-
-    expect($exampleTable['columns']['id']['type'])->toBe('integer');
-    expect($exampleTable['columns']['name']['type'])->toBe('varchar');
-
-    expect($exampleTable)->toHaveKey('indexes');
-    expect($exampleTable)->toHaveKey('foreign_keys');
-    expect($exampleTable)->toHaveKey('triggers');
-    expect($exampleTable)->toHaveKey('check_constraints');
-
-    expect($schemaArray)->toHaveKey('global');
-    expect($schemaArray['global'])->toHaveKey('views');
-    expect($schemaArray['global'])->toHaveKey('stored_procedures');
-    expect($schemaArray['global'])->toHaveKey('functions');
-    expect($schemaArray['global'])->toHaveKey('sequences');
+            expect($schemaArray)->toHaveKey('global')
+                ->and($schemaArray['global'])->toHaveKey('views')
+                ->and($schemaArray['global'])->toHaveKey('stored_procedures')
+                ->and($schemaArray['global'])->toHaveKey('functions')
+                ->and($schemaArray['global'])->toHaveKey('sequences');
+        });
 });
 
 test('it filters tables by name', function () {
@@ -83,17 +77,19 @@ test('it filters tables by name', function () {
 
     // Test filtering for 'example'
     $response = $tool->handle(['filter' => 'example']);
-    $responseArray = $response->toArray();
-    $schemaArray = json_decode($responseArray['content'][0]['text'], true);
-
-    expect($schemaArray['tables'])->toHaveKey('examples');
-    expect($schemaArray['tables'])->not->toHaveKey('users');
+    expect($response)->isToolResult()
+        ->toolHasNoError()
+        ->toolJsonContent(function ($schemaArray) {
+            expect($schemaArray['tables'])->toHaveKey('examples')
+                ->and($schemaArray['tables'])->not->toHaveKey('users');
+        });
 
     // Test filtering for 'user'
     $response = $tool->handle(['filter' => 'user']);
-    $responseArray = $response->toArray();
-    $schemaArray = json_decode($responseArray['content'][0]['text'], true);
-
-    expect($schemaArray['tables'])->toHaveKey('users');
-    expect($schemaArray['tables'])->not->toHaveKey('examples');
+    expect($response)->isToolResult()
+        ->toolHasNoError()
+        ->toolJsonContent(function ($schemaArray) {
+            expect($schemaArray['tables'])->toHaveKey('users')
+                ->and($schemaArray['tables'])->not->toHaveKey('examples');
+        });
 });

--- a/tests/Feature/Mcp/Tools/DatabaseSchemaTest.php
+++ b/tests/Feature/Mcp/Tools/DatabaseSchemaTest.php
@@ -41,28 +41,21 @@ test('it returns structured database schema', function () {
 
     expect($response)->isToolResult()
         ->toolHasNoError()
+        ->toolJsonContentToMatchArray([
+            'engine' => 'sqlite',
+        ])
         ->toolJsonContent(function ($schemaArray) {
-            expect($schemaArray)->toHaveKey('engine')
-                ->and($schemaArray['engine'])->toBe('sqlite')
-                ->and($schemaArray)->toHaveKey('tables')
+            expect($schemaArray)->toHaveKey('tables')
                 ->and($schemaArray['tables'])->toHaveKey('examples');
 
             $exampleTable = $schemaArray['tables']['examples'];
-            expect($exampleTable)->toHaveKey('columns')
-                ->and($exampleTable['columns'])->toHaveKey('id')
-                ->and($exampleTable['columns'])->toHaveKey('name')
+            expect($exampleTable)->toHaveKeys(['columns', 'indexes', 'foreign_keys', 'triggers', 'check_constraints'])
+                ->and($exampleTable['columns'])->toHaveKeys(['id', 'name'])
                 ->and($exampleTable['columns']['id']['type'])->toBe('integer')
                 ->and($exampleTable['columns']['name']['type'])->toBe('varchar')
-                ->and($exampleTable)->toHaveKey('indexes')
-                ->and($exampleTable)->toHaveKey('foreign_keys')
-                ->and($exampleTable)->toHaveKey('triggers')
-                ->and($exampleTable)->toHaveKey('check_constraints');
+                ->and($schemaArray)->toHaveKey('global')
+                ->and($schemaArray['global'])->toHaveKeys(['views', 'stored_procedures', 'functions', 'sequences']);
 
-            expect($schemaArray)->toHaveKey('global')
-                ->and($schemaArray['global'])->toHaveKey('views')
-                ->and($schemaArray['global'])->toHaveKey('stored_procedures')
-                ->and($schemaArray['global'])->toHaveKey('functions')
-                ->and($schemaArray['global'])->toHaveKey('sequences');
         });
 });
 

--- a/tests/Feature/Mcp/Tools/DatabaseSchemaTest.php
+++ b/tests/Feature/Mcp/Tools/DatabaseSchemaTest.php
@@ -39,8 +39,10 @@ test('it returns structured database schema', function () {
     $tool = new DatabaseSchema;
     $response = $tool->handle([]);
 
+    expect($response)->isToolResult()
+        ->toolHasNoError();
+
     $responseArray = $response->toArray();
-    expect($responseArray['isError'])->toBeFalse();
 
     $schemaArray = json_decode($responseArray['content'][0]['text'], true);
 

--- a/tests/Feature/Mcp/Tools/GetAbsoluteUrlTest.php
+++ b/tests/Feature/Mcp/Tools/GetAbsoluteUrlTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
 use Laravel\Boost\Mcp\Tools\GetAbsoluteUrl;
-use Laravel\Mcp\Server\Tools\ToolResult;
 
 beforeEach(function () {
     config()->set('app.url', 'http://localhost');
@@ -17,48 +16,43 @@ test('it returns absolute url for root path by default', function () {
     $tool = new GetAbsoluteUrl;
     $result = $tool->handle([]);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
-    $data = $result->toArray();
-    expect($data['isError'])->toBe(false);
-    expect($data['content'][0]['text'])->toBe('http://localhost');
+    expect($result)->isToolResult()
+        ->toolHasNoError()
+        ->toolTextContains('http://localhost');
 });
 
 test('it returns absolute url for given path', function () {
     $tool = new GetAbsoluteUrl;
     $result = $tool->handle(['path' => '/dashboard']);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
-    $data = $result->toArray();
-    expect($data['isError'])->toBe(false);
-    expect($data['content'][0]['text'])->toBe('http://localhost/dashboard');
+    expect($result)->isToolResult()
+        ->toolHasNoError()
+        ->toolTextContains('http://localhost/dashboard');
 });
 
 test('it returns absolute url for named route', function () {
     $tool = new GetAbsoluteUrl;
     $result = $tool->handle(['route' => 'test.route']);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
-    $data = $result->toArray();
-    expect($data['isError'])->toBe(false);
-    expect($data['content'][0]['text'])->toBe('http://localhost/test');
+    expect($result)->isToolResult()
+        ->toolHasNoError()
+        ->toolTextContains('http://localhost/test');
 });
 
 test('it prioritizes path over route when both are provided', function () {
     $tool = new GetAbsoluteUrl;
     $result = $tool->handle(['path' => '/dashboard', 'route' => 'test.route']);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
-    $data = $result->toArray();
-    expect($data['isError'])->toBe(false);
-    expect($data['content'][0]['text'])->toBe('http://localhost/dashboard');
+    expect($result)->isToolResult()
+        ->toolHasNoError()
+        ->toolTextContains('http://localhost/dashboard');
 });
 
 test('it handles empty path', function () {
     $tool = new GetAbsoluteUrl;
     $result = $tool->handle(['path' => '']);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
-    $data = $result->toArray();
-    expect($data['isError'])->toBe(false);
-    expect($data['content'][0]['text'])->toBe('http://localhost');
+    expect($result)->isToolResult()
+        ->toolHasNoError()
+        ->toolTextContains('http://localhost');
 });

--- a/tests/Feature/Mcp/Tools/GetConfigTest.php
+++ b/tests/Feature/Mcp/Tools/GetConfigTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Laravel\Boost\Mcp\Tools\GetConfig;
-use Laravel\Mcp\Server\Tools\ToolResult;
 
 beforeEach(function () {
     config()->set('test.key', 'test_value');
@@ -15,42 +14,34 @@ test('it returns config value when key exists', function () {
     $tool = new GetConfig;
     $result = $tool->handle(['key' => 'test.key']);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
-
-    $data = $result->toArray();
-    expect($data['content'][0]['text'])->toContain('"key": "test.key"');
-    expect($data['content'][0]['text'])->toContain('"value": "test_value"');
+    expect($result)->isToolResult()
+        ->toolHasNoError()
+        ->toolTextContains('"key": "test.key"', '"value": "test_value"');
 });
 
 test('it returns nested config value', function () {
     $tool = new GetConfig;
     $result = $tool->handle(['key' => 'nested.config.key']);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
-
-    $data = $result->toArray();
-    expect($data['content'][0]['text'])->toContain('"key": "nested.config.key"');
-    expect($data['content'][0]['text'])->toContain('"value": "nested_value"');
+    expect($result)->isToolResult()
+        ->toolHasNoError()
+        ->toolTextContains('"key": "nested.config.key"', '"value": "nested_value"');
 });
 
 test('it returns error when config key does not exist', function () {
     $tool = new GetConfig;
     $result = $tool->handle(['key' => 'nonexistent.key']);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
-
-    $data = $result->toArray();
-    expect($data['isError'])->toBe(true);
-    expect($data['content'][0]['text'])->toContain("Config key 'nonexistent.key' not found.");
+    expect($result)->isToolResult()
+        ->toolHasError()
+        ->toolTextContains("Config key 'nonexistent.key' not found.");
 });
 
 test('it works with built-in Laravel config keys', function () {
     $tool = new GetConfig;
     $result = $tool->handle(['key' => 'app.name']);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
-
-    $data = $result->toArray();
-    expect($data['content'][0]['text'])->toContain('"key": "app.name"');
-    expect($data['content'][0]['text'])->toContain('"value": "Test App"');
+    expect($result)->isToolResult()
+        ->toolHasNoError()
+        ->toolTextContains('"key": "app.name"', '"value": "Test App"');
 });

--- a/tests/Feature/Mcp/Tools/ListArtisanCommandsTest.php
+++ b/tests/Feature/Mcp/Tools/ListArtisanCommandsTest.php
@@ -3,36 +3,34 @@
 declare(strict_types=1);
 
 use Laravel\Boost\Mcp\Tools\ListArtisanCommands;
-use Laravel\Mcp\Server\Tools\ToolResult;
 
 test('it returns list of artisan commands', function () {
     $tool = new ListArtisanCommands;
     $result = $tool->handle([]);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
-    $data = $result->toArray();
-    expect($data['isError'])->toBe(false);
+    expect($result)->isToolResult()
+        ->toolHasNoError()
+        ->toolJsonContent(function ($content) {
+            expect($content)->toBeArray()
+                ->and($content)->not->toBeEmpty();
 
-    $content = json_decode($data['content'][0]['text'], true);
-    expect($content)->toBeArray();
-    expect($content)->not->toBeEmpty();
+            // Check that it contains some basic Laravel commands
+            $commandNames = array_column($content, 'name');
+            expect($commandNames)->toContain('migrate')
+                ->and($commandNames)->toContain('make:model')
+                ->and($commandNames)->toContain('route:list');
 
-    // Check that it contains some basic Laravel commands
-    $commandNames = array_column($content, 'name');
-    expect($commandNames)->toContain('migrate');
-    expect($commandNames)->toContain('make:model');
-    expect($commandNames)->toContain('route:list');
+            // Check the structure of each command
+            foreach ($content as $command) {
+                expect($command)->toHaveKey('name')
+                    ->and($command)->toHaveKey('description')
+                    ->and($command['name'])->toBeString()
+                    ->and($command['description'])->toBeString();
+            }
 
-    // Check the structure of each command
-    foreach ($content as $command) {
-        expect($command)->toHaveKey('name');
-        expect($command)->toHaveKey('description');
-        expect($command['name'])->toBeString();
-        expect($command['description'])->toBeString();
-    }
-
-    // Check that commands are sorted alphabetically
-    $sortedNames = $commandNames;
-    sort($sortedNames);
-    expect($commandNames)->toBe($sortedNames);
+            // Check that commands are sorted alphabetically
+            $sortedNames = $commandNames;
+            sort($sortedNames);
+            expect($commandNames)->toBe($sortedNames);
+        });
 });

--- a/tests/Feature/Mcp/Tools/ListAvailableConfigKeysTest.php
+++ b/tests/Feature/Mcp/Tools/ListAvailableConfigKeysTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Laravel\Boost\Mcp\Tools\ListAvailableConfigKeys;
-use Laravel\Mcp\Server\Tools\ToolResult;
 
 beforeEach(function () {
     config()->set('test.simple', 'value');
@@ -15,29 +14,26 @@ test('it returns list of config keys in dot notation', function () {
     $tool = new ListAvailableConfigKeys;
     $result = $tool->handle([]);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
-    $data = $result->toArray();
-    expect($data['isError'])->toBe(false);
+    expect($result)->isToolResult()
+        ->toolHasNoError()
+        ->toolJsonContent(function ($content) {
+            expect($content)->toBeArray()
+                ->and($content)->not->toBeEmpty()
+                // Check that it contains common Laravel config keys
+                ->and($content)->toContain('app.name')
+                ->and($content)->toContain('app.env')
+                ->and($content)->toContain('database.default')
+                // Check that it contains our test keys
+                ->and($content)->toContain('test.simple')
+                ->and($content)->toContain('test.nested.key')
+                ->and($content)->toContain('test.array.0')
+                ->and($content)->toContain('test.array.1');
 
-    $content = json_decode($data['content'][0]['text'], true);
-    expect($content)->toBeArray();
-    expect($content)->not->toBeEmpty();
-
-    // Check that it contains common Laravel config keys
-    expect($content)->toContain('app.name');
-    expect($content)->toContain('app.env');
-    expect($content)->toContain('database.default');
-
-    // Check that it contains our test keys
-    expect($content)->toContain('test.simple');
-    expect($content)->toContain('test.nested.key');
-    expect($content)->toContain('test.array.0');
-    expect($content)->toContain('test.array.1');
-
-    // Check that keys are sorted
-    $sortedContent = $content;
-    sort($sortedContent);
-    expect($content)->toBe($sortedContent);
+            // Check that keys are sorted
+            $sortedContent = $content;
+            sort($sortedContent);
+            expect($content)->toBe($sortedContent);
+        });
 });
 
 test('it handles empty config gracefully', function () {
@@ -47,12 +43,11 @@ test('it handles empty config gracefully', function () {
     $tool = new ListAvailableConfigKeys;
     $result = $tool->handle([]);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
-    $data = $result->toArray();
-    expect($data['isError'])->toBe(false);
-
-    $content = json_decode($data['content'][0]['text'], true);
-    expect($content)->toBeArray();
-    // Should still have Laravel default config keys
-    expect($content)->toContain('app.name');
+    expect($result)->isToolResult()
+        ->toolHasNoError()
+        ->toolJsonContent(function ($content) {
+            expect($content)->toBeArray()
+                // Should still have Laravel default config keys
+                ->and($content)->toContain('app.name');
+        });
 });

--- a/tests/Feature/Mcp/Tools/TinkerTest.php
+++ b/tests/Feature/Mcp/Tools/TinkerTest.php
@@ -3,111 +3,99 @@
 declare(strict_types=1);
 
 use Laravel\Boost\Mcp\Tools\Tinker;
-use Laravel\Mcp\Server\Tools\ToolResult;
-
-function getToolResultData(ToolResult $result): array
-{
-    $data = $result->toArray();
-
-    return json_decode($data['content'][0]['text'], true);
-}
 
 test('executes simple php code', function () {
     $tool = new Tinker;
     $result = $tool->handle(['code' => 'return 2 + 2;']);
 
-    expect($result)->isToolResult();
-
-    $data = getToolResultData($result);
-    expect($data['result'])->toBe(4)
-        ->and($data['type'])->toBe('integer');
+    expect($result)->isToolResult()
+        ->toolJsonContent(function ($data) {
+            expect($data['result'])->toBe(4)
+                ->and($data['type'])->toBe('integer');
+        });
 });
 
 test('executes code with output', function () {
     $tool = new Tinker;
     $result = $tool->handle(['code' => 'echo "Hello World"; return "test";']);
 
-    expect($result)->isToolResult();
-
-    $data = getToolResultData($result);
-    expect($data['result'])->toBe('test')
-        ->and($data['output'])->toBe('Hello World')
-        ->and($data['type'])->toBe('string');
+    expect($result)->isToolResult()
+        ->toolJsonContent(function ($data) {
+            expect($data['result'])->toBe('test')
+                ->and($data['output'])->toBe('Hello World')
+                ->and($data['type'])->toBe('string');
+        });
 });
 
 test('accesses laravel facades', function () {
     $tool = new Tinker;
     $result = $tool->handle(['code' => 'return config("app.name");']);
 
-    expect($result)->isToolResult();
-
-    $data = getToolResultData($result);
-    expect($data['result'])->toBeString()
-        ->and($data['result'])->toBe(config('app.name'))
-        ->and($data['type'])->toBe('string');
+    expect($result)->isToolResult()
+        ->toolJsonContent(function ($data) {
+            expect($data['result'])->toBeString()
+                ->and($data['result'])->toBe(config('app.name'))
+                ->and($data['type'])->toBe('string');
+        });
 });
 
 test('creates objects', function () {
     $tool = new Tinker;
     $result = $tool->handle(['code' => 'return new stdClass();']);
 
-    expect($result)->isToolResult();
-
-    $data = getToolResultData($result);
-    expect($data['type'])->toBe('object')
-        ->and($data['class'])->toBe('stdClass');
+    expect($result)->isToolResult()
+        ->toolJsonContent(function ($data) {
+            expect($data['type'])->toBe('object')
+                ->and($data['class'])->toBe('stdClass');
+        });
 });
 
 test('handles syntax errors', function () {
     $tool = new Tinker;
     $result = $tool->handle(['code' => 'invalid syntax here']);
 
-    expect($result)->isToolResult();
-
-    $resultArray = $result->toArray();
-    expect($resultArray['isError'])->toBeFalse();
-
-    $data = getToolResultData($result);
-    expect($data)->toHaveKey('error')
-        ->and($data)->toHaveKey('type')
-        ->and($data['type'])->toBe('ParseError');
+    expect($result)->isToolResult()
+        ->toolHasNoError()
+        ->toolJsonContent(function ($data) {
+            expect($data)->toHaveKey('error')
+                ->and($data)->toHaveKey('type')
+                ->and($data['type'])->toBe('ParseError');
+        });
 });
 
 test('handles runtime errors', function () {
     $tool = new Tinker;
     $result = $tool->handle(['code' => 'throw new Exception("Test error");']);
 
-    expect($result)->isToolResult();
-
-    $resultArray = $result->toArray();
-    expect($resultArray['isError'])->toBeFalse();
-
-    $data = getToolResultData($result);
-    expect($data)->toHaveKey('error')
-        ->and($data['type'])->toBe('Exception')
-        ->and($data['error'])->toBe('Test error');
+    expect($result)->isToolResult()
+        ->toolHasNoError()
+        ->toolJsonContent(function ($data) {
+            expect($data)->toHaveKey('error')
+                ->and($data['type'])->toBe('Exception')
+                ->and($data['error'])->toBe('Test error');
+        });
 });
 
 test('captures multiple outputs', function () {
     $tool = new Tinker;
     $result = $tool->handle(['code' => 'echo "First"; echo "Second"; return "done";']);
 
-    expect($result)->isToolResult();
-
-    $data = getToolResultData($result);
-    expect($data['result'])->toBe('done')
-        ->and($data['output'])->toBe('FirstSecond');
+    expect($result)->isToolResult()
+        ->toolJsonContent(function ($data) {
+            expect($data['result'])->toBe('done')
+                ->and($data['output'])->toBe('FirstSecond');
+        });
 });
 
 test('executes code with different return types', function (string $code, mixed $expectedResult, string $expectedType) {
     $tool = new Tinker;
     $result = $tool->handle(['code' => $code]);
 
-    expect($result)->isToolResult();
-
-    $data = getToolResultData($result);
-    expect($data['result'])->toBe($expectedResult)
-        ->and($data['type'])->toBe($expectedType);
+    expect($result)->isToolResult()
+        ->toolJsonContent(function ($data) use ($expectedResult, $expectedType) {
+            expect($data['result'])->toBe($expectedResult)
+                ->and($data['type'])->toBe($expectedType);
+        });
 })->with([
     'integer' => ['return 42;', 42, 'integer'],
     'string' => ['return "hello";', 'hello', 'string'],
@@ -122,22 +110,22 @@ test('handles empty code', function () {
     $tool = new Tinker;
     $result = $tool->handle(['code' => '']);
 
-    expect($result)->isToolResult();
-
-    $data = getToolResultData($result);
-    expect($data['result'])->toBeFalse()
-        ->and($data['type'])->toBe('boolean');
+    expect($result)->isToolResult()
+        ->toolJsonContent(function ($data) {
+            expect($data['result'])->toBeFalse()
+                ->and($data['type'])->toBe('boolean');
+        });
 });
 
 test('handles code with no return statement', function () {
     $tool = new Tinker;
     $result = $tool->handle(['code' => '$x = 5;']);
 
-    expect($result)->isToolResult();
-
-    $data = getToolResultData($result);
-    expect($data['result'])->toBeNull()
-        ->and($data['type'])->toBe('NULL');
+    expect($result)->isToolResult()
+        ->toolJsonContent(function ($data) {
+            expect($data['result'])->toBeNull()
+                ->and($data['type'])->toBe('NULL');
+        });
 });
 
 test('should register only in local environment', function () {
@@ -155,22 +143,22 @@ test('uses custom timeout parameter', function () {
     $tool = new Tinker;
     $result = $tool->handle(['code' => 'return 2 + 2;', 'timeout' => 10]);
 
-    expect($result)->isToolResult();
-
-    $data = getToolResultData($result);
-    expect($data['result'])->toBe(4)
-        ->and($data['type'])->toBe('integer');
+    expect($result)->isToolResult()
+        ->toolJsonContent(function ($data) {
+            expect($data['result'])->toBe(4)
+                ->and($data['type'])->toBe('integer');
+        });
 });
 
 test('uses default timeout when not specified', function () {
     $tool = new Tinker;
     $result = $tool->handle(['code' => 'return 2 + 2;']);
 
-    expect($result)->isToolResult();
-
-    $data = getToolResultData($result);
-    expect($data['result'])->toBe(4)
-        ->and($data['type'])->toBe('integer');
+    expect($result)->isToolResult()
+        ->toolJsonContent(function ($data) {
+            expect($data['result'])->toBe(4)
+                ->and($data['type'])->toBe('integer');
+        });
 });
 
 test('times out when code takes too long', function () {
@@ -187,9 +175,9 @@ test('times out when code takes too long', function () {
 
     $result = $tool->handle(['code' => $slowCode, 'timeout' => 1]);
 
-    expect($result)->isToolResult();
-
-    $data = getToolResultData($result);
-    expect($data)->toHaveKey('error')
-        ->and($data['error'])->toMatch('/(Maximum execution time|Code execution timed out)/');
+    expect($result)->isToolResult()
+        ->toolJsonContent(function ($data) {
+            expect($data)->toHaveKey('error')
+                ->and($data['error'])->toMatch('/(Maximum execution time|Code execution timed out)/');
+        });
 });

--- a/tests/Feature/Mcp/Tools/TinkerTest.php
+++ b/tests/Feature/Mcp/Tools/TinkerTest.php
@@ -9,10 +9,10 @@ test('executes simple php code', function () {
     $result = $tool->handle(['code' => 'return 2 + 2;']);
 
     expect($result)->isToolResult()
-        ->toolJsonContent(function ($data) {
-            expect($data['result'])->toBe(4)
-                ->and($data['type'])->toBe('integer');
-        });
+        ->toolJsonContentToMatchArray([
+            'result' => 4,
+            'type' => 'integer',
+        ]);
 });
 
 test('executes code with output', function () {
@@ -20,11 +20,11 @@ test('executes code with output', function () {
     $result = $tool->handle(['code' => 'echo "Hello World"; return "test";']);
 
     expect($result)->isToolResult()
-        ->toolJsonContent(function ($data) {
-            expect($data['result'])->toBe('test')
-                ->and($data['output'])->toBe('Hello World')
-                ->and($data['type'])->toBe('string');
-        });
+        ->toolJsonContentToMatchArray([
+            'result' => 'test',
+            'output' => 'Hello World',
+            'type' => 'string',
+        ]);
 });
 
 test('accesses laravel facades', function () {
@@ -32,11 +32,10 @@ test('accesses laravel facades', function () {
     $result = $tool->handle(['code' => 'return config("app.name");']);
 
     expect($result)->isToolResult()
-        ->toolJsonContent(function ($data) {
-            expect($data['result'])->toBeString()
-                ->and($data['result'])->toBe(config('app.name'))
-                ->and($data['type'])->toBe('string');
-        });
+        ->toolJsonContentToMatchArray([
+            'result' => config('app.name'),
+            'type' => 'string',
+        ]);
 });
 
 test('creates objects', function () {
@@ -44,10 +43,10 @@ test('creates objects', function () {
     $result = $tool->handle(['code' => 'return new stdClass();']);
 
     expect($result)->isToolResult()
-        ->toolJsonContent(function ($data) {
-            expect($data['type'])->toBe('object')
-                ->and($data['class'])->toBe('stdClass');
-        });
+        ->toolJsonContentToMatchArray([
+            'type' => 'object',
+            'class' => 'stdClass',
+        ]);
 });
 
 test('handles syntax errors', function () {
@@ -56,10 +55,11 @@ test('handles syntax errors', function () {
 
     expect($result)->isToolResult()
         ->toolHasNoError()
+        ->toolJsonContentToMatchArray([
+            'type' => 'ParseError',
+        ])
         ->toolJsonContent(function ($data) {
-            expect($data)->toHaveKey('error')
-                ->and($data)->toHaveKey('type')
-                ->and($data['type'])->toBe('ParseError');
+            expect($data)->toHaveKey('error');
         });
 });
 
@@ -69,10 +69,12 @@ test('handles runtime errors', function () {
 
     expect($result)->isToolResult()
         ->toolHasNoError()
+        ->toolJsonContentToMatchArray([
+            'type' => 'Exception',
+            'error' => 'Test error',
+        ])
         ->toolJsonContent(function ($data) {
-            expect($data)->toHaveKey('error')
-                ->and($data['type'])->toBe('Exception')
-                ->and($data['error'])->toBe('Test error');
+            expect($data)->toHaveKey('error');
         });
 });
 
@@ -81,10 +83,10 @@ test('captures multiple outputs', function () {
     $result = $tool->handle(['code' => 'echo "First"; echo "Second"; return "done";']);
 
     expect($result)->isToolResult()
-        ->toolJsonContent(function ($data) {
-            expect($data['result'])->toBe('done')
-                ->and($data['output'])->toBe('FirstSecond');
-        });
+        ->toolJsonContentToMatchArray([
+            'result' => 'done',
+            'output' => 'FirstSecond',
+        ]);
 });
 
 test('executes code with different return types', function (string $code, mixed $expectedResult, string $expectedType) {
@@ -92,10 +94,10 @@ test('executes code with different return types', function (string $code, mixed 
     $result = $tool->handle(['code' => $code]);
 
     expect($result)->isToolResult()
-        ->toolJsonContent(function ($data) use ($expectedResult, $expectedType) {
-            expect($data['result'])->toBe($expectedResult)
-                ->and($data['type'])->toBe($expectedType);
-        });
+        ->toolJsonContentToMatchArray([
+            'result' => $expectedResult,
+            'type' => $expectedType,
+        ]);
 })->with([
     'integer' => ['return 42;', 42, 'integer'],
     'string' => ['return "hello";', 'hello', 'string'],
@@ -111,10 +113,10 @@ test('handles empty code', function () {
     $result = $tool->handle(['code' => '']);
 
     expect($result)->isToolResult()
-        ->toolJsonContent(function ($data) {
-            expect($data['result'])->toBeFalse()
-                ->and($data['type'])->toBe('boolean');
-        });
+        ->toolJsonContentToMatchArray([
+            'result' => false,
+            'type' => 'boolean',
+        ]);
 });
 
 test('handles code with no return statement', function () {
@@ -122,10 +124,10 @@ test('handles code with no return statement', function () {
     $result = $tool->handle(['code' => '$x = 5;']);
 
     expect($result)->isToolResult()
-        ->toolJsonContent(function ($data) {
-            expect($data['result'])->toBeNull()
-                ->and($data['type'])->toBe('NULL');
-        });
+        ->toolJsonContentToMatchArray([
+            'result' => null,
+            'type' => 'NULL',
+        ]);
 });
 
 test('should register only in local environment', function () {
@@ -144,10 +146,10 @@ test('uses custom timeout parameter', function () {
     $result = $tool->handle(['code' => 'return 2 + 2;', 'timeout' => 10]);
 
     expect($result)->isToolResult()
-        ->toolJsonContent(function ($data) {
-            expect($data['result'])->toBe(4)
-                ->and($data['type'])->toBe('integer');
-        });
+        ->toolJsonContentToMatchArray([
+            'result' => 4,
+            'type' => 'integer',
+        ]);
 });
 
 test('uses default timeout when not specified', function () {
@@ -155,10 +157,10 @@ test('uses default timeout when not specified', function () {
     $result = $tool->handle(['code' => 'return 2 + 2;']);
 
     expect($result)->isToolResult()
-        ->toolJsonContent(function ($data) {
-            expect($data['result'])->toBe(4)
-                ->and($data['type'])->toBe('integer');
-        });
+        ->toolJsonContentToMatchArray([
+            'result' => 4,
+            'type' => 'integer',
+        ]);
 });
 
 test('times out when code takes too long', function () {

--- a/tests/Feature/Mcp/Tools/TinkerTest.php
+++ b/tests/Feature/Mcp/Tools/TinkerTest.php
@@ -16,7 +16,7 @@ test('executes simple php code', function () {
     $tool = new Tinker;
     $result = $tool->handle(['code' => 'return 2 + 2;']);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
+    expect($result)->isToolResult();
 
     $data = getToolResultData($result);
     expect($data['result'])->toBe(4)
@@ -27,7 +27,7 @@ test('executes code with output', function () {
     $tool = new Tinker;
     $result = $tool->handle(['code' => 'echo "Hello World"; return "test";']);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
+    expect($result)->isToolResult();
 
     $data = getToolResultData($result);
     expect($data['result'])->toBe('test')
@@ -39,7 +39,7 @@ test('accesses laravel facades', function () {
     $tool = new Tinker;
     $result = $tool->handle(['code' => 'return config("app.name");']);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
+    expect($result)->isToolResult();
 
     $data = getToolResultData($result);
     expect($data['result'])->toBeString()
@@ -51,7 +51,7 @@ test('creates objects', function () {
     $tool = new Tinker;
     $result = $tool->handle(['code' => 'return new stdClass();']);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
+    expect($result)->isToolResult();
 
     $data = getToolResultData($result);
     expect($data['type'])->toBe('object')
@@ -62,7 +62,7 @@ test('handles syntax errors', function () {
     $tool = new Tinker;
     $result = $tool->handle(['code' => 'invalid syntax here']);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
+    expect($result)->isToolResult();
 
     $resultArray = $result->toArray();
     expect($resultArray['isError'])->toBeFalse();
@@ -77,7 +77,7 @@ test('handles runtime errors', function () {
     $tool = new Tinker;
     $result = $tool->handle(['code' => 'throw new Exception("Test error");']);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
+    expect($result)->isToolResult();
 
     $resultArray = $result->toArray();
     expect($resultArray['isError'])->toBeFalse();
@@ -92,7 +92,7 @@ test('captures multiple outputs', function () {
     $tool = new Tinker;
     $result = $tool->handle(['code' => 'echo "First"; echo "Second"; return "done";']);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
+    expect($result)->isToolResult();
 
     $data = getToolResultData($result);
     expect($data['result'])->toBe('done')
@@ -103,7 +103,7 @@ test('executes code with different return types', function (string $code, mixed 
     $tool = new Tinker;
     $result = $tool->handle(['code' => $code]);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
+    expect($result)->isToolResult();
 
     $data = getToolResultData($result);
     expect($data['result'])->toBe($expectedResult)
@@ -122,7 +122,7 @@ test('handles empty code', function () {
     $tool = new Tinker;
     $result = $tool->handle(['code' => '']);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
+    expect($result)->isToolResult();
 
     $data = getToolResultData($result);
     expect($data['result'])->toBeFalse()
@@ -133,7 +133,7 @@ test('handles code with no return statement', function () {
     $tool = new Tinker;
     $result = $tool->handle(['code' => '$x = 5;']);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
+    expect($result)->isToolResult();
 
     $data = getToolResultData($result);
     expect($data['result'])->toBeNull()
@@ -155,7 +155,7 @@ test('uses custom timeout parameter', function () {
     $tool = new Tinker;
     $result = $tool->handle(['code' => 'return 2 + 2;', 'timeout' => 10]);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
+    expect($result)->isToolResult();
 
     $data = getToolResultData($result);
     expect($data['result'])->toBe(4)
@@ -166,7 +166,7 @@ test('uses default timeout when not specified', function () {
     $tool = new Tinker;
     $result = $tool->handle(['code' => 'return 2 + 2;']);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
+    expect($result)->isToolResult();
 
     $data = getToolResultData($result);
     expect($data['result'])->toBe(4)
@@ -187,7 +187,7 @@ test('times out when code takes too long', function () {
 
     $result = $tool->handle(['code' => $slowCode, 'timeout' => 1]);
 
-    expect($result)->toBeInstanceOf(ToolResult::class);
+    expect($result)->isToolResult();
 
     $data = getToolResultData($result);
     expect($data)->toHaveKey('error')

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -13,16 +13,28 @@ declare(strict_types=1);
 |
 */
 
+use Laravel\Mcp\Server\Tools\ToolResult;
+
 uses(Tests\TestCase::class)->in('Feature');
 
 expect()->extend('isToolResult', function () {
-    return $this->toBeInstanceOf(\Laravel\Mcp\Server\Tools\ToolResult::class);
+    return $this->toBeInstanceOf(ToolResult::class);
 });
 
 expect()->extend('toolTextContains', function (mixed ...$needles) {
-    /** @var \Laravel\Mcp\Server\Tools\ToolResult $this->value */
+    /** @var ToolResult $this->value */
     $output = implode('', array_column($this->value->toArray()['content'], 'text'));
     expect($output)->toContain(...func_get_args());
+
+    return $this;
+});
+
+expect()->extend('toolTextDoesNotContain', function (mixed ...$needles) {
+    /** @var ToolResult $this->value */
+    $output = implode('', array_column($this->value->toArray()['content'], 'text'));
+    foreach ($needles as $needle) {
+        expect($output)->not->toContain($needle);
+    }
 
     return $this;
 });
@@ -35,6 +47,15 @@ expect()->extend('toolHasError', function () {
 
 expect()->extend('toolHasNoError', function () {
     expect($this->value->toArray()['isError'])->toBeFalse();
+
+    return $this;
+});
+
+expect()->extend('toolJsonContent', function (callable $callback) {
+    /** @var ToolResult $this->value */
+    $data = $this->value->toArray();
+    $content = json_decode($data['content'][0]['text'], true);
+    $callback($content);
 
     return $this;
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -32,9 +32,7 @@ expect()->extend('toolTextContains', function (mixed ...$needles) {
 expect()->extend('toolTextDoesNotContain', function (mixed ...$needles) {
     /** @var ToolResult $this->value */
     $output = implode('', array_column($this->value->toArray()['content'], 'text'));
-    foreach ($needles as $needle) {
-        expect($output)->not->toContain($needle);
-    }
+    expect($output)->not->toContain(...func_get_args());
 
     return $this;
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -58,6 +58,15 @@ expect()->extend('toolJsonContent', function (callable $callback) {
     return $this;
 });
 
+expect()->extend('toolJsonContentToMatchArray', function (array $expectedArray) {
+    /** @var ToolResult $this->value */
+    $data = $this->value->toArray();
+    $content = json_decode($data['content'][0]['text'], true);
+    expect($content)->toMatchArray($expectedArray);
+
+    return $this;
+});
+
 function fixture(string $name): string
 {
     return file_get_contents(\Pest\testDirectory('fixtures/'.$name));


### PR DESCRIPTION
This MR refactored all test files in `/tests/Feature/Mcp/Tools/` to use custom Pest expectations instead of repetitive assertion patterns.