### PR TITLE
Add DDEV support for MCP server and guidelines

### DIFF
--- a/.ai/ddev/core.blade.php
+++ b/.ai/ddev/core.blade.php
@@ -1,0 +1,12 @@
+@php
+/** @var \Laravel\Boost\Install\GuidelineAssist $assist */
+@endphp
+# DDEV
+
+- This project runs inside DDEV's Docker containers. You MUST execute all PHP, Artisan, and Composer commands through DDEV.
+- Start services using `ddev start` and stop them with `ddev stop`.
+- Always prefix PHP, Artisan, and Composer commands with `ddev exec`. Examples:
+    - Run Artisan Commands: `{{ $assist->artisanCommand('migrate') }}`
+    - Install Composer packages: `{{ $assist->composerCommand('install') }}`
+    - Run bin scripts: `{{ $assist->binCommand('pint') }}`
+- Node/frontend commands (npm, bun, etc.) run on the host, not inside DDEV.

--- a/src/Install/Ddev.php
+++ b/src/Install/Ddev.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install;
+
+class Ddev
+{
+    public function isInstalled(): bool
+    {
+        return file_exists(base_path('.ddev/config.yaml'));
+    }
+
+    public function isActive(): bool
+    {
+        return getenv('IS_DDEV_PROJECT') === 'true';
+    }
+
+    /**
+     * @return array{key: string, command: string, args: array<int, string>}
+     */
+    public function buildMcpCommand(string $serverName): array
+    {
+        return [
+            'key' => $serverName,
+            'command' => 'ddev',
+            'args' => ['exec', 'php', 'artisan', 'boost:mcp'],
+        ];
+    }
+
+    public static function artisanCommand(): string
+    {
+        return self::command('php artisan');
+    }
+
+    public static function composerCommand(): string
+    {
+        return self::command('composer');
+    }
+
+    public static function binCommand(): string
+    {
+        return self::command('vendor/bin/');
+    }
+
+    public static function command(string $command): string
+    {
+        return 'ddev exec '.$command;
+    }
+}

--- a/src/Install/GuidelineAssist.php
+++ b/src/Install/GuidelineAssist.php
@@ -202,6 +202,10 @@ class GuidelineAssist
 
     public function composerCommand(string $command): string
     {
+        if ($this->config->usesDdev) {
+            return Ddev::composerCommand()." {$command}";
+        }
+
         $composerCommand = $this->config->usesSail
             ? Sail::composerCommand()
             : 'composer';
@@ -211,6 +215,10 @@ class GuidelineAssist
 
     public function binCommand(string $command): string
     {
+        if ($this->config->usesDdev) {
+            return Ddev::binCommand().$command;
+        }
+
         return $this->config->usesSail
             ? Sail::binCommand().$command
             : "vendor/bin/{$command}";
@@ -218,6 +226,10 @@ class GuidelineAssist
 
     public function artisan(): string
     {
+        if ($this->config->usesDdev) {
+            return Ddev::artisanCommand();
+        }
+
         return $this->config->usesSail
             ? Sail::artisanCommand()
             : 'php artisan';

--- a/src/Install/GuidelineComposer.php
+++ b/src/Install/GuidelineComposer.php
@@ -137,8 +137,12 @@ class GuidelineComposer
     protected function getConditionalGuidelines(): Collection
     {
         return collect([
+            'ddev' => [
+                'condition' => $this->config->usesDdev,
+                'path' => 'ddev/core',
+            ],
             'herd' => [
-                'condition' => str_contains((string) config('app.url'), '.test') && $this->herd->isInstalled() && ! $this->config->usesSail,
+                'condition' => str_contains((string) config('app.url'), '.test') && $this->herd->isInstalled() && ! $this->config->usesSail && ! $this->config->usesDdev,
                 'path' => 'herd/core',
             ],
             'sail' => [

--- a/src/Install/GuidelineConfig.php
+++ b/src/Install/GuidelineConfig.php
@@ -10,6 +10,8 @@ class GuidelineConfig
 
     public bool $laravelStyle = false;
 
+    public bool $usesDdev = false;
+
     public bool $usesSail = false;
 
     public bool $caresAboutLocalization = false;

--- a/src/Install/McpWriter.php
+++ b/src/Install/McpWriter.php
@@ -16,9 +16,9 @@ class McpWriter
         //
     }
 
-    public function write(?Sail $sail = null, ?Herd $herd = null): int
+    public function write(?Sail $sail = null, ?Ddev $ddev = null, ?Herd $herd = null): int
     {
-        $this->installBoostMcp($sail);
+        $this->installBoostMcp($sail, $ddev);
 
         if ($herd instanceof Herd) {
             $this->installHerdMcp($herd);
@@ -27,9 +27,9 @@ class McpWriter
         return self::SUCCESS;
     }
 
-    protected function installBoostMcp(?Sail $sail): void
+    protected function installBoostMcp(?Sail $sail, ?Ddev $ddev): void
     {
-        $mcp = $this->buildBoostMcpCommand($sail);
+        $mcp = $this->buildBoostMcpCommand($sail, $ddev);
 
         if (! $this->agent->installMcp($mcp['key'], $mcp['command'], $mcp['args'])) {
             throw new RuntimeException('Failed to install Boost MCP: could not write configuration');
@@ -39,10 +39,14 @@ class McpWriter
     /**
      * @return array{key: string, command: string, args: array<int, string>}
      */
-    protected function buildBoostMcpCommand(?Sail $sail): array
+    protected function buildBoostMcpCommand(?Sail $sail, ?Ddev $ddev): array
     {
         if ($sail instanceof Sail) {
             return $sail->buildMcpCommand('laravel-boost');
+        }
+
+        if ($ddev instanceof Ddev) {
+            return $ddev->buildMcpCommand('laravel-boost');
         }
 
         if ($this->isRunningInsideWsl()) {

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -93,6 +93,16 @@ class Config
         return $this->get('herd_mcp', false);
     }
 
+    public function setDdev(bool $useDdev): void
+    {
+        $this->set('ddev', $useDdev);
+    }
+
+    public function getDdev(): bool
+    {
+        return $this->get('ddev', false);
+    }
+
     public function setSail(bool $useSail): void
     {
         $this->set('sail', $useSail);

--- a/tests/Unit/Install/DdevTest.php
+++ b/tests/Unit/Install/DdevTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Install\Ddev;
+
+it('detects ddev is installed when .ddev/config.yaml exists', function (): void {
+    $configDir = base_path('.ddev');
+    mkdir($configDir, 0755, true);
+    file_put_contents($configDir.'/config.yaml', 'name: test');
+
+    $ddev = new Ddev;
+
+    expect($ddev->isInstalled())->toBeTrue();
+
+    unlink($configDir.'/config.yaml');
+    rmdir($configDir);
+});
+
+it('detects ddev is not installed when .ddev/config.yaml is missing', function (): void {
+    $ddev = new Ddev;
+
+    expect($ddev->isInstalled())->toBeFalse();
+});
+
+it('builds correct mcp command', function (): void {
+    $ddev = new Ddev;
+
+    expect($ddev->buildMcpCommand('laravel-boost'))->toBe([
+        'key' => 'laravel-boost',
+        'command' => 'ddev',
+        'args' => ['exec', 'php', 'artisan', 'boost:mcp'],
+    ]);
+});
+
+it('returns correct artisan command', function (): void {
+    expect(Ddev::artisanCommand())->toBe('ddev exec php artisan');
+});
+
+it('returns correct composer command', function (): void {
+    expect(Ddev::composerCommand())->toBe('ddev exec composer');
+});
+
+it('returns correct bin command', function (): void {
+    expect(Ddev::binCommand())->toBe('ddev exec vendor/bin/');
+});


### PR DESCRIPTION
## Summary

Adds first-class DDEV support to Laravel Boost, following the same pattern as the existing Sail integration.

**Problem:** When a project uses DDEV, `boost:install` generates MCP commands as `php artisan boost:mcp`, which runs on the host where the Laravel app isn't accessible — it needs to run inside the DDEV container via `ddev exec`.

**Solution:** Detect DDEV projects (via `.ddev/config.yaml`) and configure the MCP server command accordingly (`ddev exec php artisan boost:mcp`). Also prefixes PHP/Artisan/Composer commands in guidelines with `ddev exec`.

## Changes

- **`src/Install/Ddev.php`** — New class mirroring `Sail.php` with `isInstalled()`, `isActive()`, `buildMcpCommand()`, and static command helpers
- **`src/Install/McpWriter.php`** — Accept optional `Ddev` parameter; use DDEV command when provided (Sail takes priority if both are configured)
- **`src/Console/InstallCommand.php`** — Detect DDEV during install, prompt user to configure, persist `ddev` flag to `boost.json`
- **`src/Support/Config.php`** — Add `getDdev()`/`setDdev()` methods
- **`src/Install/GuidelineConfig.php`** — Add `usesDdev` flag
- **`src/Install/GuidelineAssist.php`** — DDEV-aware `artisan()`, `composerCommand()`, `binCommand()` helpers
- **`src/Install/GuidelineComposer.php`** — Add conditional DDEV guideline; exclude Herd guideline when DDEV is active
- **`.ai/ddev/core.blade.php`** — DDEV guideline template (instructs AI to use `ddev exec` for PHP commands)
- **Tests** — `DdevTest.php` (unit tests for Ddev class) + DDEV tests in `McpWriterTest.php` (with ddev, sail+ddev priority, ddev+herd)

All 497 existing tests pass.