### PR TITLE
add RooCode (VsCode Extension) support

### DIFF
--- a/src/BoostManager.php
+++ b/src/BoostManager.php
@@ -12,6 +12,7 @@ use Laravel\Boost\Install\CodeEnvironment\Copilot;
 use Laravel\Boost\Install\CodeEnvironment\Cursor;
 use Laravel\Boost\Install\CodeEnvironment\OpenCode;
 use Laravel\Boost\Install\CodeEnvironment\PhpStorm;
+use Laravel\Boost\Install\CodeEnvironment\RooCode;
 use Laravel\Boost\Install\CodeEnvironment\VSCode;
 
 class BoostManager
@@ -25,6 +26,7 @@ class BoostManager
         'codex' => Codex::class,
         'copilot' => Copilot::class,
         'opencode' => OpenCode::class,
+        'roocode' => RooCode::class,
     ];
 
     /**

--- a/src/Install/CodeEnvironment/RooCode.php
+++ b/src/Install/CodeEnvironment/RooCode.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install\CodeEnvironment;
+
+use Laravel\Boost\Contracts\Agent;
+use Laravel\Boost\Install\Enums\Platform;
+
+class RooCode extends CodeEnvironment implements Agent
+{
+    public function name(): string
+    {
+        return 'roocode';
+    }
+
+    public function displayName(): string
+    {
+        return 'RooCode';
+    }
+
+    public function systemDetectionConfig(Platform $platform): array
+    {
+        // RooCode is a VSCode extension, not a standalone app
+        return [
+            'files' => [],
+        ];
+    }
+
+    public function projectDetectionConfig(): array
+    {
+        return [
+            'paths' => ['.roo'],
+        ];
+    }
+
+    public function detectOnSystem(Platform $platform): bool
+    {
+        return false;
+    }
+
+    public function mcpClientName(): ?string
+    {
+        return null;
+    }
+
+    public function guidelinesPath(): string
+    {
+        return '.roo/rules/rules.md';
+    }
+
+    public function frontmatter(): bool
+    {
+        return false;
+    }
+}
+


### PR DESCRIPTION
This PR adds support for RooCode, a VSCode extension, as an AI agent option in Laravel Boost.
