### PR TITLE
Change default value for browser_logs_watcher

### DIFF
--- a/config/boost.php
+++ b/config/boost.php
@@ -27,6 +27,6 @@ return [
     | errors within the browser's console to give Boost better context.
     */
 
-    'browser_logs_watcher' => env('BOOST_BROWSER_LOGS_WATCHER', true),
+    'browser_logs_watcher' => env('BOOST_BROWSER_LOGS_WATCHER', env('APP_DEBUG', false)),
 
 ];


### PR DESCRIPTION
Add better default value for browser_logs_watcher.

We typically don't want to inject the watcher on production sites. This way, we disable the watcher by default when the application doesn't have debugging enabled.
