### PR TITLE
Add Kiro IDE support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased](https://github.com/laravel/boost/compare/v1.7.1...main)
 
+### Added
+
+- Added support for Kiro IDE as both an editor and AI agent
+- Kiro guidelines are created at `.kiro/steering/laravel-boost.md`
+- Kiro MCP configuration at `.kiro/settings/mcp.json`
+
 ## [v1.7.1](https://github.com/laravel/boost/compare/v1.7.0...v1.7.1) - 2025-11-05
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -37,9 +37,17 @@ php artisan boost:install
 
 Feel free to add the generated MCP configuration file, guideline files (`.mcp.json`, `CLAUDE.md`, `AGENTS.md`, `junie/`, etc.) and `boost.json` configuration file to your application's `.gitignore` as these files are automatically re-generated when running `boost:install` and `boost:update`.
 
-Once Laravel Boost has been installed, you're ready to start coding with Cursor, Claude Code, or your AI agent of choice.
+Once Laravel Boost has been installed, you're ready to start coding with Cursor, Claude Code, Kiro, or your AI agent of choice.
 
 ### Setup Your Code Editors
+
+#### Kiro
+
+1. Open the command palette (`Cmd+Shift+P` or `Ctrl+Shift+P`)
+2. Search for "MCP: Reconnect All Servers" and press `enter`
+3. The `laravel-boost` MCP server will be automatically detected and connected
+
+Kiro automatically loads AI guidelines from `.kiro/steering/laravel-boost.md` to provide context-aware assistance for your Laravel application.
 
 #### PhpStorm
 

--- a/src/BoostManager.php
+++ b/src/BoostManager.php
@@ -10,6 +10,7 @@ use Laravel\Boost\Install\CodeEnvironment\CodeEnvironment;
 use Laravel\Boost\Install\CodeEnvironment\Codex;
 use Laravel\Boost\Install\CodeEnvironment\Copilot;
 use Laravel\Boost\Install\CodeEnvironment\Cursor;
+use Laravel\Boost\Install\CodeEnvironment\Kiro;
 use Laravel\Boost\Install\CodeEnvironment\OpenCode;
 use Laravel\Boost\Install\CodeEnvironment\PhpStorm;
 use Laravel\Boost\Install\CodeEnvironment\VSCode;
@@ -25,6 +26,7 @@ class BoostManager
         'codex' => Codex::class,
         'copilot' => Copilot::class,
         'opencode' => OpenCode::class,
+        'kiro' => Kiro::class,
     ];
 
     /**

--- a/src/Install/CodeEnvironment/Kiro.php
+++ b/src/Install/CodeEnvironment/Kiro.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install\CodeEnvironment;
+
+use Laravel\Boost\Contracts\Agent;
+use Laravel\Boost\Contracts\McpClient;
+use Laravel\Boost\Install\Enums\Platform;
+
+/**
+ * Kiro IDE code environment implementation.
+ *
+ * Kiro is an AI-powered IDE that supports the Model Context Protocol (MCP).
+ * This implementation configures Boost to work seamlessly with Kiro by:
+ * - Detecting Kiro installations on the system
+ * - Configuring MCP settings at .kiro/settings/mcp.json
+ * - Creating AI guidelines at .kiro/steering/laravel-boost.md
+ * - Supporting Kiro as both an editor and an AI agent
+ */
+class Kiro extends CodeEnvironment implements Agent, McpClient
+{
+    /**
+     * Get the internal name identifier for Kiro.
+     */
+    public function name(): string
+    {
+        return 'kiro';
+    }
+
+    /**
+     * Get the display name for Kiro shown to users.
+     */
+    public function displayName(): string
+    {
+        return 'Kiro';
+    }
+
+    /**
+     * Get system-level detection configuration for Kiro.
+     *
+     * Defines the paths where Kiro might be installed on different platforms.
+     */
+    public function systemDetectionConfig(Platform $platform): array
+    {
+        return match ($platform) {
+            Platform::Darwin => [
+                'paths' => ['/Applications/Kiro.app'],
+            ],
+            Platform::Linux => [
+                'paths' => [
+                    '/opt/kiro',
+                    '/usr/local/bin/kiro',
+                    '~/.local/bin/kiro',
+                ],
+            ],
+            Platform::Windows => [
+                'paths' => [
+                    '%ProgramFiles%\\Kiro',
+                    '%LOCALAPPDATA%\\Programs\\Kiro',
+                ],
+            ],
+        };
+    }
+
+    /**
+     * Get project-level detection configuration for Kiro.
+     *
+     * Kiro projects are identified by the presence of a .kiro directory.
+     */
+    public function projectDetectionConfig(): array
+    {
+        return [
+            'paths' => ['.kiro'],
+        ];
+    }
+
+    /**
+     * Get the path to Kiro's MCP configuration file.
+     */
+    public function mcpConfigPath(): string
+    {
+        return '.kiro/settings/mcp.json';
+    }
+
+    /**
+     * Get the path where AI guidelines should be created for Kiro.
+     *
+     * Kiro uses the steering directory for AI guidelines that are
+     * automatically loaded to provide context-aware assistance.
+     */
+    public function guidelinesPath(): string
+    {
+        return '.kiro/steering/laravel-boost.md';
+    }
+
+    /**
+     * Determine if Kiro guidelines should include YAML frontmatter.
+     *
+     * Kiro supports frontmatter for controlling when guidelines are included.
+     */
+    public function frontmatter(): bool
+    {
+        return false;
+    }
+}

--- a/tests/Unit/BoostManagerTest.php
+++ b/tests/Unit/BoostManagerTest.php
@@ -7,6 +7,7 @@ use Laravel\Boost\Install\CodeEnvironment\ClaudeCode;
 use Laravel\Boost\Install\CodeEnvironment\Codex;
 use Laravel\Boost\Install\CodeEnvironment\Copilot;
 use Laravel\Boost\Install\CodeEnvironment\Cursor;
+use Laravel\Boost\Install\CodeEnvironment\Kiro;
 use Laravel\Boost\Install\CodeEnvironment\PhpStorm;
 use Laravel\Boost\Install\CodeEnvironment\VSCode;
 use Tests\Unit\Install\ExampleCodeEnvironment;
@@ -22,6 +23,7 @@ it('returns default code environments', function (): void {
         'claudecode' => ClaudeCode::class,
         'codex' => Codex::class,
         'copilot' => Copilot::class,
+        'kiro' => Kiro::class,
     ]);
 });
 

--- a/tests/Unit/Install/CodeEnvironmentsDetectorTest.php
+++ b/tests/Unit/Install/CodeEnvironmentsDetectorTest.php
@@ -10,6 +10,7 @@ use Laravel\Boost\Install\CodeEnvironment\CodeEnvironment;
 use Laravel\Boost\Install\CodeEnvironment\Codex;
 use Laravel\Boost\Install\CodeEnvironment\Copilot;
 use Laravel\Boost\Install\CodeEnvironment\Cursor;
+use Laravel\Boost\Install\CodeEnvironment\Kiro;
 use Laravel\Boost\Install\CodeEnvironment\OpenCode;
 use Laravel\Boost\Install\CodeEnvironment\PhpStorm;
 use Laravel\Boost\Install\CodeEnvironment\VSCode;
@@ -30,9 +31,9 @@ it('returns collection of all registered code environments', function (): void {
     $codeEnvironments = $this->detector->getCodeEnvironments();
 
     expect($codeEnvironments)->toBeInstanceOf(Collection::class)
-        ->and($codeEnvironments->count())->toBe(7)
+        ->and($codeEnvironments->count())->toBe(8)
         ->and($codeEnvironments->keys()->toArray())->toBe([
-            'phpstorm', 'vscode', 'cursor', 'claudecode', 'codex', 'copilot', 'opencode',
+            'phpstorm', 'vscode', 'cursor', 'claudecode', 'codex', 'copilot', 'opencode', 'kiro',
         ]);
 
     $codeEnvironments->each(function ($environment): void {
@@ -64,6 +65,7 @@ it('returns an array of detected environment names for system discovery', functi
     $this->container->bind(Codex::class, fn () => $mockOther);
     $this->container->bind(Copilot::class, fn () => $mockOther);
     $this->container->bind(OpenCode::class, fn () => $mockOther);
+    $this->container->bind(Kiro::class, fn () => $mockOther);
 
     $detector = new CodeEnvironmentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverSystemInstalledCodeEnvironments();
@@ -83,6 +85,7 @@ it('returns an empty array when no environments are detected for system discover
     $this->container->bind(Codex::class, fn () => $mockEnvironment);
     $this->container->bind(Copilot::class, fn () => $mockEnvironment);
     $this->container->bind(OpenCode::class, fn () => $mockEnvironment);
+    $this->container->bind(Kiro::class, fn () => $mockEnvironment);
 
     $detector = new CodeEnvironmentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverSystemInstalledCodeEnvironments();
@@ -116,6 +119,7 @@ it('returns an array of detected environment names for project discovery', funct
     $this->container->bind(Codex::class, fn () => $mockOther);
     $this->container->bind(Copilot::class, fn () => $mockOther);
     $this->container->bind(OpenCode::class, fn () => $mockOther);
+    $this->container->bind(Kiro::class, fn () => $mockOther);
 
     $detector = new CodeEnvironmentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverProjectInstalledCodeEnvironments($basePath);
@@ -137,6 +141,7 @@ it('returns an empty array when no environments are detected for project discove
     $this->container->bind(Codex::class, fn () => $mockEnvironment);
     $this->container->bind(Copilot::class, fn () => $mockEnvironment);
     $this->container->bind(OpenCode::class, fn () => $mockEnvironment);
+    $this->container->bind(Kiro::class, fn () => $mockEnvironment);
 
     $detector = new CodeEnvironmentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverProjectInstalledCodeEnvironments($basePath);


### PR DESCRIPTION
# Add Kiro IDE Support

## Description
This PR adds support for Kiro IDE to Laravel Boost.

## Changes
- Created `Kiro` CodeEnvironment class implementing both `Agent` and `McpClient` interfaces
- Registered Kiro in `BoostManager`
- Configured MCP installation at `.kiro/settings/mcp.json`
- Configured AI guidelines at `.kiro/steering/laravel-boost.md`
- Added platform detection for macOS, Linux, and Windows
- Updated tests to include Kiro in all relevant test cases
- Updated README with Kiro setup instructions
- Updated CHANGELOG

## Kiro Configuration
When users run `php artisan boost:install`, Kiro will:
- Appear in the list of available editors (for MCP configuration)
- Appear in the list of available agents (for AI guidelines)
- Auto-detect if `.kiro` directory exists in the project
- Create MCP config at `.kiro/settings/mcp.json`
- Create AI guidelines at `.kiro/steering/laravel-boost.md`