### PR TITLE
Add `--compact` flag to testing examples

### DIFF
--- a/.ai/enforce-tests.blade.php
+++ b/.ai/enforce-tests.blade.php
@@ -4,4 +4,4 @@
 ## Test Enforcement
 
 - Every change must be programmatically tested. Write a new test or update an existing test, then run the affected tests to make sure they pass.
-- Run the minimum number of tests needed to ensure code quality and speed. Use `{{ $assist->artisanCommand('test') }}` with a specific filename or filter.
+- Run the minimum number of tests needed to ensure code quality and speed. Use `{{ $assist->artisanCommand('test --compact') }}` with a specific filename or filter.

--- a/.ai/pest/core.blade.php
+++ b/.ai/pest/core.blade.php
@@ -19,9 +19,9 @@ it('is true', function () {
 
 ### Running Tests
 - Run the minimal number of tests using an appropriate filter before finalizing code edits.
-- To run all tests: `{{ $assist->artisanCommand('test') }}`.
-- To run all tests in a file: `{{ $assist->artisanCommand('test tests/Feature/ExampleTest.php') }}`.
-- To filter on a particular test name: `{{ $assist->artisanCommand('test --filter=testName') }}` (recommended after making a change to a related file).
+- To run all tests: `{{ $assist->artisanCommand('test --compact') }}`.
+- To run all tests in a file: `{{ $assist->artisanCommand('test --compact tests/Feature/ExampleTest.php') }}`.
+- To filter on a particular test name: `{{ $assist->artisanCommand('test --compact --filter=testName') }}` (recommended after making a change to a related file).
 - When the tests relating to your changes are passing, ask the user if they would like to run the entire test suite to ensure everything is still passing.
 
 ### Pest Assertions

--- a/.ai/phpunit/core.blade.php
+++ b/.ai/phpunit/core.blade.php
@@ -12,6 +12,6 @@
 
 ### Running Tests
 - Run the minimal number of tests, using an appropriate filter, before finalizing.
-- To run all tests: `{{ $assist->artisanCommand('test') }}`.
-- To run all tests in a file: `{{ $assist->artisanCommand('test tests/Feature/ExampleTest.php') }}`.
-- To filter on a particular test name: `{{ $assist->artisanCommand('test --filter=testName') }}` (recommended after making a change to a related file).
+- To run all tests: `{{ $assist->artisanCommand('test --compact') }}`.
+- To run all tests in a file: `{{ $assist->artisanCommand('test --compact tests/Feature/ExampleTest.php') }}`.
+- To filter on a particular test name: `{{ $assist->artisanCommand('test --compact --filter=testName') }}` (recommended after making a change to a related file).


### PR DESCRIPTION
The compact printer can save a lot of tokens being passed to the model.

Quite often the model will run a test file or whole suite and receive 100s or 1000s of lines of :

```
✓ it injects script in html responses with dataset "with head and body tags"
✓ executes code with different return types with dataset "float"
```

This can burn through a _lot_ of tokens.  By telling it to use the `--compact` flag the output is just a series of `.`'s - but the model still gets the full output for tests which fail.

I've been using this instruction in my local .ai/ guidance and it seems to help quite a bit - especially if the model is in a bit of a 'rut' running tests over and over.