### PR TITLE
Add PhpStorm detection path for Windows

### DIFF
--- a/src/Install/CodeEnvironment/PhpStorm.php
+++ b/src/Install/CodeEnvironment/PhpStorm.php
@@ -40,6 +40,7 @@ class PhpStorm extends CodeEnvironment implements Agent, McpClient
                 'paths' => [
                     '%ProgramFiles%\\JetBrains\\PhpStorm*',
                     '%LOCALAPPDATA%\\JetBrains\\Toolbox\\apps\\PhpStorm\\ch-*',
+                    '%LOCALAPPDATA%\\Programs\\PhpStorm',
                 ],
             ],
         };


### PR DESCRIPTION
## Description

This PR adds an additional detection path for PhpStorm on Windows: `%LOCALAPPDATA%\Programs\PhpStorm`.

## Benefit to End Users

Users who have PhpStorm installed in the `%LOCALAPPDATA%\Programs\PhpStorm` directory on Windows will now have their IDE automatically detected by Laravel Boost, eliminating the need for manual configuration.

## Why This Doesn't Break Existing Features

- This change only **adds** a new detection path to the existing array
- No existing paths are modified or removed
- The detection logic remains unchanged
- All existing PhpStorm installations continue to be detected as before