### PR TITLE
Update FluxUI component list

### DIFF
--- a/.ai/fluxui-free/core.blade.php
+++ b/.ai/fluxui-free/core.blade.php
@@ -16,5 +16,5 @@
 This is correct as of Boost installation, but there may be additional components within the codebase.
 
 <available-flux-components>
-avatar, badge, brand, breadcrumbs, button, callout, checkbox, dropdown, field, heading, icon, input, modal, navbar, profile, radio, select, separator, switch, text, textarea, tooltip
+avatar, badge, brand, breadcrumbs, button, callout, checkbox, dropdown, field, heading, icon, input, modal, navbar, otp-input, profile, radio, select, separator, skeleton, switch, text, textarea, tooltip
 </available-flux-components>

--- a/.ai/fluxui-pro/core.blade.php
+++ b/.ai/fluxui-pro/core.blade.php
@@ -16,5 +16,5 @@
 This is correct as of Boost installation, but there may be additional components within the codebase.
 
 <available-flux-components>
-accordion, autocomplete, avatar, badge, brand, breadcrumbs, button, calendar, callout, card, chart, checkbox, command, composer, context, date-picker, dropdown, editor, field, file-upload, heading, icon, input, modal, navbar, otp, pagination, pillbox, popover, profile, radio, select, separator, slider, switch, table, tabs, text, textarea, time-picker, toast, tooltip
+accordion, autocomplete, avatar, badge, brand, breadcrumbs, button, calendar, callout, card, chart, checkbox, command, composer, context, date-picker, dropdown, editor, field, file-upload, heading, icon, input, kanban, modal, navbar, otp-input, pagination, pillbox, popover, profile, radio, select, separator, skeleton, slider, switch, table, tabs, text, textarea, time-picker, toast, tooltip
 </available-flux-components>


### PR DESCRIPTION
I added the newest flux ui pro components:
- [x] composer 
- [x] otp
- [x] slider 
- [x] time-picker

I also changed `file upload` to `file-upload` to match the component name and move `heading` after `file-upload` to match the list sorting.