### PR TITLE
Detect Inertia pages directory casing from filesystem

### DIFF
--- a/.ai/inertia-laravel/core.blade.php
+++ b/.ai/inertia-laravel/core.blade.php
@@ -1,7 +1,7 @@
 # Inertia
 
 - Inertia creates fully client-side rendered SPAs without modern SPA complexity, leveraging existing server-side patterns.
-- Components live in `resources/js/Pages` (unless specified in `vite.config.js`). Use `Inertia::render()` for server-side routing instead of Blade views.
+- Components live in `{{ $assist->inertia()->pagesDirectory() }}` (unless specified in `vite.config.js`). Use `Inertia::render()` for server-side routing instead of Blade views.
 - ALWAYS use `search-docs` tool for version-specific Inertia documentation and updated code examples.
 @if($assist->hasPackage(\Laravel\Roster\Enums\Packages::INERTIA_REACT))
 - IMPORTANT: Activate `inertia-react-development` when working with Inertia client-side patterns.

--- a/.ai/inertia-react/1/skill/inertia-react-development/SKILL.blade.php
+++ b/.ai/inertia-react/1/skill/inertia-react-development/SKILL.blade.php
@@ -27,7 +27,7 @@ Use `search-docs` for detailed Inertia v1 React patterns and documentation.
 
 ### Page Components Location
 
-React page components should be placed in the `resources/js/Pages` directory.
+React page components should be placed in the `{{ $assist->inertia()->pagesDirectory() }}` directory.
 
 ### Page Component Structure
 

--- a/.ai/inertia-react/2/skill/inertia-react-development/SKILL.blade.php
+++ b/.ai/inertia-react/2/skill/inertia-react-development/SKILL.blade.php
@@ -29,7 +29,7 @@ Use `search-docs` for detailed Inertia v2 React patterns and documentation.
 
 ### Page Components Location
 
-React page components should be placed in the `resources/js/Pages` directory.
+React page components should be placed in the `{{ $assist->inertia()->pagesDirectory() }}` directory.
 
 ### Page Component Structure
 

--- a/.ai/inertia-svelte/1/skill/inertia-svelte-development/SKILL.blade.php
+++ b/.ai/inertia-svelte/1/skill/inertia-svelte-development/SKILL.blade.php
@@ -27,7 +27,7 @@ Use `search-docs` for detailed Inertia v1 Svelte patterns and documentation.
 
 ### Page Components Location
 
-Svelte page components should be placed in the `resources/js/Pages` directory.
+Svelte page components should be placed in the `{{ $assist->inertia()->pagesDirectory() }}` directory.
 
 ### Page Component Structure
 

--- a/.ai/inertia-svelte/2/skill/inertia-svelte-development/SKILL.blade.php
+++ b/.ai/inertia-svelte/2/skill/inertia-svelte-development/SKILL.blade.php
@@ -29,7 +29,7 @@ Use `search-docs` for detailed Inertia v2 Svelte patterns and documentation.
 
 ### Page Components Location
 
-Svelte page components should be placed in the `resources/js/Pages` directory.
+Svelte page components should be placed in the `{{ $assist->inertia()->pagesDirectory() }}` directory.
 
 ### Page Component Structure
 

--- a/.ai/inertia-vue/1/skill/inertia-vue-development/SKILL.blade.php
+++ b/.ai/inertia-vue/1/skill/inertia-vue-development/SKILL.blade.php
@@ -27,7 +27,7 @@ Use `search-docs` for detailed Inertia v1 Vue patterns and documentation.
 
 ### Page Components Location
 
-Vue page components should be placed in the `resources/js/Pages` directory.
+Vue page components should be placed in the `{{ $assist->inertia()->pagesDirectory() }}` directory.
 
 ### Page Component Structure
 

--- a/.ai/inertia-vue/2/skill/inertia-vue-development/SKILL.blade.php
+++ b/.ai/inertia-vue/2/skill/inertia-vue-development/SKILL.blade.php
@@ -29,7 +29,7 @@ Use `search-docs` for detailed Inertia v2 Vue patterns and documentation.
 
 ### Page Components Location
 
-Vue page components should be placed in the `resources/js/Pages` directory.
+Vue page components should be placed in the `{{ $assist->inertia()->pagesDirectory() }}` directory.
 
 ### Page Component Structure
 

--- a/src/Install/Assists/Inertia.php
+++ b/src/Install/Assists/Inertia.php
@@ -40,4 +40,19 @@ class Inertia
     {
         return $this->gte('2.1.2');
     }
+
+    public function pagesDirectory(): string
+    {
+        $jsPath = base_path('resources/js');
+
+        if (is_dir($jsPath)) {
+            $entries = @scandir($jsPath);
+
+            if ($entries !== false && in_array('pages', $entries, true)) {
+                return 'resources/js/pages';
+            }
+        }
+
+        return 'resources/js/Pages';
+    }
 }

--- a/tests/Unit/Install/Agents/CodexTest.php
+++ b/tests/Unit/Install/Agents/CodexTest.php
@@ -98,7 +98,7 @@ test('returns correct guidelines path', function (): void {
 test('returns correct skills path', function (): void {
     $codex = new Codex($this->strategyFactory);
 
-    expect($codex->skillsPath())->toBe('.codex/skills');
+    expect($codex->skillsPath())->toBe('.agents/skills');
 });
 
 test('system detection uses which command on Darwin', function (): void {

--- a/tests/Unit/Install/Assists/InertiaTest.php
+++ b/tests/Unit/Install/Assists/InertiaTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Install\Assists\Inertia;
+use Laravel\Roster\Roster;
+
+beforeEach(function (): void {
+    $this->roster = Mockery::mock(Roster::class);
+    $this->roster->shouldReceive('usesVersion')->andReturn(false);
+
+    $this->inertia = new Inertia($this->roster);
+});
+
+afterEach(function (): void {
+    $jsPath = base_path('resources/js');
+
+    if (is_dir($jsPath.'/pages')) {
+        rmdir($jsPath.'/pages');
+    }
+
+    if (is_dir($jsPath.'/Pages')) {
+        rmdir($jsPath.'/Pages');
+    }
+
+    if (is_dir($jsPath)) {
+        rmdir($jsPath);
+    }
+
+    if (is_dir(base_path('resources'))) {
+        @rmdir(base_path('resources'));
+    }
+});
+
+it('returns PascalCase Pages directory as default when no resources/js directory exists', function (): void {
+    expect($this->inertia->pagesDirectory())->toBe('resources/js/Pages');
+});
+
+it('returns lowercase pages directory when it exists on disk', function (): void {
+    $jsPath = base_path('resources/js');
+    mkdir($jsPath, 0755, true);
+    mkdir($jsPath.'/pages', 0755);
+
+    expect($this->inertia->pagesDirectory())->toBe('resources/js/pages');
+    expect($this->inertia->pagesDirectory())->not->toBe('resources/js/Pages');
+});
+
+it('returns PascalCase Pages directory when it exists on disk', function (): void {
+    $jsPath = base_path('resources/js');
+    mkdir($jsPath, 0755, true);
+    mkdir($jsPath.'/Pages', 0755);
+
+    expect($this->inertia->pagesDirectory())->toBe('resources/js/Pages');
+    expect($this->inertia->pagesDirectory())->not->toBe('resources/js/pages');
+});


### PR DESCRIPTION
## Summary
- Guidelines hardcoded `resources/js/Pages` (PascalCase), but some projects use `resources/js/pages` (lowercase). This caused AI assistants to create or reference files in the wrong directory.
- Added a `pagesDirectory()` method that detects the actual casing from disk using `scandir()`, which works reliably on case-insensitive filesystems like macOS.
- Updated all 7 Inertia Blade templates to use the detected directory instead of the hardcoded path.
- Fixed a stale test in CodexTest that expected `.codex/skills` instead of `.agents/skills` after the unified paths change.

## How To Test
- [x] Run `composer test` — all tests pass
- [x] Verify on a project with `resources/js/pages` (lowercase) that guidelines output the correct path
- [x] Verify on a project with `resources/js/Pages` (PascalCase) that guidelines output the correct path