### PR TITLE
Clarify that PHPStorm setup only applies to Junie

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Once Laravel Boost has been installed, you're ready to start coding with Cursor,
 
 ### Setup Your Code Editors
 
-#### PhpStorm
+#### PhpStorm + Junie
 
 1. Press `shift` twice to open the command palette
 2. Search "MCP Settings" and press `enter`


### PR DESCRIPTION
The README has instructions for setting up PHPStorm, but these instructions are only applicable if you have the Junie plugin installed. They are not applicable for other AI plugins such as GitHub CoPilot.
