### PR TITLE
fix: remove stray parenthesis in lifecycle hook guidance in livewire guidelines

### DIFF
--- a/.ai/livewire/core.blade.php
+++ b/.ai/livewire/core.blade.php
@@ -17,7 +17,7 @@
     @endforeach
     ```
 @endverbatim
-- Prefer lifecycle hooks like `mount()`, `updatedFoo()`) for initialization and reactive side effects:
+- Prefer lifecycle hooks like `mount()`, `updatedFoo()` for initialization and reactive side effects:
 @verbatim
 <code-snippet name="Lifecycle hook examples" lang="php">
     public function mount(User $user) { $this->user = $user; }


### PR DESCRIPTION
Correct grammatical error by removing a stray closing parenthesis from the Livewire guidance on using lifecycle hooks