### PR TITLE
Add note about boost:update command requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ You may also automate this process by adding it to your Composer "post-update-cm
 }
 ```
 
+> [!NOTE]
+> If you do not see a `boost:update` command, make sure you are on the latest Laravel Boost version. Laravel Boost will only be registered if `BOOST_ENABLED=true` is set in your `.env` file (or if `APP_DEBUG=true`).
+
 ## Available Documentation
 
 | Package | Versions Supported |


### PR DESCRIPTION
This PR adds a helpful note in the "Keeping Guidelines Up-to-Date" section to clarify the requirements for the `boost:update` command.

   ## Changes

   - Added a note block explaining that users need to be on the latest Laravel Boost version
   - Clarified that Laravel Boost only registers when `BOOST_ENABLED=true` or `APP_DEBUG=true` is set in `.env`

   ## Why

   This helps users troubleshoot issues when the `boost:update` command is not appearing in their artisan command list.

   Fixes #352
