### PR TITLE
Fix PHP 8.5 compatibility and MCP tool error handling

### DIFF
--- a/src/Console/ExecuteToolCommand.php
+++ b/src/Console/ExecuteToolCommand.php
@@ -51,12 +51,13 @@ class ExecuteToolCommand extends Command
         } catch (Throwable $throwable) {
             $errorResult = Response::error("Tool execution failed (E_THROWABLE): {$throwable->getMessage()}");
 
-            $this->error(json_encode([
+            // Write to STDOUT (not STDERR) so ToolExecutor can read the response
+            echo json_encode([
                 'isError' => true,
                 'content' => [
                     $errorResult->content()->toTool($tool),
                 ],
-            ]));
+            ]);
 
             return static::FAILURE;
         }

--- a/src/Mcp/ToolExecutor.php
+++ b/src/Mcp/ToolExecutor.php
@@ -126,6 +126,9 @@ class ToolExecutor
     {
         return [
             PHP_BINARY,
+            // Suppress deprecation warnings that corrupt JSON output (e.g., PHP 8.5 PDO constant deprecations)
+            '-d', 'error_reporting='.(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED),
+            '-d', 'display_errors=stderr',
             base_path('artisan'),
             'boost:execute-tool',
             $toolClass,

--- a/src/Mcp/Tools/LastError.php
+++ b/src/Mcp/Tools/LastError.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Mcp\Tools;
 
+use Exception;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
@@ -29,12 +30,16 @@ class LastError extends Tool
         if (! self::$listenerRegistered) {
             Log::listen(function (MessageLogged $event): void {
                 if ($event->level === 'error') {
-                    Cache::forever('boost:last_error', [
-                        'timestamp' => now()->toDateTimeString(),
-                        'level' => $event->level,
-                        'message' => $event->message,
-                        'context' => [], // $event->context,
-                    ]);
+                    try {
+                        Cache::forever('boost:last_error', [
+                            'timestamp' => now()->toDateTimeString(),
+                            'level' => $event->level,
+                            'message' => $event->message,
+                            'context' => [], // $event->context,
+                        ]);
+                    } catch (Exception) {
+                        // Cache may be unavailable, skip storing
+                    }
                 }
             });
 


### PR DESCRIPTION
# PR Description

## Summary

This PR fixes several issues affecting MCP tool execution, particularly on PHP 8.5:

- **PHP 8.5 deprecation warnings corrupt JSON output** - Deprecation warnings (e.g., `PDO::MYSQL_ATTR_SSL_CA`) printed to STDOUT during Laravel bootstrap corrupt the JSON response, causing "Invalid JSON output" errors
- **Error responses written to STDERR instead of STDOUT** - When a tool throws an exception, the error JSON was written to STDERR via `$this->error()`, but `ToolExecutor` only reads STDOUT
- **Cache unavailability crashes LastError tool** - `Cache::forever()` in the log listener throws if cache is unavailable

## Changes

| File | Change |
|------|--------|
| `ToolExecutor.php` | Pass `-d error_reporting=...` to subprocess to suppress deprecation warnings |
| `ExecuteToolCommand.php` | Change `$this->error()` to `echo` so error JSON goes to STDOUT |
| `LastError.php` | Wrap `Cache::forever()` in try/catch for resilience |

## Testing

Tested on PHP 8.5.2 with Laravel 11.48.0. All MCP tools now return valid JSON responses.

---

### Vibe Coded

This fix was discovered and implemented through a conversation with [Claude Code](https://claude.ai/code) (Anthropic's CLI tool).

The debugging process:
1. Asked Claude to look for bugs in the Laravel Boost vendor package
2. Claude identified 4 potential issues through code analysis
3. Tested fixes by running `php artisan boost:execute-tool` directly to see the raw output
4. Discovered PHP 8.5 deprecation warnings were corrupting the JSON
5. Iterated on fixes until `mcp__laravel-boost__tinker` worked

Total time from "can you look for bugs" to working fix: ~15 minutes
