### PR TITLE
fix: update copilot instructions generation

### DIFF
--- a/src/Install/CodeEnvironment/Copilot.php
+++ b/src/Install/CodeEnvironment/Copilot.php
@@ -30,7 +30,7 @@ class Copilot extends CodeEnvironment implements Agent
     public function projectDetectionConfig(): array
     {
         return [
-            'files' => ['.github/copilot-instructions.md'],
+            'files' => ['.github/instructions/laravel-boost.instructions.md'],
         ];
     }
 
@@ -46,6 +46,11 @@ class Copilot extends CodeEnvironment implements Agent
 
     public function guidelinesPath(): string
     {
-        return '.github/copilot-instructions.md';
+        return '.github/instructions/laravel-boost.instructions.md';
+    }
+
+    public function frontmatter(): bool
+    {
+        return true;
     }
 }

--- a/src/Install/GuidelineWriter.php
+++ b/src/Install/GuidelineWriter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laravel\Boost\Install;
 
 use Laravel\Boost\Contracts\Agent;
+use Laravel\Boost\Install\CodeEnvironment\Copilot;
 use RuntimeException;
 
 class GuidelineWriter
@@ -60,7 +61,11 @@ class GuidelineWriter
                 // No existing Boost guidelines found, append to end of existing file
                 $frontMatter = '';
                 if ($this->agent->frontmatter() && ! str_contains($content, "\n---\n")) {
-                    $frontMatter = "---\nalwaysApply: true\n---\n";
+                    if ($this->agent instanceof Copilot) {
+                        $frontMatter = "---\napplyTo: \"**\"\n---\n";
+                    } else {
+                        $frontMatter = "---\nalwaysApply: true\n---\n";
+                    }
                 }
 
                 $existingContent = rtrim($content);

--- a/tests/Unit/Install/CodeEnvironmentsDetectorTest.php
+++ b/tests/Unit/Install/CodeEnvironmentsDetectorTest.php
@@ -144,15 +144,16 @@ test('discoverProjectInstalledCodeEnvironments detects applications with mixed t
 test('discoverProjectInstalledCodeEnvironments detects copilot with nested file path', function (): void {
     $tempDir = sys_get_temp_dir().'/boost_test_'.uniqid();
     mkdir($tempDir);
-    mkdir($tempDir.'/.github');
-    file_put_contents($tempDir.'/.github/copilot-instructions.md', 'test');
+    mkdir($tempDir.'/.github/instructions', recursive: true);
+    file_put_contents($tempDir.'/.github/instructions/laravel-boost.instructions.md', 'test');
 
     $detected = $this->detector->discoverProjectInstalledCodeEnvironments($tempDir);
 
     expect($detected)->toContain('copilot');
 
     // Cleanup
-    unlink($tempDir.'/.github/copilot-instructions.md');
+    unlink($tempDir.'/.github/instructions/laravel-boost.instructions.md');
+    rmdir($tempDir.'/.github/instructions');
     rmdir($tempDir.'/.github');
     rmdir($tempDir);
 });


### PR DESCRIPTION
fix: update Copilot instructions generation to output `.github/instructions/laravel-boost.instructions.md` with frontmatter support

## Summary

This PR is kinda duplicate from #284 and refactors how we generate GitHub Copilot instructions.  
Instead of using `copilot-instructions.md`, we now:

- Mirror the existing `.cursor/rules/laravel-boost.mdc` behavior for consistency using `.github/instructions/laravel-boost.instructions.md`

## Changes

1. **Copilot.php**  
   - Updated the path to reflect the `.github/instructions/…` directory structure and added frontmatter support so you can pass metadata (like `applyTo`) into the generated instructions.

2. **GuidelineWriter.php**  
   - Introduced an `instanceof Copilot` check to route Copilot-specific guideline frontmatter generation appropriately.

3. **CodeEnvironmentsDetectorTest.php**  
   - Updated test paths to reflect the `.github/instructions/…` directory structure.

## Affected files

- `src/CodeEnvironmentsDetectorTest.php`  
- `src/Copilot.php`  
- `src/GuidelineWriter.php`  

Honestly, for GuidelineWriter.php I just added a simple check `instanceof Copilot` using AI, so please let me know if these changes don't fit the contribution guidelines or anything.

## References

- VS Code Copilot custom instructions:  
  https://code.visualstudio.com/docs/copilot/customization/custom-instructions
- GitHub Changelog (2025-07-23):  
  https://github.blog/changelog/2025-07-23-github-copilot-coding-agent-now-supports-instructions-md-custom-instructions/
- GitHub Docs on repository instructions:  
  https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions#creating-custom-instructions