### PR TITLE
Sort user guidelines by filename for predictable ordering

### DIFF
--- a/src/Install/GuidelineComposer.php
+++ b/src/Install/GuidelineComposer.php
@@ -225,7 +225,8 @@ class GuidelineComposer
                 ->in($dirPath)
                 ->exclude('skill')
                 ->name('*.blade.php')
-                ->name('*.md');
+                ->name('*.md')
+                ->sortByName();
         } catch (DirectoryNotFoundException) {
             return [];
         }

--- a/tests/Feature/Install/GuidelineComposerTest.php
+++ b/tests/Feature/Install/GuidelineComposerTest.php
@@ -712,3 +712,26 @@ test('includes enabled conditional guidelines and orders them before packages', 
         ->and($testsPos)->toBeGreaterThan($foundationPos)
         ->and($testsPos)->toBeLessThan($pestPos);
 });
+
+test('user guidelines are sorted by filename for predictable ordering', function (): void {
+    $packages = new PackageCollection([
+        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+    ]);
+
+    $this->roster->shouldReceive('packages')->andReturn($packages);
+
+    $composer = Mockery::mock(GuidelineComposer::class, [$this->roster, $this->herd])->makePartial();
+    $composer
+        ->shouldReceive('customGuidelinePath')
+        ->andReturnUsing(fn ($path = ''): string => realpath(testDirectory('Fixtures/.ai/sorted-guidelines')).'/'.ltrim((string) $path, '/'));
+
+    $guidelines = $composer->guidelines();
+    $keys = $guidelines->keys()->toArray();
+
+    // Get the positions of our test guidelines
+    $userGuidelineKeys = collect($keys)->filter(fn ($key): bool => str_starts_with((string) $key, '.ai/'))->values()->toArray();
+
+    // Files should be sorted alphabetically by filename:
+    // 00-first.md, 10-middle.md, 20-second.md
+    expect($userGuidelineKeys)->toBe(['.ai/00-first', '.ai/10-middle', '.ai/20-second']);
+});

--- a/tests/Fixtures/.ai/sorted-guidelines/00-first.md
+++ b/tests/Fixtures/.ai/sorted-guidelines/00-first.md
@@ -1,0 +1,3 @@
+# First Guidelines
+
+This should appear first in the sorted output.

--- a/tests/Fixtures/.ai/sorted-guidelines/10-middle.md
+++ b/tests/Fixtures/.ai/sorted-guidelines/10-middle.md
@@ -1,0 +1,3 @@
+# Middle Guidelines
+
+This should appear in the middle of the sorted output.

--- a/tests/Fixtures/.ai/sorted-guidelines/20-second.md
+++ b/tests/Fixtures/.ai/sorted-guidelines/20-second.md
@@ -1,0 +1,3 @@
+# Second Guidelines
+
+This should appear second in the sorted output.


### PR DESCRIPTION
I have been weighting my guidelines by filename `10-project.md`, `20-frontend.md` etc to give priority to the LLM.

Symfony's finder seems to let the OS decide which order the files are returned. My MacOS setup is returning the by last modified by default, which is changing the order whenever I update. 

This PR sorts the files by name before writing the agent files.