### PR TITLE
feat: add generic Docker support (without Sail)

### DIFF
--- a/src/Install/Docker.php
+++ b/src/Install/Docker.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install;
+
+use RuntimeException;
+
+class Docker
+{
+    protected ?string $containerName = null;
+
+    /**
+     * Check if Docker Compose is available without Laravel Sail.
+     */
+    public function isAvailableWithoutSail(): bool
+    {
+        $hasSail = file_exists(base_path('vendor'.DIRECTORY_SEPARATOR.'bin'.DIRECTORY_SEPARATOR.'sail'));
+        $hasDockerCompose = file_exists(base_path('docker-compose.yml')) || file_exists(base_path('compose.yaml'));
+
+        return ! $hasSail && $hasDockerCompose;
+    }
+
+    /**
+     * Set the container name to use for Docker commands.
+     */
+    public function setContainerName(string $containerName): self
+    {
+        $this->containerName = $containerName;
+
+        return $this;
+    }
+
+    /**
+     * Get the configured container name.
+     */
+    public function getContainerName(): ?string
+    {
+        return $this->containerName;
+    }
+
+    /**
+     * Check if a container name has been configured.
+     */
+    public function hasContainerName(): bool
+    {
+        return $this->containerName !== null && $this->containerName !== '';
+    }
+
+    /**
+     * Build the MCP command for generic Docker execution.
+     *
+     * @return array<int, string>
+     */
+    public function buildMcpCommand(string $serverName): array
+    {
+        if (! $this->hasContainerName()) {
+            throw new RuntimeException('Docker container name has not been configured.');
+        }
+
+        return [$serverName, 'docker', 'exec', '-i', $this->containerName, 'php', 'artisan', 'boost:mcp'];
+    }
+
+    /**
+     * Build a generic command to run inside the Docker container.
+     */
+    public function command(string $command): string
+    {
+        if (! $this->hasContainerName()) {
+            throw new RuntimeException('Docker container name has not been configured.');
+        }
+
+        return sprintf('docker exec -i %s %s', $this->containerName, $command);
+    }
+
+    /**
+     * Build the artisan command for Docker execution.
+     */
+    public function artisanCommand(): string
+    {
+        return $this->command('php artisan');
+    }
+
+    /**
+     * Build the composer command for Docker execution.
+     */
+    public function composerCommand(): string
+    {
+        return $this->command('composer');
+    }
+}

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -72,6 +72,26 @@ class Config
         return $this->get('sail', false);
     }
 
+    public function setDocker(bool $useDocker): void
+    {
+        $this->set('docker', $useDocker);
+    }
+
+    public function getDocker(): bool
+    {
+        return $this->get('docker', false);
+    }
+
+    public function setDockerContainer(?string $containerName): void
+    {
+        $this->set('docker_container', $containerName);
+    }
+
+    public function getDockerContainer(): ?string
+    {
+        return $this->get('docker_container');
+    }
+
     public function flush(): void
     {
         $path = base_path(self::FILE);


### PR DESCRIPTION
## Summary

This PR adds support for generic Docker Compose setups that don't use Laravel Sail. When `docker-compose.yml` or `compose.yaml` is detected without Sail being installed, the installer now prompts users to configure Boost MCP to run inside a Docker container.

**Problem:** Developers using custom Docker setups (not Laravel Sail) couldn't use Boost MCP effectively because the MCP server runs on the host machine but can't connect to services inside Docker containers (like databases with `DB_HOST=db`).

**Solution:** Similar to the existing Sail support, this PR:
- Detects Docker Compose files when Sail is not present
- Prompts users to configure Docker container execution
- Auto-detects common container names from `docker-compose.yml`
- Configures MCP to run via `docker exec -i <container> php artisan boost:mcp`

## Changes

- **New `Docker.php` class** (`src/Install/Docker.php`): Handles Docker container detection and command building, mirroring the Sail class structure
- **Config persistence** (`src/Support/Config.php`): Added `docker` and `docker_container` settings
- **Install command updates** (`src/Console/InstallCommand.php`):
  - Added Docker detection in `selectBoostFeatures()`
  - Added `shouldConfigureDocker()` confirmation prompt
  - Added `getDockerContainerName()` text input
  - Added `guessContainerName()` to auto-detect from docker-compose.yml
  - Updated `buildMcpCommand()` to use Docker when configured
  - Updated `installGuidelines()` to persist Docker config

## Test plan

- [x] Run existing test suite - all 385 tests pass
- [x] Tested locally with a custom Docker Compose setup (not using Sail)
- [x] Verified MCP can connect to containerized database after configuration
- [ ] Test on fresh project with Docker Compose but without Sail

Related to #429