### PR TITLE
add `boost:rm-skill` command to remove installed skills

### DIFF
--- a/src/BoostServiceProvider.php
+++ b/src/BoostServiceProvider.php
@@ -107,6 +107,7 @@ class BoostServiceProvider extends ServiceProvider
                 Console\UpdateCommand::class,
                 Console\ExecuteToolCommand::class,
                 Console\AddSkillCommand::class,
+                Console\RemoveSkillCommand::class,
             ]);
         }
     }

--- a/src/Console/RemoveSkillCommand.php
+++ b/src/Console/RemoveSkillCommand.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Laravel\Boost\Concerns\DisplayHelper;
+use Laravel\Prompts\Terminal;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\multiselect;
+use function Laravel\Prompts\spin;
+
+class RemoveSkillCommand extends Command
+{
+    use DisplayHelper;
+
+    /** @var string */
+    protected $signature = 'boost:rm-skill
+        {skills?* : The names of the skills to remove}
+        {--force : Force removal without confirmation}';
+
+    /** @var string */
+    protected $description = 'Remove installed skills';
+
+    protected string $defaultSkillsPath = '.ai/skills';
+
+    public function __construct(private readonly Terminal $terminal)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $this->displayHeader();
+
+        $skillNames = $this->argument('skills');
+
+        if (empty($skillNames)) {
+            $skillNames = $this->promptForSkills();
+        }
+
+        if (empty($skillNames)) {
+            $this->warn('No skills selected.');
+
+            return self::SUCCESS;
+        }
+
+        $validSkills = $this->validateSkills($skillNames);
+
+        if ($validSkills === []) {
+            $this->error('No valid skills to remove.');
+
+            return self::FAILURE;
+        }
+
+        if (! $this->confirmRemoval($validSkills)) {
+            return self::SUCCESS;
+        }
+
+        return $this->removeSkills($validSkills);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function promptForSkills(): array
+    {
+        $skillsPath = base_path($this->defaultSkillsPath);
+
+        if (! File::exists($skillsPath)) {
+            $this->error('No skills directory found.');
+
+            return [];
+        }
+
+        $skills = collect(File::directories($skillsPath))
+            ->map(fn (string $path): string => basename($path))
+            ->mapWithKeys(fn (string $name): array => [$name => $name])
+            ->all();
+
+        if (empty($skills)) {
+            $this->error('No skills installed.');
+
+            return [];
+        }
+
+        return multiselect(
+            label: 'Which skills would you like to remove?',
+            options: $skills,
+            required: true
+        );
+    }
+
+    /**
+     * @param  array<int, string>  $skillNames
+     * @return array<int, string>
+     */
+    protected function validateSkills(array $skillNames): array
+    {
+        $validSkills = [];
+
+        foreach ($skillNames as $name) {
+            $skillPath = base_path($this->defaultSkillsPath.DIRECTORY_SEPARATOR.$name);
+
+            if (File::exists($skillPath)) {
+                $validSkills[] = $name;
+            } else {
+                $this->warn("Skill '{$name}' not found.");
+            }
+        }
+
+        return $validSkills;
+    }
+
+    /**
+     * @param  array<int, string>  $skills
+     */
+    protected function confirmRemoval(array $skills): bool
+    {
+        if ($this->option('force')) {
+            return true;
+        }
+
+        $count = count($skills);
+        $skillList = implode(', ', $skills);
+        $label = $count === 1
+            ? "Are you sure you want to remove the '{$skills[0]}' skill?"
+            : "Are you sure you want to remove these {$count} skills? ({$skillList})";
+
+        if (! confirm($label)) {
+            $this->info('Removal cancelled.');
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  array<int, string>  $skills
+     */
+    protected function removeSkills(array $skills): int
+    {
+        $removed = [];
+        $failed = [];
+
+        foreach ($skills as $name) {
+            $skillPath = base_path($this->defaultSkillsPath.DIRECTORY_SEPARATOR.$name);
+
+            $success = spin(
+                callback: fn () => File::deleteDirectory($skillPath),
+                message: "Removing skill '{$name}'..."
+            );
+
+            if ($success) {
+                $removed[] = $name;
+            } else {
+                $failed[] = $name;
+                $this->error("Failed to remove skill '{$name}'.");
+            }
+        }
+
+        if ($removed !== []) {
+            $this->info('Skills removed: '.implode(', ', $removed));
+            $this->runBoostUpdate();
+            $this->displayOutro('Enjoy the boost 🚀', terminalWidth: $this->terminal->cols());
+        }
+
+        return $failed === [] ? self::SUCCESS : self::FAILURE;
+    }
+
+    protected function displayHeader(): void
+    {
+        $this->terminal->initDimensions();
+        $this->displayBoostHeader('Skill', config('app.name'));
+    }
+
+    protected function runBoostUpdate(): void
+    {
+        $this->callSilently(UpdateCommand::class);
+    }
+}

--- a/tests/Feature/Console/RemoveSkillCommandTest.php
+++ b/tests/Feature/Console/RemoveSkillCommandTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+use Orchestra\Testbench\Concerns\InteractsWithPublishedFiles;
+
+uses(InteractsWithPublishedFiles::class);
+
+beforeEach(function (): void {
+    File::deleteDirectory(base_path('.ai/skills'));
+    File::ensureDirectoryExists(base_path('.ai/skills/skill-one'));
+    File::put(base_path('.ai/skills/skill-one/SKILL.md'), 'content');
+    File::ensureDirectoryExists(base_path('.ai/skills/skill-two'));
+    File::put(base_path('.ai/skills/skill-two/SKILL.md'), 'content');
+});
+
+it('removes a single skill with confirmation', function (): void {
+    $this->artisan('boost:rm-skill', ['skills' => ['skill-one']])
+        ->expectsConfirmation("Are you sure you want to remove the 'skill-one' skill?", 'yes')
+        ->expectsOutput('Skills removed: skill-one')
+        ->assertSuccessful();
+
+    $this->assertFilenameNotExists('.ai/skills/skill-one');
+    $this->assertFilenameExists('.ai/skills/skill-two');
+});
+
+it('removes multiple skills with confirmation', function (): void {
+    $this->artisan('boost:rm-skill', ['skills' => ['skill-one', 'skill-two']])
+        ->expectsConfirmation('Are you sure you want to remove these 2 skills? (skill-one, skill-two)', 'yes')
+        ->expectsOutput('Skills removed: skill-one, skill-two')
+        ->assertSuccessful();
+
+    $this->assertFilenameNotExists('.ai/skills/skill-one');
+    $this->assertFilenameNotExists('.ai/skills/skill-two');
+});
+
+it('cancels removal when confirmation is denied', function (): void {
+    $this->artisan('boost:rm-skill', ['skills' => ['skill-one']])
+        ->expectsConfirmation("Are you sure you want to remove the 'skill-one' skill?", 'no')
+        ->expectsOutput('Removal cancelled.')
+        ->assertSuccessful();
+
+    $this->assertFilenameExists('.ai/skills/skill-one/SKILL.md');
+});
+
+it('removes skills without confirmation using --force', function (): void {
+    $this->artisan('boost:rm-skill', ['skills' => ['skill-one'], '--force' => true])
+        ->expectsOutput('Skills removed: skill-one')
+        ->assertSuccessful();
+
+    $this->assertFilenameNotExists('.ai/skills/skill-one');
+});
+
+it('fails to remove a non-existent skill', function (): void {
+    $this->artisan('boost:rm-skill', ['skills' => ['non-existent-skill']])
+        ->expectsOutput("Skill 'non-existent-skill' not found.")
+        ->expectsOutput('No valid skills to remove.')
+        ->assertFailed();
+});
+
+it('prompts for skill selection if no argument is provided', function (): void {
+    $this->artisan('boost:rm-skill')
+        ->expectsChoice('Which skills would you like to remove?', ['skill-one'], ['skill-one' => 'skill-one', 'skill-two' => 'skill-two'])
+        ->expectsConfirmation("Are you sure you want to remove the 'skill-one' skill?", 'yes')
+        ->expectsOutput('Skills removed: skill-one')
+        ->assertSuccessful();
+
+    $this->assertFilenameNotExists('.ai/skills/skill-one');
+    $this->assertFilenameExists('.ai/skills/skill-two');
+});
+
+it('displays error when no skills are installed when prompting', function (): void {
+    File::deleteDirectory(base_path('.ai/skills'));
+    File::ensureDirectoryExists(base_path('.ai/skills'));
+
+    $this->artisan('boost:rm-skill')
+        ->expectsOutput('No skills installed.')
+        ->assertSuccessful();
+});


### PR DESCRIPTION
hi maintainers,

personally, i needed this command because as the number of installed skills grows, manually managing files inside `.ai/skills` becomes annoying and easy to mess up. having a first-class, explicit removal command makes day-to-day skill management much smoother and safer for me, and i thought it might be useful for others as well.

if this turns out to be a bad idea, or doesn’t align with the project’s direction, that’s totally fine and i’m okay with this being rejected.

it supports both interactive multi-selection and direct arguments for specifying skills. Includes safety confirmations that can be bypassed using a force flag, and automatically triggers a system update after removal to maintain consistency.

#### usage

```bash
# remove specific skills
php artisan boost:rm-skill skill-one skill-two

# remove with interactive selection
php artisan boost:rm-skill

# force remove without confirmation
php artisan boost:rm-skill skill-one --force
```

feedback is very welcome, especially if there’s a better mental model or workflow you’d prefer for skill removal.
