### PR TITLE
Command to facilitate the generation of custom guidelines for the user

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,12 @@ You may also automate this process by adding it to your Composer "post-update-cm
 
 ## Adding Custom AI Guidelines
 
-To augment Laravel Boost with your own custom AI guidelines, add `.blade.php` files to your application's `.ai/guidelines/*` directory. These files will automatically be included with Laravel Boost's guidelines when you run `boost:install`.
+To augment Laravel Boost with your own custom AI guidelines, you can:
+
+1. **Manually create** `.blade.php` files in your application's `.ai/guidelines/*` directory
+2. **Use the command**: `php artisan boost:custom {name}` - An interactive wizard will guide you through creating a custom guideline
+
+These files will automatically be included with Laravel Boost's guidelines when you run `boost:install`.
 
 ### Overriding Boost AI Guidelines
 

--- a/src/BoostServiceProvider.php
+++ b/src/BoostServiceProvider.php
@@ -93,6 +93,7 @@ class BoostServiceProvider extends ServiceProvider
                 Console\InstallCommand::class,
                 Console\UpdateCommand::class,
                 Console\ExecuteToolCommand::class,
+                Console\CustomGuideCommand::class,
             ]);
         }
     }

--- a/src/Console/CustomGuideCommand.php
+++ b/src/Console/CustomGuideCommand.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand('boost:custom', 'Create a custom guide based on your requirements.')]
+
+class CustomGuideCommand extends Command
+{
+    protected $signature = 'boost:custom {name : The name of the custom guide}';
+
+    public function handle(): void
+    {
+        $name = $this->argument('name');
+        assert(is_string($name), 'Name argument must be a string');
+
+        $sanitizedName = preg_replace('/[^a-zA-Z0-9_-]/', '', $name);
+        assert(is_string($sanitizedName), 'Sanitized name must be a string');
+
+        if ($sanitizedName === '' || $sanitizedName === '0') {
+            $this->components->error('Invalid guide name. Use only alphanumeric characters, hyphens, and underscores.');
+
+            return;
+        }
+
+        $fileName = $sanitizedName.'.blade.php';
+        $directory = base_path('.ai/guidelines');
+        $filePath = $directory.'/'.$fileName;
+
+        if (! is_dir($directory) && ! mkdir($directory, 0755, true)) {
+            $this->components->error("Failed to create directory: {$directory}");
+
+            return;
+        }
+
+        $realDirectory = realpath($directory);
+        assert(is_string($realDirectory), 'Real directory path must be a string');
+        $realFilePath = $realDirectory.'/'.basename($filePath);
+
+        if (! str_starts_with($realFilePath, $realDirectory)) {
+            $this->components->error('Invalid file path.');
+
+            return;
+        }
+
+        if (file_exists($filePath)) {
+            $this->components->error("A guideline with the name '{$sanitizedName}' already exists.");
+
+            return;
+        }
+
+        $titleRaw = $this->ask('* What is the title of your custom guide?');
+        $descriptionRaw = $this->ask('* Describe the purpose of this guide (optional)', '');
+
+        $title = is_string($titleRaw) ? mb_substr($titleRaw, 0, 200) : '';
+        $description = is_string($descriptionRaw) ? mb_substr($descriptionRaw, 0, 500) : '';
+
+        // Create the file with basic structure
+        $content = "# {$title}
+
+";
+
+        if ($description !== '' && $description !== '0') {
+            $content .= "## {$description}
+";
+        }
+
+        $content .= '
+<!-- Add your custom guidelines here -->
+';
+
+        if (file_put_contents($filePath, $content) === false) {
+            $this->components->error("Failed to create file: {$fileName}");
+
+            return;
+        }
+
+        $this->components->info("Custom guide created: .ai/{$fileName}");
+    }
+}

--- a/src/Console/CustomGuideCommand.php
+++ b/src/Console/CustomGuideCommand.php
@@ -71,6 +71,38 @@ class CustomGuideCommand extends Command
 
         $content .= '
 <!-- Add your custom guidelines here -->
+## Project Overview
+
+## Coding Standards
+
+### General
+
+### Laravel Specific
+
+## Architecture Patterns
+
+#### Instalación y Configuración:
+
+#### Organización:
+
+### DTOs y Value Objects
+
+### Testing
+
+## Naming Conventions
+
+## Database
+
+## Frontend
+
+## Security
+
+## Performance
+
+## Git Workflow
+
+## Comments & Documentation
+
 ';
 
         if (file_put_contents($filePath, $content) === false) {

--- a/tests/Feature/Console/CustomGuideCommandTest.php
+++ b/tests/Feature/Console/CustomGuideCommandTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+beforeEach(function (): void {
+    // Clean up any test files created
+    $this->testDirectory = base_path('.ai/guidelines');
+});
+
+afterEach(function (): void {
+    // Clean up test files
+    if (is_dir($this->testDirectory)) {
+        $files = glob($this->testDirectory.'/*.blade.php');
+        foreach ($files as $file) {
+            if (str_contains(basename($file), 'test-') ||
+                str_contains(basename($file), 'my-') ||
+                str_contains(basename($file), 'myguidewithspecial')) {
+                @unlink($file);
+            }
+        }
+    }
+});
+
+test('creates a custom guide successfully', function (): void {
+    $this->artisan('boost:custom', ['name' => 'test-success'])
+        ->expectsQuestion('* What is the title of your custom guide?', 'My Custom Guide')
+        ->expectsQuestion('* Describe the purpose of this guide (optional)', 'This is a test guide')
+        ->assertExitCode(0);
+
+    $filePath = base_path('.ai/guidelines/test-success.blade.php');
+    expect(file_exists($filePath))->toBeTrue();
+
+    $content = file_get_contents($filePath);
+    expect($content)->toContain('# My Custom Guide');
+    expect($content)->toContain('## This is a test guide');
+    expect($content)->toContain('<!-- Add your custom guidelines here -->');
+});
+
+test('shows error for invalid guide name with special characters', function (): void {
+    $this->artisan('boost:custom', ['name' => '!!!@@@###'])
+        ->assertExitCode(0);
+
+    $filePath = base_path('.ai/guidelines/.blade.php');
+    expect(file_exists($filePath))->toBeFalse();
+});
+
+test('shows error when guide already exists', function (): void {
+    // Create the file first
+    $directory = base_path('.ai/guidelines');
+    if (! is_dir($directory)) {
+        mkdir($directory, 0755, true);
+    }
+    $filePath = $directory.'/test-existing.blade.php';
+    file_put_contents($filePath, '# Existing guide');
+
+    // Try to create it again
+    $this->artisan('boost:custom', ['name' => 'test-existing'])
+        ->assertExitCode(0);
+
+    // Content should not change
+    $content = file_get_contents($filePath);
+    expect($content)->toBe('# Existing guide');
+
+    // Clean up
+    @unlink($filePath);
+});
+
+test('sanitizes guide name correctly', function (): void {
+    $this->artisan('boost:custom', ['name' => 'my-guide-123_test'])
+        ->expectsQuestion('* What is the title of your custom guide?', 'Test Guide')
+        ->expectsQuestion('* Describe the purpose of this guide (optional)', 'Description')
+        ->assertExitCode(0);
+
+    $filePath = base_path('.ai/guidelines/my-guide-123_test.blade.php');
+    expect(file_exists($filePath))->toBeTrue();
+});
+
+test('removes special characters from guide name', function (): void {
+    $this->artisan('boost:custom', ['name' => 'my@guide#with$special'])
+        ->expectsQuestion('* What is the title of your custom guide?', 'Clean Guide')
+        ->expectsQuestion('* Describe the purpose of this guide (optional)', 'Description')
+        ->assertExitCode(0);
+
+    // Should create file without special characters
+    $filePath = base_path('.ai/guidelines/myguidewithspecial.blade.php');
+    expect(file_exists($filePath))->toBeTrue();
+});
+
+test('shows error when name becomes empty after sanitization', function (): void {
+    $this->artisan('boost:custom', ['name' => '@@@###!!!'])
+        ->assertExitCode(0);
+
+    // No file should be created
+    $directory = base_path('.ai/guidelines');
+    if (is_dir($directory)) {
+        $files = glob($directory.'/.blade.php');
+        expect($files)->toBeEmpty();
+    }
+});
+
+test('creates guide without description when description is empty', function (): void {
+    $this->artisan('boost:custom', ['name' => 'test-nodesc'])
+        ->expectsQuestion('* What is the title of your custom guide?', 'My Guide')
+        ->expectsQuestion('* Describe the purpose of this guide (optional)', '')
+        ->assertExitCode(0);
+
+    $filePath = base_path('.ai/guidelines/test-nodesc.blade.php');
+    $content = file_get_contents($filePath);
+
+    expect($content)->toContain('# My Guide');
+    expect($content)->not->toContain('##');
+    expect($content)->toContain('<!-- Add your custom guidelines here -->');
+});
+
+test('truncates title to 200 characters', function (): void {
+    $longTitle = str_repeat('a', 250);
+
+    $this->artisan('boost:custom', ['name' => 'test-longtitle'])
+        ->expectsQuestion('* What is the title of your custom guide?', $longTitle)
+        ->expectsQuestion('* Describe the purpose of this guide (optional)', 'Description')
+        ->assertExitCode(0);
+
+    $filePath = base_path('.ai/guidelines/test-longtitle.blade.php');
+    $content = file_get_contents($filePath);
+
+    $truncatedTitle = str_repeat('a', 200);
+    expect($content)->toContain("# {$truncatedTitle}");
+
+    // Verify it's actually truncated and not longer
+    $firstLine = explode("\n", $content)[0];
+    expect(strlen($firstLine))->toBeLessThanOrEqual(202); // "# " + 200 chars
+});
+
+test('truncates description to 500 characters', function (): void {
+    $longDescription = str_repeat('b', 600);
+
+    $this->artisan('boost:custom', ['name' => 'test-longdesc'])
+        ->expectsQuestion('* What is the title of your custom guide?', 'Title')
+        ->expectsQuestion('* Describe the purpose of this guide (optional)', $longDescription)
+        ->assertExitCode(0);
+
+    $filePath = base_path('.ai/guidelines/test-longdesc.blade.php');
+    $content = file_get_contents($filePath);
+
+    $truncatedDescription = str_repeat('b', 500);
+    expect($content)->toContain("## {$truncatedDescription}");
+
+    // Find the description line and verify it's truncated
+    $lines = explode("\n", $content);
+    $descLine = array_filter($lines, fn ($line) => str_starts_with($line, '##'));
+    $descLine = reset($descLine);
+    expect(strlen($descLine))->toBeLessThanOrEqual(503); // "## " + 500 chars
+});

--- a/tests/Feature/Console/CustomGuideCommandTest.php
+++ b/tests/Feature/Console/CustomGuideCommandTest.php
@@ -108,8 +108,16 @@ test('creates guide without description when description is empty', function ():
     $content = file_get_contents($filePath);
 
     expect($content)->toContain('# My Guide');
-    expect($content)->not->toContain('##');
     expect($content)->toContain('<!-- Add your custom guidelines here -->');
+    expect($content)->toContain('## Project Overview');
+    // Verify no user description is added before the template sections
+    $lines = explode("\n", $content);
+    $titleIndex = array_search('# My Guide', $lines);
+    $commentIndex = array_search('<!-- Add your custom guidelines here -->', $lines);
+    // Between title and comment, there should only be blank lines (no ## description)
+    for ($i = $titleIndex + 1; $i < $commentIndex; $i++) {
+        expect(trim($lines[$i]))->toBe('');
+    }
 });
 
 test('truncates title to 200 characters', function (): void {


### PR DESCRIPTION
Add the command: `php artisan boost:custom {name}`

 to generate a basic blade file in .ia/guidelines/name.blade.php with some basic sections to make a custom specification.

The the benefit to end users are:

- It facilitates the generation of guidelines for the user and reduces creation errors.
- It helps provide a basis for generating a guideline.
- An interactive wizard for creating a custom guideline
