### PR TITLE
tests: adds missing opencode in tests

### DIFF
--- a/tests/Unit/BoostManagerTest.php
+++ b/tests/Unit/BoostManagerTest.php
@@ -7,6 +7,7 @@ use Laravel\Boost\Install\CodeEnvironment\ClaudeCode;
 use Laravel\Boost\Install\CodeEnvironment\Codex;
 use Laravel\Boost\Install\CodeEnvironment\Copilot;
 use Laravel\Boost\Install\CodeEnvironment\Cursor;
+use Laravel\Boost\Install\CodeEnvironment\OpenCode;
 use Laravel\Boost\Install\CodeEnvironment\PhpStorm;
 use Laravel\Boost\Install\CodeEnvironment\VSCode;
 use Tests\Unit\Install\ExampleCodeEnvironment;
@@ -22,6 +23,7 @@ it('returns default code environments', function (): void {
         'claudecode' => ClaudeCode::class,
         'codex' => Codex::class,
         'copilot' => Copilot::class,
+        'opencode' => OpenCode::class,
     ]);
 });
 


### PR DESCRIPTION
This pull request makes a minor update to the `BoostManagerTest` unit test by adding the `OpenCode`.
