### PR TITLE
Fix boolean parameter handling in ListRoutes MCP tool

### DIFF
--- a/src/Mcp/Tools/ListRoutes.php
+++ b/src/Mcp/Tools/ListRoutes.php
@@ -64,9 +64,15 @@ class ListRoutes extends Tool
         foreach ($optionMap as $argKey => $cliOption) {
             $value = $request->get($argKey);
             if (! empty($value)) {
-                $sanitizedValue = str_replace(['*', '?'], '', $value);
-                if (filled($sanitizedValue)) {
-                    $options['--'.$cliOption] = $sanitizedValue;
+                if (is_bool($value)) {
+                    if ($value === true) {
+                        $options['--'.$cliOption] = true;
+                    }
+                } else {
+                    $sanitizedValue = str_replace(['*', '?'], '', $value);
+                    if (filled($sanitizedValue)) {
+                        $options['--'.$cliOption] = $sanitizedValue;
+                    }
                 }
             }
         }


### PR DESCRIPTION
  ### Summary
  Fixes a type error when using boolean parameters (`except_vendor`, `only_vendor`) with the ListRoutes
  MCP tool.

  ### Problem
  The tool was calling `str_replace()` on boolean values, causing this error:
  str_replace(): Argument #3 ($subject) must be of type array|string, true given

  ### Solution
  Added type checking before string manipulation in `src/Mcp/Tools/ListRoutes.php`:
  - Boolean values are passed through directly
  - String values continue to have wildcards sanitized

  ### Testing
  - `except_vendor => true` now works correctly
  - String parameters like `method => "POST"` still work as before
  - No breaking changes