### PR TITLE
Filter orphaned packages from config

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -386,8 +386,7 @@ class InstallCommand extends Command
             $this->config->flush();
             $this->config->setAgents($this->selectedAgents->map(fn (Agent $agent): string => $agent->name())->values()->toArray());
             $this->config->setPackages($this->selectedThirdPartyPackages->values()->toArray());
-        } else {
-            // In explicit mode, still clean up orphaned packages from config
+        } elseif ($this->selectedBoostFeatures->contains('guidelines') || $this->selectedBoostFeatures->contains('skills')) {
             $this->config->setPackages($this->selectedThirdPartyPackages->values()->toArray());
         }
 

--- a/tests/Feature/Console/InstallCommandOrphanedPackagesTest.php
+++ b/tests/Feature/Console/InstallCommandOrphanedPackagesTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Install\ThirdPartyPackage;
+use Laravel\Boost\Support\Config;
+use Laravel\Prompts\Key;
+use Laravel\Prompts\Prompt;
+
+use function Laravel\Prompts\multiselect;
+
+beforeEach(function (): void {
+    (new Config)->flush();
+});
+
+it('passes only valid defaults to multiselect when orphaned packages exist in config', function (): void {
+    Prompt::fake([Key::ENTER]);
+
+    $configuredPackages = ['valid-pkg', 'orphaned-pkg'];
+
+    $discoveredPackages = collect([
+        'valid-pkg' => new ThirdPartyPackage('valid-pkg', true, false),
+    ]);
+
+    $validDefaults = collect($configuredPackages)
+        ->filter(fn (string $name) => $discoveredPackages->has($name))
+        ->values()
+        ->toArray();
+
+    $result = multiselect(
+        label: 'Select packages',
+        options: $discoveredPackages->mapWithKeys(fn (ThirdPartyPackage $pkg, string $name): array => [
+            $name => $pkg->displayLabel(),
+        ])->toArray(),
+        default: $validDefaults,
+    );
+
+    expect($result)->toContain('valid-pkg')
+        ->and($result)->not->toContain('orphaned-pkg');
+})->skipOnWindows();


### PR DESCRIPTION
When a third-party package is **uninstalled** via Composer, its entry remains in `boost.json`. This causes errors in two scenarios:

1. **`boost:update`** fails immediately with `Value "package-name" is invalid`
2. **`boost:install`** fails when the **multiselect** prompt tries to pre-select the orphaned package

## Changes

1. Filter orphaned packages from multiselect defaults in `selectThirdPartyPackages()` - applies the same pattern already used in `selectAgents()`
2. Clean up orphaned packages from config in explicit mode (when `boost:update` runs)

## Testing

- Installed `laravel/fortify` and `spatie/boost-spatie-guidelines`
- Ran `boost:install` and selected both packages
- Removed `spatie/boost-spatie-guidelines` via Composer
- Verified both `boost:update` and `boost:install` work without errors
- Verified orphaned package is removed from `boost.json`
