### PR TITLE
fix: update copilot instructions path in project detection config

### DIFF
--- a/src/Install/CodeEnvironment/Copilot.php
+++ b/src/Install/CodeEnvironment/Copilot.php
@@ -30,7 +30,7 @@ class Copilot extends CodeEnvironment implements Agent
     public function projectDetectionConfig(): array
     {
         return [
-            'files' => ['.github/copilot-instructions.md'],
+            'files' => ['.github/instructions/copilot-instructions.md'],
         ];
     }
 
@@ -46,6 +46,6 @@ class Copilot extends CodeEnvironment implements Agent
 
     public function guidelinesPath(): string
     {
-        return '.github/copilot-instructions.md';
+        return '.github/instructions/copilot-instructions.md';
     }
 }

--- a/tests/Unit/Install/CodeEnvironmentsDetectorTest.php
+++ b/tests/Unit/Install/CodeEnvironmentsDetectorTest.php
@@ -145,14 +145,16 @@ test('discoverProjectInstalledCodeEnvironments detects copilot with nested file 
     $tempDir = sys_get_temp_dir().'/boost_test_'.uniqid();
     mkdir($tempDir);
     mkdir($tempDir.'/.github');
-    file_put_contents($tempDir.'/.github/copilot-instructions.md', 'test');
+    mkdir ($tempDir.'/.github/instructions');
+    file_put_contents($tempDir.'/.github/instructions/copilot-instructions.md', 'test');
 
     $detected = $this->detector->discoverProjectInstalledCodeEnvironments($tempDir);
 
     expect($detected)->toContain('copilot');
 
     // Cleanup
-    unlink($tempDir.'/.github/copilot-instructions.md');
+    unlink($tempDir.'/.github/instructions/copilot-instructions.md');
+    rmdir($tempDir.'/.github/instructions');
     rmdir($tempDir.'/.github');
     rmdir($tempDir);
 });


### PR DESCRIPTION
This pull request updates the location of the Copilot instructions file in the codebase, moving it from `.github/copilot-instructions.md` to `.github/instructions/copilot-instructions.md`. The changes ensure that both the configuration logic and related tests reference the new path.

**Copilot instructions file path update:**

* Updated the `projectDetectionConfig` and `guidelinesPath` methods in `src/Install/CodeEnvironment/Copilot.php` to use the new instructions file location `.github/instructions/copilot-instructions.md` instead of `.github/copilot-instructions.md`. [[1]](diffhunk://#diff-e1c512241441a879be4c5c7cec95dbec9372cf02fa748857ab01634c44dc298eL33-R33) [[2]](diffhunk://#diff-e1c512241441a879be4c5c7cec95dbec9372cf02fa748857ab01634c44dc298eL49-R49)

**Test adjustments:**

* Modified `tests/Unit/Install/CodeEnvironmentsDetectorTest.php` to create and clean up the instructions file in the new `.github/instructions` directory for test setup and teardown.