### PR TITLE
Add Codex Guideline Support

### DIFF
--- a/src/Install/CodeEnvironment/Codex.php
+++ b/src/Install/CodeEnvironment/Codex.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install\CodeEnvironment;
+
+use Laravel\Boost\Contracts\Agent;
+use Laravel\Boost\Install\Enums\Platform;
+
+class Codex extends CodeEnvironment implements Agent
+{
+    public function name(): string
+    {
+        return 'codex';
+    }
+
+    public function displayName(): string
+    {
+        return 'Codex';
+    }
+
+    public function systemDetectionConfig(Platform $platform): array
+    {
+        return match ($platform) {
+            Platform::Darwin, Platform::Linux => [
+                'command' => 'which codex',
+            ],
+            Platform::Windows => [
+                'command' => 'where codex 2>nul',
+            ],
+        };
+    }
+
+    public function projectDetectionConfig(): array
+    {
+        return [
+            'paths' => ['.codex'],
+            'files' => ['AGENTS.md'],
+        ];
+    }
+
+    public function guidelinesPath(): string
+    {
+        return 'AGENTS.md';
+    }
+}

--- a/src/Install/CodeEnvironmentsDetector.php
+++ b/src/Install/CodeEnvironmentsDetector.php
@@ -8,6 +8,7 @@ use Illuminate\Container\Container;
 use Illuminate\Support\Collection;
 use Laravel\Boost\Install\CodeEnvironment\ClaudeCode;
 use Laravel\Boost\Install\CodeEnvironment\CodeEnvironment;
+use Laravel\Boost\Install\CodeEnvironment\Codex;
 use Laravel\Boost\Install\CodeEnvironment\Copilot;
 use Laravel\Boost\Install\CodeEnvironment\Cursor;
 use Laravel\Boost\Install\CodeEnvironment\PhpStorm;
@@ -22,6 +23,7 @@ class CodeEnvironmentsDetector
         'vscode' => VSCode::class,
         'cursor' => Cursor::class,
         'claudecode' => ClaudeCode::class,
+        'codex' => Codex::class,
         'copilot' => Copilot::class,
     ];
 

--- a/tests/Unit/Install/CodeEnvironmentsDetectorTest.php
+++ b/tests/Unit/Install/CodeEnvironmentsDetectorTest.php
@@ -40,6 +40,7 @@ test('discoverSystemInstalledCodeEnvironments returns detected programs', functi
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\VSCode::class, fn () => $program2);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Cursor::class, fn () => $program3);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\ClaudeCode::class, fn () => $otherProgram);
+    $container->bind(\Laravel\Boost\Install\CodeEnvironment\Codex::class, fn () => $otherProgram);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Copilot::class, fn () => $otherProgram);
 
     $detector = new CodeEnvironmentsDetector($container);
@@ -64,6 +65,7 @@ test('discoverSystemInstalledCodeEnvironments returns empty array when no progra
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\VSCode::class, fn () => $otherProgram);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Cursor::class, fn () => $otherProgram);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\ClaudeCode::class, fn () => $otherProgram);
+    $container->bind(\Laravel\Boost\Install\CodeEnvironment\Codex::class, fn () => $otherProgram);
     $container->bind(\Laravel\Boost\Install\CodeEnvironment\Copilot::class, fn () => $otherProgram);
 
     $detector = new CodeEnvironmentsDetector($container);
@@ -139,7 +141,6 @@ test('discoverProjectInstalledCodeEnvironments detects applications with mixed t
 
     expect($detected)->toContain('claudecode');
 
-    // Cleanup
     unlink($tempDir.'/CLAUDE.md');
     rmdir($tempDir);
 });
@@ -169,7 +170,6 @@ test('discoverProjectInstalledCodeEnvironments detects claude code with director
 
     expect($detected)->toContain('claudecode');
 
-    // Cleanup
     rmdir($tempDir.'/.claude');
     rmdir($tempDir);
 });
@@ -213,6 +213,32 @@ test('discoverProjectInstalledCodeEnvironments detects cursor with cursor direct
 
     // Cleanup
     rmdir($tempDir.'/.cursor');
+    rmdir($tempDir);
+});
+
+test('discoverProjectInstalledCodeEnvironments detects codex with codex directory', function () {
+    $tempDir = sys_get_temp_dir().'/boost_test_'.uniqid();
+    mkdir($tempDir);
+    mkdir($tempDir.'/.codex');
+
+    $detected = $this->detector->discoverProjectInstalledCodeEnvironments($tempDir);
+
+    expect($detected)->toContain('codex');
+
+    rmdir($tempDir.'/.codex');
+    rmdir($tempDir);
+});
+
+test('discoverProjectInstalledCodeEnvironments detects codex with AGENTS.md file', function () {
+    $tempDir = sys_get_temp_dir().'/boost_test_'.uniqid();
+    mkdir($tempDir);
+    file_put_contents($tempDir.'/AGENTS.md', 'test');
+
+    $detected = $this->detector->discoverProjectInstalledCodeEnvironments($tempDir);
+
+    expect($detected)->toContain('codex');
+
+    unlink($tempDir.'/AGENTS.md');
     rmdir($tempDir);
 });
 


### PR DESCRIPTION
This MR adds support for the Codex CLI for guidelines only.
An additional benefit is that it also supports [AGENTS.md](https://agents.md/), enabling guideline usage in other IDEs too.

https://github.com/openai/codex/