### PR TITLE
Add validation UpdateCommand to handle errors

### DIFF
--- a/src/Console/UpdateCommand.php
+++ b/src/Console/UpdateCommand.php
@@ -11,13 +11,19 @@ use Symfony\Component\Console\Attribute\AsCommand;
 #[AsCommand('boost:update', 'Update the Laravel Boost guidelines & skills to the latest guidance')]
 class UpdateCommand extends Command
 {
-    public function handle(Config $config): void
+    public function handle(Config $config): int
     {
+        if (! $config->isValid() || empty($config->getAgents())) {
+            $this->error('Please set up Boost with [php artisan boost:install] first.');
+
+            return self::FAILURE;
+        }
+
         $guidelines = $config->getGuidelines();
         $hasSkills = $config->hasSkills();
 
         if (! $guidelines && ! $hasSkills) {
-            return;
+            return self::SUCCESS;
         }
 
         $this->callSilently(InstallCommand::class, [
@@ -26,6 +32,8 @@ class UpdateCommand extends Command
             '--skills' => $hasSkills,
         ]);
 
-        $this->components->info('Boost guidelines and skills updated successfully.');
+        $this->info('Boost guidelines and skills updated successfully.');
+
+        return self::SUCCESS;
     }
 }

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -103,6 +103,19 @@ class Config
         return $this->get('sail', false);
     }
 
+    public function isValid(): bool
+    {
+        $path = base_path(self::FILE);
+
+        if (! file_exists($path)) {
+            return false;
+        }
+
+        json_decode(file_get_contents($path), true);
+
+        return json_last_error() === JSON_ERROR_NONE;
+    }
+
     public function flush(): void
     {
         $path = base_path(self::FILE);

--- a/tests/Feature/Console/UpdateCommandTest.php
+++ b/tests/Feature/Console/UpdateCommandTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Console\OutputStyle;
+use Laravel\Boost\Console\InstallCommand;
+use Laravel\Boost\Console\UpdateCommand;
+use Laravel\Boost\Support\Config;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+beforeEach(function (): void {
+    (new Config)->flush();
+});
+
+afterEach(function (): void {
+    (new Config)->flush();
+});
+
+it('it shows an error when boost.json does not exist', function (): void {
+    $this->artisan('boost:update')
+        ->expectsOutputToContain('Please set up Boost with [php artisan boost:install] first.')
+        ->assertFailed();
+});
+
+it('it shows an error when boost.json contains invalid json', function (): void {
+    file_put_contents(base_path('boost.json'), 'invalid json {{{');
+
+    $this->artisan('boost:update')
+        ->expectsOutputToContain('Please set up Boost with [php artisan boost:install] first.')
+        ->assertFailed();
+});
+
+it('it shows an error when agents are empty', function (): void {
+    $config = new Config;
+    $config->setGuidelines(true);
+
+    $this->artisan('boost:update')
+        ->expectsOutputToContain('Please set up Boost with [php artisan boost:install] first.')
+        ->assertFailed();
+});
+
+it('exits silently when no guidelines and no skills are configured', function (): void {
+    $config = new Config;
+    $config->setAgents(['claude-code']);
+    $config->setGuidelines(false);
+    $config->setSkills([]);
+
+    $this->artisan('boost:update')
+        ->doesntExpectOutputToContain('Boost guidelines and skills updated successfully.')
+        ->assertSuccessful();
+});
+
+it('calls install command with a guidelines flag when guidelines are enabled', function (): void {
+    $config = new Config;
+    $config->setAgents(['claude-code']);
+    $config->setGuidelines(true);
+    $config->setSkills([]);
+
+    $command = Mockery::mock(UpdateCommand::class)->makePartial();
+    $command->shouldReceive('callSilently')
+        ->once()
+        ->with(InstallCommand::class, [
+            '--no-interaction' => true,
+            '--guidelines' => true,
+            '--skills' => false,
+        ])
+        ->andReturn(0);
+
+    $input = new ArrayInput([]);
+    $output = new OutputStyle($input, new BufferedOutput);
+
+    $command->setLaravel($this->app);
+    $command->setOutput($output);
+
+    expect($command->handle($config))->toBe(0);
+});
+
+it('calls install command with skills flag when skills are configured', function (): void {
+    $config = new Config;
+    $config->setAgents(['claude-code']);
+    $config->setGuidelines(false);
+    $config->setSkills(['test-skill']);
+
+    $command = Mockery::mock(UpdateCommand::class)->makePartial();
+    $command->shouldReceive('callSilently')
+        ->once()
+        ->with(InstallCommand::class, [
+            '--no-interaction' => true,
+            '--guidelines' => false,
+            '--skills' => true,
+        ])
+        ->andReturn(0);
+
+    $input = new ArrayInput([]);
+    $output = new OutputStyle($input, new BufferedOutput);
+
+    $command->setLaravel($this->app);
+    $command->setOutput($output);
+
+    expect($command->handle($config))->toBe(0);
+});
+
+it('calls install command with both flags when guidelines and skills are enabled', function (): void {
+    $config = new Config;
+    $config->setAgents(['claude-code']);
+    $config->setGuidelines(true);
+    $config->setSkills(['test-skill']);
+
+    $command = Mockery::mock(UpdateCommand::class)->makePartial();
+    $command->shouldReceive('callSilently')
+        ->once()
+        ->with(InstallCommand::class, [
+            '--no-interaction' => true,
+            '--guidelines' => true,
+            '--skills' => true,
+        ])
+        ->andReturn(0);
+
+    $input = new ArrayInput([]);
+    $output = new OutputStyle($input, new BufferedOutput);
+
+    $command->setLaravel($this->app);
+    $command->setOutput($output);
+
+    expect($command->handle($config))->toBe(0);
+});


### PR DESCRIPTION
### Problem

Running `php artisan boost:update` without a valid `boost.json` configuration would either fail silently or throw an unhelpful error, leaving users confused about what went wrong.

### Solution

Added an `isValid()` method to the `Config` class that checks if `boost.json` exists and contains valid JSON. The `UpdateCommand` now validates the config before proceeding and returns a clear error message:

```
Please set up Boost with [php artisan boost:install] first.
```
