### PR TITLE
Remove stale files during skill directory updates

### DIFF
--- a/src/Install/MarkdownFormatter.php
+++ b/src/Install/MarkdownFormatter.php
@@ -13,10 +13,10 @@ class MarkdownFormatter
     {
         // Ensure blank line before and after markdown headings
         $content = preg_replace('/(?<!\n)\n(#{1,4} )/m', "\n\n$1", $content);
-        $content = preg_replace('/(#{1,4} .+)\n(?!\n)/m', "$1\n\n", $content);
+        $content = preg_replace('/(#{1,4} .+)\n(?!\n)/m', "$1\n\n", (string) $content);
 
         // Collapse multiple consecutive empty lines into a single empty line
-        $content = preg_replace('/\n{3,}/', "\n\n", $content);
+        $content = preg_replace('/\n{3,}/', "\n\n", (string) $content);
 
         return $content;
     }

--- a/src/Install/SkillWriter.php
+++ b/src/Install/SkillWriter.php
@@ -129,6 +129,8 @@ class SkillWriter
             return false;
         }
 
+        $this->deleteDirectory($target);
+
         if (! $this->ensureDirectoryExists($target)) {
             throw new RuntimeException("Failed to create directory: {$target}");
         }


### PR DESCRIPTION

This pull request improves the skill directory update process by removing stale files when directories are updated. This ensures that any outdated or unused files in these directories are cleaned up.

- No breaking changes introduced.
