### PR TITLE
Update Tailwind v4+ guidelines 

### DIFF
--- a/.ai/tailwindcss/4/core.blade.php
+++ b/.ai/tailwindcss/4/core.blade.php
@@ -2,7 +2,7 @@
 
 - Always use Tailwind CSS v4 - do not use the deprecated utilities.
 - `corePlugins` is not supported in Tailwind v4.
-- In Tailwind v4, configuration is CSS-first using the `@theme` directive — no separate `tailwind.config.js` file needed.
+- In Tailwind v4, configuration is CSS-first using the `@theme` directive — no separate `tailwind.config.js` file is needed.
 @verbatim<code-snippet name="Extending Theme in CSS" lang="css">
 @theme {
   --color-brand: oklch(0.72 0.11 178);


### PR DESCRIPTION
**Fixes #161**

During development sessions with Boost, Claude occasionally tried to add a `tailwind.config.js` file, which doesn't exist in Tailwind v4. This PR updates the guidelines to explicitly mention that v4 uses CSS-first configuration with the `@theme` directive and no separate config file is needed.