### PR TITLE
Add guideline to prefer Laravel built-in helpers over custom ones

### DIFF
--- a/.ai/laravel/core.blade.php
+++ b/.ai/laravel/core.blade.php
@@ -3,6 +3,7 @@
 - Use `php artisan make:` commands to create new files (i.e. migrations, controllers, models, etc.). You can list available Artisan commands using the `list-artisan-commands` tool.
 - If you're creating a generic PHP class, use `artisan make:class`.
 - Pass `--no-interaction` to all Artisan commands to ensure they work without user input. You should also pass the correct `--options` to ensure correct behavior.
+- Prefer Laravel’s built-in global helpers over custom implementations whenever an official helper is available.
 
 ### Database
 - Always use proper Eloquent relationship methods with return type hints. Prefer relationship methods over raw queries or manual joins.


### PR DESCRIPTION
In many cases, Juni tends to re-implement functionality that already exists in the Laravel framework instead of using the built-in helpers. After a few tests, it seems this guideline helps clarify the preferred approach.