### PR TITLE
Add symlink install mode for skills

### DIFF
--- a/src/Install/SkillWriter.php
+++ b/src/Install/SkillWriter.php
@@ -150,12 +150,13 @@ class SkillWriter
                 return true;
             }
 
-            // On Windows, directory symlinks can require rmdir instead of unlink.
-            if (is_dir($path) && @rmdir($path)) {
+            // On Windows, directory symlinks can require rmdir instead of unlink,
+            // even when the symlink target no longer exists (dangling symlinks).
+            if (@rmdir($path)) {
                 return true;
             }
 
-            return ! file_exists($path);
+            return ! file_exists($path) && ! is_link($path);
         }
 
         if (is_file($path)) {

--- a/tests/Unit/Install/SkillWriterTest.php
+++ b/tests/Unit/Install/SkillWriterTest.php
@@ -666,11 +666,19 @@ it('handles dangling symlink at target path', function (): void {
 
     mkdir($danglingTarget, 0755, true);
     mkdir(dirname($linkedPath), 0755, true);
-    @symlink($danglingTarget, $linkedPath);
+
+    if (! @symlink($danglingTarget, $linkedPath)) {
+        cleanupSkillDirectory($danglingTarget);
+        cleanupSkillDirectory($absoluteTarget);
+        $this->markTestSkipped('Symlinks not supported in this environment');
+    }
+
     cleanupSkillDirectory($danglingTarget);
 
-    expect(is_link($linkedPath))->toBeTrue()
-        ->and(is_dir($linkedPath))->toBeFalse();
+    if (! is_link($linkedPath)) {
+        cleanupSkillDirectory($absoluteTarget);
+        $this->markTestSkipped('Dangling symlink not detectable in this environment');
+    }
 
     $agent = Mockery::mock(SupportsSkills::class);
     $agent->shouldReceive('skillsPath')->andReturn($relativeTarget);


### PR DESCRIPTION
## Summary

- Add optional symlink install mode for skills with canonical `.agents/skills` storage and copy fallback.

## References

- Uses the same canonical `.agents/skills` location as the Vercel [skills](skills.sh) CLI.

| Before | After |
|--------|--------|
| <img width="2069" height="1251" alt="CleanShot 2026-01-29 at 11 12 12@2x" src="https://github.com/user-attachments/assets/aa4b9759-1879-417c-84d2-474adf6af398" /> | <img width="2575" height="1396" alt="CleanShot 2026-01-29 at 11 12 17@2x" src="https://github.com/user-attachments/assets/b1a71f19-a51d-4c35-86d7-f986d48dbb49" /> |