### PR TITLE
add Laravel Valet support

### DIFF
--- a/.ai/valet/core.blade.php
+++ b/.ai/valet/core.blade.php
@@ -1,0 +1,5 @@
+# Laravel Valet
+
+- This project runs under Laravel Valet. Prefix PHP and Artisan commands with `valet php`.
+- Run Composer commands through Valet, for example: `valet composer update`.
+- Example Artisan command: `valet php artisan migrate`.

--- a/src/Install/GuidelineAssist.php
+++ b/src/Install/GuidelineAssist.php
@@ -202,9 +202,13 @@ class GuidelineAssist
 
     public function composerCommand(string $command): string
     {
-        $composerCommand = $this->config->usesSail
-            ? Sail::composerCommand()
-            : 'composer';
+        if ($this->config->usesSail) {
+            $composerCommand = Sail::composerCommand();
+        } elseif ($this->config->usesValet) {
+            $composerCommand = 'valet composer';
+        } else {
+            $composerCommand = 'composer';
+        }
 
         return "{$composerCommand} {$command}";
     }
@@ -218,9 +222,15 @@ class GuidelineAssist
 
     public function artisan(): string
     {
-        return $this->config->usesSail
-            ? Sail::artisanCommand()
-            : 'php artisan';
+        if ($this->config->usesSail) {
+            return Sail::artisanCommand();
+        }
+
+        if ($this->config->usesValet) {
+            return 'valet php artisan';
+        }
+
+        return 'php artisan';
     }
 
     public function sailBinaryPath(): string

--- a/src/Install/GuidelineComposer.php
+++ b/src/Install/GuidelineComposer.php
@@ -145,6 +145,10 @@ class GuidelineComposer
                 'condition' => $this->config->usesSail,
                 'path' => 'sail/core',
             ],
+            'valet' => [
+                'condition' => $this->config->usesValet,
+                'path' => 'valet/core',
+            ],
             'laravel/style' => [
                 'condition' => $this->config->laravelStyle,
                 'path' => 'laravel/style',

--- a/src/Install/GuidelineConfig.php
+++ b/src/Install/GuidelineConfig.php
@@ -12,6 +12,8 @@ class GuidelineConfig
 
     public bool $usesSail = false;
 
+    public bool $usesValet = false;
+
     public bool $caresAboutLocalization = false;
 
     public bool $hasAnApi = false;

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -103,6 +103,16 @@ class Config
         return $this->get('sail', false);
     }
 
+    public function setValet(bool $useValet): void
+    {
+        $this->set('valet', $useValet);
+    }
+
+    public function getValet(): bool
+    {
+        return $this->get('valet', false);
+    }
+
     public function isValid(): bool
     {
         $path = base_path(self::FILE);

--- a/tests/Feature/Install/GuidelineComposerTest.php
+++ b/tests/Feature/Install/GuidelineComposerTest.php
@@ -157,6 +157,24 @@ test('excludes Sail guidelines when Herd is configured', function (): void {
         ->not->toContain('Laravel Sail');
 });
 
+test('includes Valet guidelines when configured', function (): void {
+    $packages = new PackageCollection([
+        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+    ]);
+
+    $this->roster->shouldReceive('packages')->andReturn($packages);
+
+    $config = new GuidelineConfig;
+    $config->usesValet = true;
+
+    $guidelines = $this->composer
+        ->config($config)
+        ->compose();
+
+    expect($guidelines)
+        ->toContain('Laravel Valet');
+});
+
 test('composes guidelines with proper formatting', function (): void {
     $packages = new PackageCollection([
         new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),

--- a/tests/Unit/Support/ConfigTest.php
+++ b/tests/Unit/Support/ConfigTest.php
@@ -49,6 +49,20 @@ it('may store and retrieve herd mcp installation status', function (): void {
     expect($config->getHerdMcp())->toBeFalse();
 });
 
+it('may store and retrieve valet status', function (): void {
+    $config = new Config;
+
+    expect($config->getValet())->toBeFalse();
+
+    $config->setValet(true);
+
+    expect($config->getValet())->toBeTrue();
+
+    $config->setValet(false);
+
+    expect($config->getValet())->toBeFalse();
+});
+
 it('may store and retrieve skills as an array', function (): void {
     $config = new Config;
 


### PR DESCRIPTION
Laravel Valet support, determined by question during install. Extends Laravel Sail dynamic artisan/composer command generation.

I saw some PRs about adding composer/php binary paths, but it seemed cleaner to me just add first party support for Laravel Valet similar to Laravel Sail's implementation. Albeit with the confirmation question, as a per-project basis, has nothing to determine if Laravel Valet is being used.

Changes:
- Introduce Valet-specific guideline configurations.
- Update commands to recognize Valet for composer and artisan.
- Extend tests to verify Valet functionality.
- Add `usesValet` property across relevant classes.
- Update `Config` to manage Valet settings.