### PR TITLE
fix: add csp nonce to browser logger

### DIFF
--- a/src/Services/BrowserLogger.php
+++ b/src/Services/BrowserLogger.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laravel\Boost\Services;
 
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Vite;
 
 class BrowserLogger
 {
@@ -14,8 +15,10 @@ class BrowserLogger
             ? route('boost.browser-logs')
             : '/_boost/browser-logs';
 
+        $nonce = Vite::cspNonce();
+
         return <<<HTML
-<script id="browser-logger-active">
+<script id="browser-logger-active" nonce="{$nonce}">
 (function() {
     const ENDPOINT = '{$endpoint}';
     const logQueue = [];


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Boost injects inline Javascript, but this may not work in environments with a CSP-policy. This PR adds the Vite nonce to the injected script tag to make sure it works in CSP-enabled environments (of course, when the CSP-policy allows nonces for scripts).