### PR TITLE
[1.x] Fix: WSL by changing 'wsl' to 'wsl.exe' in MCP config

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -510,7 +510,7 @@ class InstallCommand extends Command
 
         return array_filter([
             'laravel-boost',
-            $inWsl ? 'wsl' : false,
+            $inWsl ? 'wsl.exe' : false,
             $mcpClient->getPhpPath($inWsl),
             $mcpClient->getArtisanPath($inWsl),
             'boost:mcp',


### PR DESCRIPTION
I was getting this error while trying to access the Laravel Boost MCP server.
<img width="471" height="103" alt="image" src="https://github.com/user-attachments/assets/fb9d540c-fac0-4af7-b6d7-a0862629f9c3" />

After changing it to `wsl.exe`, it worked
<img width="915" height="509" alt="image" src="https://github.com/user-attachments/assets/5cb8d104-cebd-4e50-b252-f57a4e241a2e" />

This fixes https://github.com/laravel/boost/issues/299