### PR TITLE
Refactor `RendersBladeGuidelines` namespace and update references

### DIFF
--- a/src/Concerns/RendersBladeGuidelines.php
+++ b/src/Concerns/RendersBladeGuidelines.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Laravel\Boost\Mcp\Prompts\Concerns;
+namespace Laravel\Boost\Concerns;
 
 use Illuminate\Support\Facades\Blade;
 use Laravel\Boost\Install\GuidelineAssist;

--- a/src/Install/GuidelineComposer.php
+++ b/src/Install/GuidelineComposer.php
@@ -6,8 +6,8 @@ namespace Laravel\Boost\Install;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use Laravel\Boost\Concerns\RendersBladeGuidelines;
 use Laravel\Boost\Install\Concerns\DiscoverPackagePaths;
-use Laravel\Boost\Mcp\Prompts\Concerns\RendersBladeGuidelines;
 use Laravel\Boost\Support\Composer;
 use Laravel\Roster\Enums\Packages;
 use Laravel\Roster\Package;

--- a/src/Install/SkillComposer.php
+++ b/src/Install/SkillComposer.php
@@ -6,8 +6,8 @@ namespace Laravel\Boost\Install;
 
 use Exception;
 use Illuminate\Support\Collection;
+use Laravel\Boost\Concerns\RendersBladeGuidelines;
 use Laravel\Boost\Install\Concerns\DiscoverPackagePaths;
-use Laravel\Boost\Mcp\Prompts\Concerns\RendersBladeGuidelines;
 use Laravel\Boost\Support\Composer;
 use Laravel\Roster\Roster;
 use Symfony\Component\Yaml\Yaml;

--- a/src/Install/SkillWriter.php
+++ b/src/Install/SkillWriter.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Laravel\Boost\Install;
 
 use Illuminate\Support\Collection;
+use Laravel\Boost\Concerns\RendersBladeGuidelines;
 use Laravel\Boost\Contracts\SupportsSkills;
-use Laravel\Boost\Mcp\Prompts\Concerns\RendersBladeGuidelines;
 use RuntimeException;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;

--- a/src/Mcp/Prompts/LaravelCodeSimplifier/LaravelCodeSimplifier.php
+++ b/src/Mcp/Prompts/LaravelCodeSimplifier/LaravelCodeSimplifier.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Mcp\Prompts\LaravelCodeSimplifier;
 
-use Laravel\Boost\Mcp\Prompts\Concerns\RendersBladeGuidelines;
+use Laravel\Boost\Concerns\RendersBladeGuidelines;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Prompt;
 

--- a/src/Mcp/Prompts/PackageGuidelinePrompt.php
+++ b/src/Mcp/Prompts/PackageGuidelinePrompt.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Mcp\Prompts;
 
-use Laravel\Boost\Mcp\Prompts\Concerns\RendersBladeGuidelines;
+use Laravel\Boost\Concerns\RendersBladeGuidelines;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Prompt;
 

--- a/src/Mcp/Prompts/UpgradeLivewirev4/UpgradeLivewireV4.php
+++ b/src/Mcp/Prompts/UpgradeLivewirev4/UpgradeLivewireV4.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Mcp\Prompts\UpgradeLivewirev4;
 
-use Laravel\Boost\Mcp\Prompts\Concerns\RendersBladeGuidelines;
+use Laravel\Boost\Concerns\RendersBladeGuidelines;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Prompt;
 use Laravel\Roster\Enums\Packages;

--- a/src/Mcp/Resources/PackageGuidelineResource.php
+++ b/src/Mcp/Resources/PackageGuidelineResource.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Mcp\Resources;
 
-use Laravel\Boost\Mcp\Prompts\Concerns\RendersBladeGuidelines;
+use Laravel\Boost\Concerns\RendersBladeGuidelines;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Resource;
 

--- a/tests/Unit/Concerns/RendersBladeGuidelinesTest.php
+++ b/tests/Unit/Concerns/RendersBladeGuidelinesTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Concerns\RendersBladeGuidelines;
+use Laravel\Boost\Install\GuidelineAssist;
+
+beforeEach(function (): void {
+    $this->renderer = new class
+    {
+        use RendersBladeGuidelines;
+
+        public function processSnippets(string $content): string
+        {
+            return $this->processBoostSnippets($content);
+        }
+
+        public function render(string $content, string $path): string
+        {
+            return $this->renderContent($content, $path);
+        }
+
+        public function renderFile(string $bladePath): string
+        {
+            return $this->renderBladeFile($bladePath);
+        }
+
+        public function getStoredSnippets(): array
+        {
+            return $this->storedSnippets;
+        }
+    };
+});
+
+test('boostsnippet directive extracts name and content into code-snippet xml', function (): void {
+    $content = "@boostsnippet('Authentication Example')return Auth::user();@endboostsnippet";
+
+    $result = $this->renderer->processSnippets($content);
+
+    expect($result)->toBe('___BOOST_SNIPPET_0___');
+
+    $snippet = $this->renderer->getStoredSnippets()['___BOOST_SNIPPET_0___'];
+    expect($snippet)
+        ->toContain('<code-snippet name="Authentication Example" lang="html">')
+        ->toContain('return Auth::user();')
+        ->toContain('</code-snippet>');
+});
+
+test('boostsnippet supports double quotes for name parameter', function (): void {
+    $content = '@boostsnippet("Double Quoted")code@endboostsnippet';
+
+    $this->renderer->processSnippets($content);
+
+    expect($this->renderer->getStoredSnippets()['___BOOST_SNIPPET_0___'])
+        ->toContain('name="Double Quoted"');
+});
+
+test('boostsnippet uses specified language in code-snippet output', function (): void {
+    $content = "@boostsnippet('PHP Example', 'php')\$user = User::find(1);@endboostsnippet";
+
+    $this->renderer->processSnippets($content);
+
+    expect($this->renderer->getStoredSnippets()['___BOOST_SNIPPET_0___'])
+        ->toContain('lang="php"')
+        ->toContain('$user = User::find(1);');
+});
+
+test('multiple boostsnippets are replaced with sequential placeholders', function (): void {
+    $content = "@boostsnippet('First')code1@endboostsnippet between @boostsnippet('Second', 'js')code2@endboostsnippet";
+
+    $result = $this->renderer->processSnippets($content);
+
+    expect($result)->toBe('___BOOST_SNIPPET_0___ between ___BOOST_SNIPPET_1___')
+        ->and($this->renderer->getStoredSnippets())->toHaveCount(2)
+        ->and($this->renderer->getStoredSnippets()['___BOOST_SNIPPET_1___'])->toContain('lang="js"');
+});
+
+test('escaped boostsnippet directive is not processed', function (): void {
+    $content = "@@boostsnippet('Escaped')content@@endboostsnippet";
+
+    $result = $this->renderer->processSnippets($content);
+
+    expect($result)->toBe($content)
+        ->and($this->renderer->getStoredSnippets())->toBeEmpty();
+});
+
+test('boostsnippet preserves multiline content', function (): void {
+    $content = "@boostsnippet('Multiline')\$user = User::find(1);\n\$user->name = 'John';\n\$user->save();@endboostsnippet";
+
+    $this->renderer->processSnippets($content);
+
+    expect($this->renderer->getStoredSnippets()['___BOOST_SNIPPET_0___'])
+        ->toContain("\$user = User::find(1);\n\$user->name = 'John';\n\$user->save();");
+});
+
+test('non-blade files bypass blade rendering entirely', function (): void {
+    $bladeContent = '{{ $variable }} @if(true) test @endif';
+
+    $result = $this->renderer->render($bladeContent, '/path/to/readme.md');
+
+    expect($result)->toBe($bladeContent);
+});
+
+test('backticks are preserved through blade rendering for inline code documentation', function (): void {
+    $this->mock(GuidelineAssist::class);
+
+    $content = 'Run `composer install` then `php artisan migrate`';
+
+    $result = $this->renderer->render($content, '/path/to/guide.blade.php');
+
+    expect($result)->toContain('`composer install`')
+        ->toContain('`php artisan migrate`');
+});
+
+test('php opening tags are preserved through blade rendering for code examples', function (): void {
+    $this->mock(GuidelineAssist::class);
+
+    $content = 'Example: <?php echo $greeting; ?>';
+
+    $result = $this->renderer->render($content, '/path/to/guide.blade.php');
+
+    expect($result)->toContain('<?php');
+});
+
+test('volt directives are preserved through blade rendering for livewire documentation', function (): void {
+    $this->mock(GuidelineAssist::class);
+
+    $content = '@volt("counter") component code @endvolt';
+
+    $result = $this->renderer->render($content, '/path/to/guide.blade.php');
+
+    expect($result)->toContain('@volt')
+        ->toContain('@endvolt');
+});
+
+test('renderBladeFile returns empty string for non-existent file', function (): void {
+    $result = $this->renderer->renderFile('/non/existent/guideline.blade.php');
+
+    expect($result)->toBe('');
+});
+
+test('renderBladeFile processes snippets and renders blade in single pipeline', function (): void {
+    $this->mock(GuidelineAssist::class);
+
+    $tempFile = sys_get_temp_dir().'/boost_test_'.uniqid().'.blade.php';
+    file_put_contents($tempFile, "@boostsnippet('Query', 'php')User::all()@endboostsnippet\n\nVersion: {{ \"1.0\" }}");
+
+    try {
+        $result = $this->renderer->renderFile($tempFile);
+
+        expect($result)
+            ->toContain('<code-snippet name="Query" lang="php">')
+            ->toContain('User::all()')
+            ->toContain('</code-snippet>')
+            ->toContain('Version: 1.0');
+    } finally {
+        @unlink($tempFile);
+    }
+});
+
+test('renderBladeFile clears stored snippets after rendering to prevent leakage between files', function (): void {
+    $this->mock(GuidelineAssist::class);
+
+    $tempFile = sys_get_temp_dir().'/boost_test_'.uniqid().'.blade.php';
+    file_put_contents($tempFile, "@boostsnippet('Test')content@endboostsnippet");
+
+    try {
+        $this->renderer->renderFile($tempFile);
+
+        expect($this->renderer->getStoredSnippets())->toBeEmpty();
+    } finally {
+        @unlink($tempFile);
+    }
+});


### PR DESCRIPTION
Refactored the `RendersBladeGuidelines` namespace to because it's now being used everywhere in project and not just `Prompts/`

This change does not introduce any breaking changes