### PR TITLE
Update documentation for 'search-docs' tool usage

### DIFF
--- a/.ai/boost/core.blade.php
+++ b/.ai/boost/core.blade.php
@@ -18,7 +18,7 @@
 @endif
 
 ## Searching Documentation (Critically Important)
-- Boost comes with a powerful `search-docs` tool you should use before any other approaches. This tool automatically passes a list of installed packages and their versions to the remote Boost API, so it returns only version-specific documentation specific for the user's circumstance. You should pass an array of packages to filter on if you know you need docs for particular packages.
+- Boost comes with a powerful `search-docs` tool you should use before any other approaches when dealing with Laravel or Laravel ecosystem packages. This tool automatically passes a list of installed packages and their versions to the remote Boost API, so it returns only version-specific documentation specific for the user's circumstance. You should pass an array of packages to filter on if you know you need docs for particular packages.
 - The 'search-docs' tool is perfect for all Laravel related packages, including Laravel, Inertia, Livewire, Filament, Tailwind, Pest, Nova, Nightwatch, etc.
 - You must use this tool to search for Laravel-ecosystem documentation before falling back to other approaches.
 - Search the documentation before making code changes to ensure we are taking the correct approach.


### PR DESCRIPTION
Clarified the usage of the 'search-docs' tool for Laravel packages.

I'm not entirely sure how to perform testing for this, but in my experience these boost guidelines have made it so any time I ask Claude Code to "search documentation" it immediately jumps to this tool, even if the documentation or package is unrelated to Laravel

Example:
<img width="1871" height="470" alt="image" src="https://github.com/user-attachments/assets/5fb97f14-e6a3-414c-8ef4-e14f3bb6f2fd" />

In Codex I have seen something similar where it tries to search for HTMX documentation.