### PR TITLE
Add Flux Icons documentation to SKILL.md files

### DIFF
--- a/.ai/fluxui-free/skill/fluxui-development/SKILL.md
+++ b/.ai/fluxui-free/skill/fluxui-development/SKILL.md
@@ -32,6 +32,10 @@ Use Flux UI components when available. Fall back to standard Blade components wh
 <flux:button variant="primary">Click me</flux:button>
 </code-snippet>
 
+## Available Components (Free Edition)
+
+Available: avatar, badge, brand, breadcrumbs, button, callout, checkbox, dropdown, field, heading, icon, input, modal, navbar, otp-input, profile, radio, select, separator, skeleton, switch, text, textarea, tooltip
+
 ## Icons
 
 Flux includes [Heroicons](https://heroicons.com/) as its default icon set. Search for exact icon names on the Heroicons site - do not guess or invent icon names.
@@ -45,10 +49,6 @@ For icons not available in Heroicons, use [Lucide](https://lucide.dev/). Import 
 ```bash
 php artisan flux:icon crown grip-vertical github
 ```
-
-## Available Components (Free Edition)
-
-Available: avatar, badge, brand, breadcrumbs, button, callout, checkbox, dropdown, field, heading, icon, input, modal, navbar, otp-input, profile, radio, select, separator, skeleton, switch, text, textarea, tooltip
 
 ## Common Patterns
 

--- a/.ai/fluxui-pro/skill/fluxui-development/SKILL.md
+++ b/.ai/fluxui-pro/skill/fluxui-development/SKILL.md
@@ -33,6 +33,10 @@ Use Flux UI components when available. Fall back to standard Blade components wh
 <flux:button variant="primary">Click me</flux:button>
 </code-snippet>
 
+## Available Components (Pro Edition)
+
+Available: accordion, autocomplete, avatar, badge, brand, breadcrumbs, button, calendar, callout, card, chart, checkbox, command, composer, context, date-picker, dropdown, editor, field, file-upload, heading, icon, input, kanban, modal, navbar, otp-input, pagination, pillbox, popover, profile, radio, select, separator, skeleton, slider, switch, table, tabs, text, textarea, time-picker, toast, tooltip
+
 ## Icons
 
 Flux includes [Heroicons](https://heroicons.com/) as its default icon set. Search for exact icon names on the Heroicons site - do not guess or invent icon names.
@@ -46,10 +50,6 @@ For icons not available in Heroicons, use [Lucide](https://lucide.dev/). Import 
 ```bash
 php artisan flux:icon crown grip-vertical github
 ```
-
-## Available Components (Pro Edition)
-
-Available: accordion, autocomplete, avatar, badge, brand, breadcrumbs, button, calendar, callout, card, chart, checkbox, command, composer, context, date-picker, dropdown, editor, field, file-upload, heading, icon, input, kanban, modal, navbar, otp-input, pagination, pillbox, popover, profile, radio, select, separator, skeleton, slider, switch, table, tabs, text, textarea, time-picker, toast, tooltip
 
 ## Common Patterns
 


### PR DESCRIPTION
Added Icons section to both `fluxui-free` and `fluxui-pro` SKILL.md files documenting Heroicons as the default icon set and Lucide as an alternative addresses issue where AI assistants invent non-existent icon names (e.g., download instead of arrow-down-tray)

Fixes #177
