### PR TITLE
bump roster

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/support": "^10.49.0|^11.45.3|^12.28.1",
         "laravel/mcp": "^0.2.0|^0.3.0",
         "laravel/prompts": "0.1.25|^0.3.6",
-        "laravel/roster": "^0.2.8"
+        "laravel/roster": "^0.2.9"
     },
     "require-dev": {
         "laravel/pint": "1.20",


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

I ran into an issue where I updated boost, but roster was left behind. This ensures we install a compatible version of Roster with the now required [node package manager detection](https://github.com/laravel/roster/pull/24):

```
> @php artisan boost:update --ansi

   Illuminate\View\ViewException

  Call to undefined method Laravel\Roster\Roster::nodePackageManager() (View: /repo/storage/framework/views/b45cac6caa1804305e672e99d2097f47.blade.php)

  at vendor/laravel/boost/src/Install/GuidelineAssist.php:175
    171▕     }
    172▕
    173▕     public function nodePackageManager(): string
    174▕     {
  ➜ 175▕         return ($this->roster->nodePackageManager() ?? NodePackageManager::NPM)->value;
    176▕     }
    177▕ }
    178▕

      +3 vendor frames

  4   storage/framework/views/4fb83c7f91d0de69900a30e94db9aff3.php:33
      Laravel\Boost\Install\GuidelineAssist::nodePackageManager()
      +42 vendor frames

  47  artisan:16
      Illuminate\Foundation\Application::handleCommand(Object(Symfony\Component\Console\Input\ArgvInput))

Script @php artisan boost:update --ansi handling the post-update-cmd event returned with error code 1
```
