### PR TITLE
Add strict types declaration in Inertia.php

### DIFF
--- a/src/Install/Assists/Inertia.php
+++ b/src/Install/Assists/Inertia.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Laravel\Boost\Install\Assists;
 
 use Laravel\Roster\Enums\Packages;


### PR DESCRIPTION
The declare(strict_types=1); has been added to the inertia.php file to satisfy the architecture test regarding the use of strict types.
