### PR TITLE
fix typo in pest skill

### DIFF
--- a/.ai/pest/4/skill/pest-testing/SKILL.blade.php
+++ b/.ai/pest/4/skill/pest-testing/SKILL.blade.php
@@ -116,7 +116,7 @@ it('may reset the password', function () {
     $page = visit('/sign-in');
 
     $page->assertSee('Sign In')
-        ->assertNoJavascriptErrors()
+        ->assertNoJavaScriptErrors()
         ->click('Forgot Password?')
         ->fill('email', 'nuno@laravel.com')
         ->click('Send Reset Link')
@@ -133,7 +133,7 @@ Quickly validate multiple pages have no JavaScript errors:
 @boostsnippet("Pest Smoke Testing Example", "php")
 $pages = visit(['/', '/about', '/contact']);
 
-$pages->assertNoJavascriptErrors()->assertNoConsoleLogs();
+$pages->assertNoJavaScriptErrors()->assertNoConsoleLogs();
 @endboostsnippet
 
 ### Visual Regression Testing
@@ -161,4 +161,4 @@ arch('controllers')
 - Using `assertStatus(200)` instead of `assertSuccessful()`
 - Forgetting datasets for repetitive validation tests
 - Deleting tests without approval
-- Forgetting `assertNoJavascriptErrors()` in browser tests
+- Forgetting `assertNoJavaScriptErrors()` in browser tests


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The method `->assertNoJavascriptErrors()` had a typo. According to the docs, it should be `->assertNoJavaScriptErrors()`.

https://pestphp.com/docs/browser-testing#content-assertnojavascripterrors