### PR TITLE
Extend installMcp method to accept current working directory parameter for vscode config

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -510,7 +510,9 @@ class InstallCommand extends Command
                 $result = $mcpClient->installMcp(
                     array_shift($mcp),
                     array_shift($mcp),
-                    $mcp
+                    $mcp,
+                    [],
+                    $mcpClient->name() === 'vscode' ? '${workspaceFolder}' : null
                 );
 
                 if ($result) {

--- a/src/Contracts/McpClient.php
+++ b/src/Contracts/McpClient.php
@@ -40,5 +40,5 @@ interface McpClient
      * @param  array<string, string>  $env  Environment variables
      * @return bool True if installation succeeded, false otherwise
      */
-    public function installMcp(string $key, string $command, array $args = [], array $env = []): bool;
+    public function installMcp(string $key, string $command, array $args = [], array $env = [], ?string $cwd = null): bool;
 }

--- a/src/Install/CodeEnvironment/CodeEnvironment.php
+++ b/src/Install/CodeEnvironment/CodeEnvironment.php
@@ -143,11 +143,11 @@ abstract class CodeEnvironment
      *
      * @throws FileNotFoundException
      */
-    public function installMcp(string $key, string $command, array $args = [], array $env = []): bool
+    public function installMcp(string $key, string $command, array $args = [], array $env = [], ?string $cwd = null): bool
     {
         return match ($this->mcpInstallationStrategy()) {
             McpInstallationStrategy::SHELL => $this->installShellMcp($key, $command, $args, $env),
-            McpInstallationStrategy::FILE => $this->installFileMcp($key, $command, $args, $env),
+            McpInstallationStrategy::FILE => $this->installFileMcp($key, $command, $args, $env, $cwd),
             McpInstallationStrategy::NONE => false
         };
     }
@@ -201,7 +201,7 @@ abstract class CodeEnvironment
      *
      * @throws FileNotFoundException
      */
-    protected function installFileMcp(string $key, string $command, array $args = [], array $env = []): bool
+    protected function installFileMcp(string $key, string $command, array $args = [], array $env = [], ?string $cwd = null): bool
     {
         $path = $this->mcpConfigPath();
         if (! $path) {
@@ -210,7 +210,7 @@ abstract class CodeEnvironment
 
         return (new FileWriter($path))
             ->configKey($this->mcpConfigKey())
-            ->addServer($key, $command, $args, $env)
+            ->addServer($key, $command, $args, $env, $cwd)
             ->save();
     }
 }

--- a/src/Install/Mcp/FileWriter.php
+++ b/src/Install/Mcp/FileWriter.php
@@ -29,12 +29,13 @@ class FileWriter
      * @param  array<int, string>  $args
      * @param  array<string, string>  $env
      */
-    public function addServer(string $key, string $command, array $args = [], array $env = []): self
+    public function addServer(string $key, string $command, array $args = [], array $env = [], ?string $cwd = null): self
     {
         $this->serversToAdd[$key] = collect([
             'command' => $command,
             'args' => $args,
             'env' => $env,
+            'cwd' => $cwd,
         ])->filter()->toArray();
 
         return $this;


### PR DESCRIPTION
This pull request introduces support for specifying a working directory (`cwd`) when installing MCP servers, with special handling for the VSCode client. The changes update method signatures and internal logic to propagate and store the `cwd` value throughout the installation process.

### MCP installation enhancements

* Extended the `installMcp` method signature in `McpClient` contract and `CodeEnvironment` to accept an optional `cwd` parameter, allowing the specification of a working directory for MCP server installation. [[1]](diffhunk://#diff-c09cffe2eeac6a28f1f220c47e71944504232e957666fab9497690b3cf2e5b4bL43-R43) [[2]](diffhunk://#diff-1834324a7b6be4a045cbaafc49121838da14f7a75bb510db7a5533a8087ef0c9L146-R150)
* Updated the `installFileMcp` method and its invocation to pass and handle the new `cwd` parameter, ensuring it is included when writing server configuration. [[1]](diffhunk://#diff-1834324a7b6be4a045cbaafc49121838da14f7a75bb510db7a5533a8087ef0c9L204-R204) [[2]](diffhunk://#diff-1834324a7b6be4a045cbaafc49121838da14f7a75bb510db7a5533a8087ef0c9L213-R213)

### VSCode-specific logic

* Modified the `installMcpServerConfig` method in `InstallCommand.php` to set `cwd` to `'${workspaceFolder}'` when the MCP client is VSCode, enabling proper workspace folder resolution for VSCode environments.

### Configuration storage updates

* Updated the `addServer` method in `FileWriter` to accept and store the `cwd` parameter, ensuring the working directory is saved in the server configuration.