### PR TITLE
Use skills directory instead of skill for OpenCode

### DIFF
--- a/src/Install/Agents/OpenCode.php
+++ b/src/Install/Agents/OpenCode.php
@@ -82,6 +82,6 @@ class OpenCode extends Agent implements SupportsGuidelines, SupportsMcp, Support
 
     public function skillsPath(): string
     {
-        return config('boost.agents.opencode.skills_path', '.opencode/skill');
+        return config('boost.agents.opencode.skills_path', '.opencode/skills');
     }
 }


### PR DESCRIPTION
OpenCode expects its skill files to be in the `.opencode/skills` directory. See https://opencode.ai/docs/skills/#place-files