### PR TITLE
Update scroll value for Agent selection configuration

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -306,7 +306,7 @@ class InstallCommand extends Command
     private function getSelectionConfig(string $contractClass): array
     {
         return match ($contractClass) {
-            Agent::class => ['scroll' => 4, 'required' => false, 'displayMethod' => 'agentName'],
+            Agent::class => ['scroll' => 5, 'required' => false, 'displayMethod' => 'agentName'],
             McpClient::class => ['scroll' => 5, 'required' => true, 'displayMethod' => 'displayName'],
             default => throw new InvalidArgumentException("Unsupported contract class: {$contractClass}"),
         };


### PR DESCRIPTION
This MR sets the maximum scroll value to 5, ensuring all agents are displayed in a single, non-scrollable view.

Before
<img width="1494" height="912" alt="Screenshot 2025-09-18 at 1 45 56 AM" src="https://github.com/user-attachments/assets/ccef3ad6-56bd-45dc-adc3-21714357c320" />


After
<img width="1494" height="912" alt="Screenshot 2025-09-18 at 1 59 40 AM" src="https://github.com/user-attachments/assets/52531ba4-0d92-479f-9a50-2492e5288f24" />
