### PR TITLE
fix(phpstorm): prevent creating .junie directory when Junie is not selected

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -14,6 +14,7 @@ use Laravel\Boost\Contracts\Agent;
 use Laravel\Boost\Contracts\McpClient;
 use Laravel\Boost\Install\Cli\DisplayHelper;
 use Laravel\Boost\Install\CodeEnvironment\CodeEnvironment;
+use Laravel\Boost\Install\CodeEnvironment\PhpStorm;
 use Laravel\Boost\Install\CodeEnvironmentsDetector;
 use Laravel\Boost\Install\GuidelineComposer;
 use Laravel\Boost\Install\GuidelineConfig;
@@ -592,6 +593,11 @@ class InstallCommand extends Command
         );
 
         foreach ($this->selectedTargetMcpClient as $mcpClient) {
+            if ($mcpClient instanceof PhpStorm) {
+                $mcpClient->selectedAsAgent = $this->selectedTargetAgents
+                    ->contains(fn ($agent): bool => $agent instanceof PhpStorm);
+            }
+
             $ideName = $mcpClient->mcpClientName();
             $ideDisplay = str_pad((string) $ideName, $longestIdeName);
             $this->output->write("  {$ideDisplay}... ");

--- a/src/Install/CodeEnvironment/PhpStorm.php
+++ b/src/Install/CodeEnvironment/PhpStorm.php
@@ -12,6 +12,8 @@ class PhpStorm extends CodeEnvironment implements Agent, McpClient
 {
     public bool $useAbsolutePathForMcp = true;
 
+    public bool $selectedAsAgent = false;
+
     public function name(): string
     {
         return 'phpstorm';
@@ -60,6 +62,10 @@ class PhpStorm extends CodeEnvironment implements Agent, McpClient
 
     public function mcpConfigPath(): string
     {
+        if (! $this->selectedAsAgent) {
+            return '.idea/mcp.json';
+        }
+
         return '.junie/mcp/mcp.json';
     }
 

--- a/tests/Unit/Install/CodeEnvironment/PhpStormTest.php
+++ b/tests/Unit/Install/CodeEnvironment/PhpStormTest.php
@@ -37,3 +37,17 @@ test('guidelinesPath returns a custom path from config', function (): void {
 
     expect($phpstorm->guidelinesPath())->toBe('.idea/guidelines.md');
 });
+
+test('mcpConfigPath returns idea path when not selected as agent', function (): void {
+    $phpstorm = new PhpStorm($this->strategyFactory);
+    $phpstorm->selectedAsAgent = false;
+
+    expect($phpstorm->mcpConfigPath())->toBe('.idea/mcp.json');
+});
+
+test('mcpConfigPath returns junie path when selected as agent', function (): void {
+    $phpstorm = new PhpStorm($this->strategyFactory);
+    $phpstorm->selectedAsAgent = true;
+
+    expect($phpstorm->mcpConfigPath())->toBe('.junie/mcp/mcp.json');
+});


### PR DESCRIPTION
 Problem Details                                                                                                                                                                                           
                                                                                                                                                                                                            
  Before:                                                                                                                                                                                                   
  User selects:                                                                                                                                                                                             
    ☑ PhpStorm (MCP Client)                                                                                                                                                                                 
    ☐ Junie (Agent)                                                                                                                                                                                      
                                                                                                                                                                                                            
  Result: Creates .junie/mcp/mcp.json                                                                                                                                                                       
  Problem: .junie directory created unnecessarily                                                                                                                                                           
                                                                                                                                                                                                            
  Now:                                                                                                                                                                                                      
  User selects:                                                                                                                                                                                             
    ☑ PhpStorm (MCP Client)                                                                                                                                                                                 
    ☐ Junie (Agent)                                                                                                                                                                                      
                                                                                                                                                                                                            
  Result: Creates .idea/mcp.json                                                                                                                                                                            
  Benefit: .junie only created when actually needed   


## Benefits Summary                                                                                                                                                                                          
                                                                                                                                                                                                            
  -  Cleaner: Doesn't create unnecessary directories in the project                                                                                                                                       
  -  More logical: .junie only exists when Junie is active                                                                                                                                                
  -  Better organization: Uses PhpStorm's native structure (.idea/) when appropriate                                                                                                                      
  -  Maintains compatibility: When Junie is an agent, still uses .junie/mcp/   
