### PR TITLE
Remove duplicate code in GuidelineComposer.php

### DIFF
--- a/src/Install/GuidelineComposer.php
+++ b/src/Install/GuidelineComposer.php
@@ -181,16 +181,6 @@ class GuidelineComposer
             $guidelines->put('.ai/'.$guideline['name'], $guideline);
         }
 
-        $pathsUsed = $guidelines->pluck('path');
-
-        foreach ($userGuidelines as $guideline) {
-            if ($pathsUsed->contains($guideline['path'])) {
-                continue; // Don't include this twice if it's an override
-            }
-
-            $guidelines->put('.ai/'.$guideline['name'], $guideline);
-        }
-
         collect(Composer::packagesDirectoriesWithBoostGuidelines())
             ->each(function (string $path, string $package) use ($guidelines): void {
                 $packageGuidelines = $this->guidelinesDir($path, true);


### PR DESCRIPTION
This removes some duplicate code in `src/Install/GuidelineComposer.php` where the same loop is executed twice:

First occurrence (lines 174-182):
```php
$pathsUsed = $guidelines->pluck('path');

foreach ($userGuidelines as $guideline) {
    if ($pathsUsed->contains($guideline['path'])) {
        continue; // Don't include this twice if it's an override
    }

    $guidelines->put('.ai/'.$guideline['name'], $guideline);
}
```

Second occurrence (lines 184-192):

```php
$pathsUsed = $guidelines->pluck('path');

foreach ($userGuidelines as $guideline) {
    if ($pathsUsed->contains($guideline['path'])) {
        continue; // Don't include this twice if it's an override
    }

    $guidelines->put('.ai/'.$guideline['name'], $guideline);
}
```