### PR TITLE
[1.x] Add configurable PHP and Composer paths

### DIFF
--- a/config/boost.php
+++ b/config/boost.php
@@ -31,20 +31,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Boost Commands
+    | Boost Executables Config
     |--------------------------------------------------------------------------
     |
-    | The following options allow you to configure custom paths for the PHP
-    | and Composer binaries used by Boost. Leave empty to use defaults.
+    | The following options allow you to configure custom paths for the PHP,
+    | Composer, and npm executables used by Boost. Leave empty to use defaults.
     | When configured, these take precedence over automatic detection.
     |
     */
 
-    'commands' => [
-        'php_binary' => env('BOOST_PHP_BINARY'),
-        'composer_binary' => env('BOOST_COMPOSER_BINARY'),
-        'node_package_manager_binary' => env('BOOST_NODE_PACKAGE_MANAGER_BINARY'),
-        'vendor_bin_prefix' => env('BOOST_VENDOR_BIN_PREFIX'),
+    'executables' => [
+        'php' => env('BOOST_PHP_EXECUTABLE'),
+        'composer' => env('BOOST_COMPOSER_EXECUTABLE'),
+        'npm' => env('BOOST_NPM_EXECUTABLE'),
+        'vendor_bin' => env('BOOST_VENDOR_BIN_EXECUTABLE'),
     ],
 
 ];

--- a/src/Install/CodeEnvironment/CodeEnvironment.php
+++ b/src/Install/CodeEnvironment/CodeEnvironment.php
@@ -40,9 +40,9 @@ abstract class CodeEnvironment
 
     public function getPhpPath(bool $forceAbsolutePath = false): string
     {
-        $phpBinaryPath = config('boost.commands.php_binary', 'php');
+        $phpBinaryPath = config('boost.executables.php') ?? 'php';
 
-        if ($this->useAbsolutePathForMcp() || $forceAbsolutePath) {
+        if ($phpBinaryPath === 'php' && ($this->useAbsolutePathForMcp() || $forceAbsolutePath)) {
             return PHP_BINARY;
         }
 

--- a/src/Install/GuidelineAssist.php
+++ b/src/Install/GuidelineAssist.php
@@ -177,17 +177,17 @@ class GuidelineAssist
 
     public function nodePackageManagerCommand(string $command): string
     {
-        $configuredNpm = config('boost.commands.npm');
+        $npmExecutable = config('boost.executables.npm');
 
-        if ($configuredNpm !== null) {
-            $nodePackageManagerCommand = $configuredNpm;
-        } elseif ($this->config->usesSail) {
-            $nodePackageManagerCommand = Sail::nodePackageManagerCommand($this->detectedNodePackageManager());
-        } else {
-            $nodePackageManagerCommand = $this->detectedNodePackageManager();
+        if ($npmExecutable !== null) {
+            return "{$npmExecutable} {$command}";
         }
 
-        return "{$nodePackageManagerCommand} {$command}";
+        if ($this->config->usesSail) {
+            return Sail::nodePackageManagerCommand($this->detectedNodePackageManager())." {$command}";
+        }
+
+        return "{$this->detectedNodePackageManager()} {$command}";
     }
 
     public function artisanCommand(string $command): string
@@ -197,25 +197,25 @@ class GuidelineAssist
 
     public function composerCommand(string $command): string
     {
-        $configuredComposer = config('boost.commands.composer');
+        $composerExecutable = config('boost.executables.composer');
 
-        if ($configuredComposer !== null) {
-            $composerCommand = $configuredComposer;
-        } elseif ($this->config->usesSail) {
-            $composerCommand = Sail::composerCommand();
-        } else {
-            $composerCommand = 'composer';
+        if ($composerExecutable !== null) {
+            return "{$composerExecutable} {$command}";
         }
 
-        return "{$composerCommand} {$command}";
+        if ($this->config->usesSail) {
+            return Sail::composerCommand()." {$command}";
+        }
+
+        return "composer {$command}";
     }
 
     public function binCommand(string $command): string
     {
-        $configuredBinPrefix = config('boost.commands.vendor_bin_prefix');
+        $vendorBinPrefix = config('boost.executables.vendor_bin');
 
-        if ($configuredBinPrefix !== null) {
-            return "{$configuredBinPrefix}{$command}";
+        if ($vendorBinPrefix !== null) {
+            return "{$vendorBinPrefix}{$command}";
         }
 
         if ($this->config->usesSail) {
@@ -227,17 +227,15 @@ class GuidelineAssist
 
     public function artisan(): string
     {
-        $configuredPhp = config('boost.commands.php');
+        $phpExecutable = config('boost.executables.php');
 
-        if ($configuredPhp !== null) {
-            return "{$configuredPhp} artisan";
+        if ($phpExecutable !== null) {
+            return "{$phpExecutable} artisan";
         }
 
-        if ($this->config->usesSail) {
-            return Sail::artisanCommand();
-        }
-
-        return 'php artisan';
+        return $this->config->usesSail
+            ? Sail::artisanCommand()
+            : 'php artisan';
     }
 
     public function sailBinaryPath(): string

--- a/tests/Feature/Install/CodeEnvironment/CodeEnvironmentPathResolutionTest.php
+++ b/tests/Feature/Install/CodeEnvironment/CodeEnvironmentPathResolutionTest.php
@@ -7,7 +7,7 @@ use Laravel\Boost\Install\CodeEnvironment\PhpStorm;
 use Laravel\Boost\Install\Detection\DetectionStrategyFactory;
 
 test('PhpStorm returns absolute PHP_BINARY path', function (): void {
-    config(['boost.commands.php' => null]);
+    config(['boost.executables.php' => null]);
     $strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
     $phpStorm = new PhpStorm($strategyFactory);
 
@@ -26,7 +26,7 @@ test('PhpStorm returns absolute artisan path', function (): void {
 });
 
 test('Cursor returns relative php string', function (): void {
-    config(['boost.commands.php' => null]);
+    config(['boost.executables.php' => null]);
     $strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
     $cursor = new Cursor($strategyFactory);
 
@@ -34,7 +34,7 @@ test('Cursor returns relative php string', function (): void {
 });
 
 test('Cursor uses configured default_php_bin when not forcing absolute path', function (): void {
-    config(['boost.commands.php' => '/custom/path/to/php']);
+    config(['boost.executables.php' => '/custom/path/to/php']);
 
     $strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
     $cursor = new Cursor($strategyFactory);
@@ -43,7 +43,7 @@ test('Cursor uses configured default_php_bin when not forcing absolute path', fu
 });
 
 test('Cursor uses config even when forceAbsolutePath is true', function (): void {
-    config(['boost.commands.php' => '/custom/path/to/php']);
+    config(['boost.executables.php' => '/custom/path/to/php']);
 
     $strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
     $cursor = new Cursor($strategyFactory);
@@ -52,7 +52,7 @@ test('Cursor uses config even when forceAbsolutePath is true', function (): void
 });
 
 test('Cursor uses PHP_BINARY when forceAbsolutePath is true and config is empty', function (): void {
-    config(['boost.commands.php' => null]);
+    config(['boost.executables.php' => null]);
 
     $strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
     $cursor = new Cursor($strategyFactory);
@@ -68,7 +68,7 @@ test('Cursor returns relative artisan path', function (): void {
 });
 
 test('CodeEnvironment returns absolute paths when forceAbsolutePath is true and config is empty', function (): void {
-    config(['boost.commands.php' => null]);
+    config(['boost.executables.php' => null]);
     $strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
     $cursor = new Cursor($strategyFactory);
 
@@ -78,7 +78,7 @@ test('CodeEnvironment returns absolute paths when forceAbsolutePath is true and 
 });
 
 test('CodeEnvironment maintains relative paths when forceAbsolutePath is false and config is empty', function (): void {
-    config(['boost.commands.php' => null]);
+    config(['boost.executables.php' => null]);
     $strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
     $cursor = new Cursor($strategyFactory);
 
@@ -87,7 +87,7 @@ test('CodeEnvironment maintains relative paths when forceAbsolutePath is false a
 });
 
 test('PhpStorm paths remain absolute regardless of forceAbsolutePath parameter', function (): void {
-    config(['boost.commands.php' => null]);
+    config(['boost.executables.php' => null]);
     $strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
     $phpStorm = new PhpStorm($strategyFactory);
 
@@ -103,7 +103,7 @@ test('PhpStorm paths remain absolute regardless of forceAbsolutePath parameter',
 });
 
 test('PhpStorm uses config when configured', function (): void {
-    config(['boost.commands.php' => '/custom/php']);
+    config(['boost.executables.php' => '/custom/php']);
     $strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
     $phpStorm = new PhpStorm($strategyFactory);
 

--- a/tests/Unit/Install/CodeEnvironment/CodeEnvironmentTest.php
+++ b/tests/Unit/Install/CodeEnvironment/CodeEnvironmentTest.php
@@ -407,13 +407,13 @@ test('installFileMcp works with existing config file using JSON 5', function ():
 });
 
 test('getPhpPath uses absolute paths when forceAbsolutePath is true and config is empty', function (): void {
-    config(['boost.commands.php' => null]);
+    config(['boost.executables.php' => null]);
     $environment = new TestCodeEnvironment($this->strategyFactory);
     expect($environment->getPhpPath(true))->toBe(PHP_BINARY);
 });
 
 test('getPhpPath maintains default behavior when forceAbsolutePath is false and config is empty', function (): void {
-    config(['boost.commands.php' => null]);
+    config(['boost.executables.php' => null]);
     $environment = new TestCodeEnvironment($this->strategyFactory);
     expect($environment->getPhpPath(false))->toBe('php');
 });
@@ -429,28 +429,28 @@ test('getArtisanPath maintains default behavior when forceAbsolutePath is false'
 });
 
 test('getPhpPath uses configured default_php_bin from config', function (): void {
-    config(['boost.commands.php' => '/usr/local/bin/php8.3']);
+    config(['boost.executables.php' => '/usr/local/bin/php8.3']);
 
     $environment = new TestCodeEnvironment($this->strategyFactory);
     expect($environment->getPhpPath(false))->toBe('/usr/local/bin/php8.3');
 });
 
 test('getPhpPath returns php when config is set to php', function (): void {
-    config(['boost.commands.php' => 'php']);
+    config(['boost.executables.php' => 'php']);
 
     $environment = new TestCodeEnvironment($this->strategyFactory);
     expect($environment->getPhpPath(false))->toBe('php');
 });
 
 test('getPhpPath uses config even when forceAbsolutePath is true', function (): void {
-    config(['boost.commands.php' => '/usr/local/bin/php8.3']);
+    config(['boost.executables.php' => '/usr/local/bin/php8.3']);
 
     $environment = new TestCodeEnvironment($this->strategyFactory);
     expect($environment->getPhpPath(true))->toBe('/usr/local/bin/php8.3');
 });
 
 test('getPhpPath uses PHP_BINARY when forceAbsolutePath is true and config is empty', function (): void {
-    config(['boost.commands.php' => null]);
+    config(['boost.executables.php' => null]);
 
     $environment = new TestCodeEnvironment($this->strategyFactory);
     expect($environment->getPhpPath(true))->toBe(PHP_BINARY);

--- a/tests/Unit/Install/GuidelineAssistTest.php
+++ b/tests/Unit/Install/GuidelineAssistTest.php
@@ -15,41 +15,8 @@ beforeEach(function (): void {
     $this->config = new GuidelineConfig;
 });
 
-test('artisan returns configured default_php_bin when not using Sail', function (): void {
-    config(['boost.commands.php' => '/usr/local/bin/php8.3']);
-    $this->config->usesSail = false;
-
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
-    $assist->shouldAllowMockingProtectedMethods();
-    $assist->shouldReceive('discover')->andReturn([]);
-
-    expect($assist->artisan())->toBe('/usr/local/bin/php8.3 artisan');
-});
-
-test('artisan uses php when config is set to php and not using Sail', function (): void {
-    config(['boost.commands.php' => 'php']);
-    $this->config->usesSail = false;
-
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
-    $assist->shouldAllowMockingProtectedMethods();
-    $assist->shouldReceive('discover')->andReturn([]);
-
-    expect($assist->artisan())->toBe('php artisan');
-});
-
-test('artisan uses config over Sail when config is set', function (): void {
-    config(['boost.commands.php' => '/usr/local/bin/php8.3']);
-    $this->config->usesSail = true;
-
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
-    $assist->shouldAllowMockingProtectedMethods();
-    $assist->shouldReceive('discover')->andReturn([]);
-
-    expect($assist->artisan())->toBe('/usr/local/bin/php8.3 artisan');
-});
-
-test('artisan uses Sail command when usesSail is true and config is empty', function (): void {
-    config(['boost.commands.php' => null]);
+test('php executable falls back to Sail when no config is set', function (): void {
+    config(['boost.executables.php' => null]);
     $this->config->usesSail = true;
 
     $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
@@ -59,41 +26,19 @@ test('artisan uses Sail command when usesSail is true and config is empty', func
     expect($assist->artisan())->toBe(Sail::artisanCommand());
 });
 
-test('composerCommand returns configured default_composer_bin when not using Sail', function (): void {
-    config(['boost.commands.composer' => '/usr/local/bin/composer2']);
-    $this->config->usesSail = false;
-
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
-    $assist->shouldAllowMockingProtectedMethods();
-    $assist->shouldReceive('discover')->andReturn([]);
-
-    expect($assist->composerCommand('install'))->toBe('/usr/local/bin/composer2 install');
-});
-
-test('composerCommand uses composer when config is set to composer and not using Sail', function (): void {
-    config(['boost.commands.composer' => 'composer']);
-    $this->config->usesSail = false;
-
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
-    $assist->shouldAllowMockingProtectedMethods();
-    $assist->shouldReceive('discover')->andReturn([]);
-
-    expect($assist->composerCommand('install'))->toBe('composer install');
-});
-
-test('composerCommand uses config over Sail when config is set', function (): void {
-    config(['boost.commands.composer' => '/usr/local/bin/composer2']);
+test('php executable config takes precedence over Sail', function (): void {
+    config(['boost.executables.php' => '/usr/local/bin/php8.3']);
     $this->config->usesSail = true;
 
     $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
     $assist->shouldAllowMockingProtectedMethods();
     $assist->shouldReceive('discover')->andReturn([]);
 
-    expect($assist->composerCommand('install'))->toBe('/usr/local/bin/composer2 install');
+    expect($assist->artisan())->toBe('/usr/local/bin/php8.3 artisan');
 });
 
-test('composerCommand uses Sail command when usesSail is true and config is empty', function (): void {
-    config(['boost.commands.composer' => null]);
+test('composer executable falls back to Sail when no config is set', function (): void {
+    config(['boost.executables.composer' => null]);
     $this->config->usesSail = true;
 
     $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
@@ -105,41 +50,19 @@ test('composerCommand uses Sail command when usesSail is true and config is empt
     expect($assist->composerCommand('install'))->toBe("{$defaultSailComposer} install");
 });
 
-test('artisanCommand uses configured default_php_bin', function (): void {
-    config(['boost.commands.php' => '/opt/php/bin/php']);
-    $this->config->usesSail = false;
-
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
-    $assist->shouldAllowMockingProtectedMethods();
-    $assist->shouldReceive('discover')->andReturn([]);
-
-    expect($assist->artisanCommand('migrate'))->toBe('/opt/php/bin/php artisan migrate');
-});
-
-test('nodePackageManagerCommand returns configured npm binary when set', function (): void {
-    config(['boost.commands.npm' => '/usr/local/bin/pnpm']);
-    $this->config->usesSail = false;
-
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
-    $assist->shouldAllowMockingProtectedMethods();
-    $assist->shouldReceive('discover')->andReturn([]);
-
-    expect($assist->nodePackageManagerCommand('install'))->toBe('/usr/local/bin/pnpm install');
-});
-
-test('nodePackageManagerCommand uses config over Sail when config is set', function (): void {
-    config(['boost.commands.npm' => '/usr/local/bin/yarn']);
+test('composer executable config takes precedence over Sail', function (): void {
+    config(['boost.executables.composer' => '/usr/local/bin/composer2']);
     $this->config->usesSail = true;
 
     $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
     $assist->shouldAllowMockingProtectedMethods();
     $assist->shouldReceive('discover')->andReturn([]);
 
-    expect($assist->nodePackageManagerCommand('install'))->toBe('/usr/local/bin/yarn install');
+    expect($assist->composerCommand('install'))->toBe('/usr/local/bin/composer2 install');
 });
 
-test('nodePackageManagerCommand uses Sail command when usesSail is true and config is null', function (): void {
-    config(['boost.commands.npm' => null]);
+test('npm executable falls back to Sail when no config is set', function (): void {
+    config(['boost.executables.npm' => null]);
     $this->config->usesSail = true;
 
     $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
@@ -151,8 +74,19 @@ test('nodePackageManagerCommand uses Sail command when usesSail is true and conf
     expect($assist->nodePackageManagerCommand('install'))->toBe("{$expectedCommand} install");
 });
 
-test('nodePackageManagerCommand uses detected package manager when config is null and not using Sail', function (): void {
-    config(['boost.commands.npm' => null]);
+test('npm executable config takes precedence over Sail', function (): void {
+    config(['boost.executables.npm' => '/usr/local/bin/yarn']);
+    $this->config->usesSail = true;
+
+    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
+    $assist->shouldAllowMockingProtectedMethods();
+    $assist->shouldReceive('discover')->andReturn([]);
+
+    expect($assist->nodePackageManagerCommand('install'))->toBe('/usr/local/bin/yarn install');
+});
+
+test('npm executable falls back to npm when no config and no Sail', function (): void {
+    config(['boost.executables.npm' => null]);
     $this->config->usesSail = false;
 
     $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
@@ -162,30 +96,8 @@ test('nodePackageManagerCommand uses detected package manager when config is nul
     expect($assist->nodePackageManagerCommand('install'))->toBe('npm install');
 });
 
-test('binCommand returns configured vendor_bin_prefix when set', function (): void {
-    config(['boost.commands.vendor_bin_prefix' => '/custom/path/']);
-    $this->config->usesSail = false;
-
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
-    $assist->shouldAllowMockingProtectedMethods();
-    $assist->shouldReceive('discover')->andReturn([]);
-
-    expect($assist->binCommand('pint'))->toBe('/custom/path/pint');
-});
-
-test('binCommand uses config over Sail when config is set', function (): void {
-    config(['boost.commands.vendor_bin_prefix' => '/custom/path/']);
-    $this->config->usesSail = true;
-
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
-    $assist->shouldAllowMockingProtectedMethods();
-    $assist->shouldReceive('discover')->andReturn([]);
-
-    expect($assist->binCommand('pint'))->toBe('/custom/path/pint');
-});
-
-test('binCommand uses Sail command when usesSail is true and config is null', function (): void {
-    config(['boost.commands.vendor_bin_prefix' => null]);
+test('vendor bin prefix falls back to Sail when no config is set', function (): void {
+    config(['boost.executables.vendor_bin' => null]);
     $this->config->usesSail = true;
 
     $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
@@ -197,8 +109,19 @@ test('binCommand uses Sail command when usesSail is true and config is null', fu
     expect($assist->binCommand('pint'))->toBe("{$expectedPrefix}pint");
 });
 
-test('binCommand uses vendor/bin when config is null and not using Sail', function (): void {
-    config(['boost.commands.vendor_bin_prefix' => null]);
+test('vendor bin prefix config takes precedence over Sail', function (): void {
+    config(['boost.executables.vendor_bin' => '/custom/path/']);
+    $this->config->usesSail = true;
+
+    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
+    $assist->shouldAllowMockingProtectedMethods();
+    $assist->shouldReceive('discover')->andReturn([]);
+
+    expect($assist->binCommand('pint'))->toBe('/custom/path/pint');
+});
+
+test('vendor bin prefix falls back to vendor/bin when no config and no Sail', function (): void {
+    config(['boost.executables.vendor_bin' => null]);
     $this->config->usesSail = false;
 
     $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();


### PR DESCRIPTION
## Summary

This PR adds support for configurable PHP and Composer binary paths through two new configuration options:
- `boost.default_php_bin` - Configure the PHP binary path (defaults to `php`)
- `boost.default_composer_bin` - Configure the Composer binary path (defaults to `composer`)
- It does not change the existing behaviour in any way unless the new config keys are used

## Motivation

Many developers use containerized or specialized development environments like **Lando**, **DDEV**, **Nix**, **Homebrew**, or custom Docker setups where PHP and Composer binaries are not available at the standard `php` and `composer` paths:
- Lando commands need to be prefixed with `lando` (`lando composer` etc.).
- Running multiple PHP versions side-by-side (`/usr/local/bin/php8.3`) 
- Using Homebrew-installed PHP with non-standard paths
- Working in environments where the system PATH doesn't include the desired PHP/Composer binaries

This feature allows developers to configure their environment and have Boost generate correct commands for their setup.
I did not add these config keys to the `config/boost.php` file as it seems to be the case for other custom config keys. 

## Changes

- **`CodeEnvironment::getPhpPath()`** - Now reads from `config('boost.default_php_bin', 'php')` when not forcing absolute paths
- **`GuidelineAssist::composerCommand()`** - Now reads from `config('boost.default_composer_bin', 'composer')` when not using Sail
- **`GuidelineAssist::artisan()`** - Now uses the configured PHP binary for artisan commands when not using Sail
- Adds tests matching existing patterns to cover the introduced changes

## Usage

Add the following to your `config/boost.php` file:

```php
return [
    // ... existing config

     'commands' => [                                                                                                                                                                                                         
         'php' => env('BOOST_PHP_BIN', 'php'),                                                                                                                                                                               
         'composer' => env('BOOST_COMPOSER_BIN', 'composer'),                                                                                                                                                                
     ],      
];
```

