### PR TITLE
docs: guidelines: initial laravel/mcp guidelines

### DIFF
--- a/.ai/mcp/core.blade.php
+++ b/.ai/mcp/core.blade.php
@@ -3,3 +3,4 @@
 - MCP servers need to be registered with a route or handle in `routes/ai.php`. Typically you should start with `Mcp::web()` to register a HTTP streaming MCP server.
 - Servers are very testable - use the `search-docs` tool to find testing instructions.
 - Do not run `mcp:start`. This command hangs waiting for JSON RPC MCP requests.
+- Some MCP clients use node which has its own certificate store. If a user tries to connect to their web MCP server locally on https:// it could fail due to this reason and they'll need to switch to http:// during development only.

--- a/.ai/mcp/core.blade.php
+++ b/.ai/mcp/core.blade.php
@@ -1,6 +1,7 @@
 ## Laravel MCP
-- MCP, Model Context Protocol, is very new. You must use the `search-docs` tool to get documentation for how to write and test Laravel MCP servers, tools, resources, and prompts effectively.
-- MCP servers need to be registered with a route or handle in `routes/ai.php`. Typically you should start with `Mcp::web()` to register a HTTP streaming MCP server.
+
+- MCP (Model Context Protocol) is very new. You must use the `search-docs` tool to get documentation for how to write and test Laravel MCP servers, tools, resources, and prompts effectively.
+- MCP servers need to be registered with a route or handle in `routes/ai.php`. Typically, they will be registered using `Mcp::web()` to register a HTTP streaming MCP server.
 - Servers are very testable - use the `search-docs` tool to find testing instructions.
 - Do not run `mcp:start`. This command hangs waiting for JSON RPC MCP requests.
-- Some MCP clients use node which has its own certificate store. If a user tries to connect to their web MCP server locally on https:// it could fail due to this reason and they'll need to switch to http:// during development only.
+- Some MCP clients use Node, which has its own certificate store. If a user tries to connect to their web MCP server locally using https://, it could fail due to this reason. They will need to switch to http:// during local development.

--- a/.ai/mcp/core.blade.php
+++ b/.ai/mcp/core.blade.php
@@ -1,0 +1,5 @@
+## Laravel MCP
+- MCP, Model Context Protocol, is very new. You must use the `search-docs` tool to get documentation for how to write and test Laravel MCP servers, tools, resources, and prompts effectively.
+- MCP servers need to be registered with a route or handle in `routes/ai.php`. Typically you should start with `Mcp::web()` to register a HTTP streaming MCP server.
+- Servers are very testable - use the `search-docs` tool to find testing instructions.
+- Do not run `mcp:start`. This command hangs waiting for JSON RPC MCP requests.


### PR DESCRIPTION
# What & Why
Adds initial guidelines for `laravel/mcp`.

They don't need to be super detailed because the documentation is so good.

# How I tested
  1. Added an MCP server to an existing Livewire/Flux project with Claude Code
  2. Added tools, resources, prompts - asked it to add tests
  3. Asked it "how do i add auth to my mcp server"? -> searched docs, gave me info I needed


# Demo
<img width="4040" height="2332" alt="CleanShot 2025-09-18 at 16 18 20@2x" src="https://github.com/user-attachments/assets/545eea06-fb07-43c9-8268-2406f687cd51" />
