### PR TITLE
[1.x] Add Augment Code Agent Support

### DIFF
--- a/src/Install/CodeEnvironment/AugmentCode.php
+++ b/src/Install/CodeEnvironment/AugmentCode.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install\CodeEnvironment;
+
+use Laravel\Boost\Contracts\Agent;
+use Laravel\Boost\Install\Enums\Platform;
+
+class AugmentCode extends CodeEnvironment implements Agent
+{
+    public function name(): string
+    {
+        return 'augment';
+    }
+
+    public function displayName(): string
+    {
+        return 'Augment Code';
+    }
+
+    public function systemDetectionConfig(Platform $platform): array
+    {
+        // Detect Auggie CLI installed globally via npm
+        return match ($platform) {
+            Platform::Darwin, Platform::Linux => [
+                'command' => 'which auggie',
+            ],
+            Platform::Windows => [
+                'command' => 'where auggie 2>nul',
+            ],
+        };
+    }
+
+    public function projectDetectionConfig(): array
+    {
+        return [
+            'paths' => ['.augment'],
+            'files' => ['.augment/rules/guidelines.md'],
+        ];
+    }
+
+    public function detectOnSystem(Platform $platform): bool
+    {
+        // Use parent's detection logic which will run the command
+        return parent::detectOnSystem($platform);
+    }
+
+    public function mcpClientName(): ?string
+    {
+        return null;
+    }
+
+    public function guidelinesPath(): string
+    {
+        return '.augment/rules/guidelines.md';
+    }
+}

--- a/src/Install/CodeEnvironment/CodeEnvironment.php
+++ b/src/Install/CodeEnvironment/CodeEnvironment.php
@@ -98,6 +98,7 @@ abstract class CodeEnvironment
         $detectionFactory = app(DetectionStrategyFactory::class);
 
         foreach ([
+            AugmentCode::class,
             ClaudeCode::class,
             Codex::class,
             Copilot::class,

--- a/src/Install/CodeEnvironmentsDetector.php
+++ b/src/Install/CodeEnvironmentsDetector.php
@@ -6,6 +6,7 @@ namespace Laravel\Boost\Install;
 
 use Illuminate\Container\Container;
 use Illuminate\Support\Collection;
+use Laravel\Boost\Install\CodeEnvironment\AugmentCode;
 use Laravel\Boost\Install\CodeEnvironment\ClaudeCode;
 use Laravel\Boost\Install\CodeEnvironment\CodeEnvironment;
 use Laravel\Boost\Install\CodeEnvironment\Codex;
@@ -25,6 +26,7 @@ class CodeEnvironmentsDetector
         'claudecode' => ClaudeCode::class,
         'codex' => Codex::class,
         'copilot' => Copilot::class,
+        'augment' => AugmentCode::class,
     ];
 
     public function __construct(


### PR DESCRIPTION
This adds support for Augment Code to the list of AI agents that can receive guidelines from Laravel Boost.

## Key changes

- Added `AugmentCode` class that implements the `Agent` interface
- Registered it in `CodeEnvironmentsDetector` alongside the other agents
- System detection checks for the Auggie CLI (installed via `npm install -g @augmentcode/auggie`)
- Project detection looks for `.augment` directory or existing guidelines file
- Guidelines get written to `.augment/rules/guidelines.md`
- Added tests covering the new agent implementation

MCP is not yet configurable at the project level in Augment Code, so this PR only implements the Agent interface (for guidelines). I'll add MCP client support in a follow-up PR once that's available.

Pretty straightforward addition following the existing patterns we have for Copilot and Codex.
   
Please consider this PR for inclusion.
