### PR TITLE
Add model binding and page content examples to Folio routing skill

### DIFF
--- a/.ai/folio/skill/folio-routing/SKILL.blade.php
+++ b/.ai/folio/skill/folio-routing/SKILL.blade.php
@@ -136,6 +136,6 @@ render(function (View $view, Post $post) {
 
 ### Folio 404 Debug Checklist
 
-1. Run `{{ $assist->artisanCommand('folio:list') }}`.
-2. If routes are missing, confirm Folio is mounted (`folio:install` + provider registration, or `Folio::path(...)`) and pages are under the mounted path.
-3. Verify filename-to-route mapping (`index.blade.php`, nested paths, `[id]` vs `[Model]`), then rerun `{{ $assist->artisanCommand('folio:list') }}`.
+1. Run `{{ $assist->artisanCommand('folio:list') }}`
+2. If routes are missing, confirm Folio is mounted (`folio:install` + provider registration, or `Folio::path(...)`) and pages are under the mounted path
+3. Verify filename-to-route mapping (`index.blade.php`, nested paths, `[id]` vs `[Model]`), then rerun `{{ $assist->artisanCommand('folio:list') }}`


### PR DESCRIPTION
## Summary
- Adds clear distinction between route parameters (`[id]`) and model binding (`[User]`) with examples
- Includes practical patterns for loading data in Folio pages (inline queries and render hooks)
- Adds a 404 debug checklist for troubleshooting common routing issues

## Context
While working on an application, noticed AI was making mistakes with Folio routing—specifically confusing route parameters with model binding and not knowing how to properly load data in Folio pages. This updates the skill documentation to prevent these issues.
