### PR TITLE
Extend Codex functionality with MCP config

### DIFF
--- a/src/Install/CodeEnvironment/Codex.php
+++ b/src/Install/CodeEnvironment/Codex.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Install\CodeEnvironment;
 
-use Illuminate\Support\Facades\Process;
 use Laravel\Boost\Contracts\Agent;
 use Laravel\Boost\Contracts\McpClient;
 use Laravel\Boost\Install\Enums\McpInstallationStrategy;


### PR DESCRIPTION
Resolves #363.

We use the MCP shell installation strategy to add MCP config support as described in the Codex [MCP CLI](https://developers.openai.com/codex/mcp/#configuration---cli) docs. This enables Codex to install MCP servers directly via CLI. Although [Codex](https://github.com/openai/codex/issues/2628) does not support project specific config yet, it now supports relative paths in the MCP config, which we leverage to add support for Laravel Boost.

Tested this with sail, herd and it work without any issues. 

<img width="1795" height="414" alt="Screenshot 2025-11-20 at 4 14 35 PM" src="https://github.com/user-attachments/assets/eb8168b5-a0a6-433d-bf78-b78c6721f0a1" />
<img width="1795" height="414" alt="Screenshot 2025-11-20 at 4 19 07 PM" src="https://github.com/user-attachments/assets/1fbc5d0c-5860-4abe-92bf-e99852c876de" />
<img width="985" height="267" alt="Screenshot 2025-11-20 at 4 29 06 PM" src="https://github.com/user-attachments/assets/dd9cb424-78b1-4c60-b253-a2d20ea094b7" />
