### PR TITLE
Add file paths and format guidance to Livewire 4 skill

### DIFF
--- a/.ai/livewire/4/skill/livewire-development/SKILL.blade.php
+++ b/.ai/livewire/4/skill/livewire-development/SKILL.blade.php
@@ -48,7 +48,7 @@ Use `{{ $assist->artisanCommand('livewire:convert create-post') }}` to convert b
 
 ### Choosing a Component Format
 
-Before creating a component, check `config/livewire.php` for overrides, these change where files are stored. Then look at existing files in those directories (defaulting to `app/Livewire/` and `resources/views/livewire/`) to match the established convention.
+Before creating a component, check `config/livewire.php` for directory overrides, which change where files are stored. Then, look at existing files in those directories (defaulting to `app/Livewire/` and `resources/views/livewire/`) to match the established convention.
 
 ### Component Format Reference
 


### PR DESCRIPTION
While using the Livewire 4 skill in a real application, I identified several gaps where AI models were placing files in wrong directories or skipping required files entirely. This PR closes those gaps:

- Added a "Choosing a Component Format" section that instructs models to check `config/livewire.php` for path overrides, then match the existing convention before defaulting
- Replaced the vague format table with explicit Class Path and View Path columns so models know exactly which files each format creates and where they go
- Added file location to the single-file component example
- Added a concrete `Route::livewire()` example for full-page component routing
- Added namespaced component subdirectory mapping

