### PR TITLE
Exclude Livewire skills and guidelines for indirect dependencies (#477)

### DIFF
--- a/src/Install/Concerns/DiscoverPackagePaths.php
+++ b/src/Install/Concerns/DiscoverPackagePaths.php
@@ -19,6 +19,7 @@ trait DiscoverPackagePaths
      * */
     protected array $mustBeDirect = [
         Packages::MCP,
+        Packages::LIVEWIRE,
     ];
 
     /**

--- a/tests/Feature/Install/GuidelineComposerTest.php
+++ b/tests/Feature/Install/GuidelineComposerTest.php
@@ -355,6 +355,28 @@ test('includes laravel/mcp guidelines when directly required', function (): void
         ->not->toContain('Mcp::web');
 });
 
+test('excludes livewire guidelines when indirectly required', function (): void {
+    $packages = new PackageCollection([
+        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        (new Package(Packages::LIVEWIRE, 'livewire/livewire', '3.0.0'))->setDirect(false),
+    ]);
+
+    $this->roster->shouldReceive('packages')->andReturn($packages);
+
+    expect($this->composer->compose())->not->toContain('=== livewire/core rules ===');
+});
+
+test('includes livewire guidelines when directly required', function (): void {
+    $packages = new PackageCollection([
+        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        (new Package(Packages::LIVEWIRE, 'livewire/livewire', '3.0.0'))->setDirect(true),
+    ]);
+
+    $this->roster->shouldReceive('packages')->andReturn($packages);
+
+    expect($this->composer->compose())->toContain('=== livewire/core rules ===');
+});
+
 test('includes PHPUnit guidelines when Pest is not present', function (): void {
     $packages = new PackageCollection([
         new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),

--- a/tests/Feature/Install/SkillComposerTest.php
+++ b/tests/Feature/Install/SkillComposerTest.php
@@ -22,7 +22,7 @@ beforeEach(function (): void {
 test('skills return a collection keyed by skill name', function (): void {
     $packages = new PackageCollection([
         new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::LIVEWIRE, 'livewire/livewire', '3.0.0'),
+        (new Package(Packages::LIVEWIRE, 'livewire/livewire', '3.0.0'))->setDirect(true),
     ]);
 
     $this->roster->shouldReceive('packages')->andReturn($packages);
@@ -37,7 +37,7 @@ test('skills return a collection keyed by skill name', function (): void {
 test('skills are discovered from Boost built-in .ai directory', function (): void {
     $packages = new PackageCollection([
         new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::LIVEWIRE, 'livewire/livewire', '3.0.0'),
+        (new Package(Packages::LIVEWIRE, 'livewire/livewire', '3.0.0'))->setDirect(true),
     ]);
 
     $this->roster->shouldReceive('packages')->andReturn($packages);
@@ -62,7 +62,7 @@ test('skills only includes skills for installed packages', function (): void {
 test('skill has name, description, path, and package', function (): void {
     $packages = new PackageCollection([
         new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::LIVEWIRE, 'livewire/livewire', '3.0.0'),
+        (new Package(Packages::LIVEWIRE, 'livewire/livewire', '3.0.0'))->setDirect(true),
     ]);
 
     $this->roster->shouldReceive('packages')->andReturn($packages);
@@ -101,4 +101,30 @@ test('config change clears skills cache', function (): void {
     $composer->config(new GuidelineConfig);
 
     expect($composer->skills())->not->toBe($first);
+});
+
+test('excludes livewire skills when indirectly required', function (): void {
+    $packages = new PackageCollection([
+        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        (new Package(Packages::LIVEWIRE, 'livewire/livewire', '3.0.0'))->setDirect(false),
+    ]);
+
+    $this->roster->shouldReceive('packages')->andReturn($packages);
+
+    $skills = (new SkillComposer($this->roster))->skills();
+
+    expect($skills->has('livewire-development'))->toBeFalse();
+});
+
+test('includes livewire skills when directly required', function (): void {
+    $packages = new PackageCollection([
+        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        (new Package(Packages::LIVEWIRE, 'livewire/livewire', '3.0.0'))->setDirect(true),
+    ]);
+
+    $this->roster->shouldReceive('packages')->andReturn($packages);
+
+    $skills = (new SkillComposer($this->roster))->skills();
+
+    expect($skills->has('livewire-development'))->toBeTrue();
 });


### PR DESCRIPTION
  ## Summary

  Fixes #477

  This PR adds `Packages::LIVEWIRE` to the `$mustBeDirect` array, ensuring that Livewire skills and guidelines are
  only included when Livewire is explicitly listed in the user's `composer.json`.

  ### Problem

  When a user installs a package like `laravel/pulse` that depends on Livewire as a transitive dependency, Boost was
  incorrectly including Livewire-specific skills and guidelines. This clutters the AI context with irrelevant
  information for users who aren't directly using Livewire.

  ### Solution

  Added Livewire to the existing `$mustBeDirect` mechanism (same approach used for `laravel/mcp`), so its
  skills/guidelines are only included when Livewire is a direct dependency.

  ### Changes

  - Added `Packages::LIVEWIRE` to `$mustBeDirect` array in `DiscoverPackagePaths.php`
  - Added tests for both `SkillComposer` and `GuidelineComposer` to verify indirect Livewire dependencies are excluded
  - Updated existing tests to explicitly mark Livewire as direct dependency where needed

  ### Benefit to End Users

  Users who install packages with Livewire as a transitive dependency (e.g., Laravel Pulse) will no longer receive
  Livewire-specific AI guidelines, resulting in cleaner, more relevant AI context.

  ### No Breaking Changes

  - Users who directly require `livewire/livewire` in their `composer.json` will continue to receive Livewire
  skills/guidelines as before
  - Only affects indirect/transitive dependencies

  ---

  ## Future Consideration

  The current `$mustBeDirect` approach requires manual code changes for each package. For a more scalable solution,
  consider one of these approaches:

  **Option 1: Default all packages to direct-only**
  ```php
  // Flip the logic - exclude ALL indirect packages by default
  return $package->indirect();

  Option 2: User-configurable via boost.json
  {
      "directOnly": ["livewire/livewire", "laravel/mcp"],
      "includeIndirect": ["some-package/i-want-anyway"]
  }

  Option 3: Opt-in for transitive dependencies
  {
      "includeTransitive": false,
      "allowTransitive": ["specific/package"]
  }

  This would give users control without requiring code changes for each new commonly-transitive package.
  ```