### PR TITLE
Replace >- block scalar with single-line descriptions in SKILL files

### DIFF
--- a/.ai/fluxui-free/skill/fluxui-development/SKILL.md
+++ b/.ai/fluxui-free/skill/fluxui-development/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: fluxui-development
-description: >-
-  Develops UIs with Flux UI Free components. Activates when creating buttons, forms, modals,
-  inputs, dropdowns, checkboxes, or UI components; replacing HTML form elements with Flux;
-  working with flux: components; or when the user mentions Flux, component library, UI components,
-  form fields, or asks about available Flux components.
+description: "Develops UIs with Flux UI Free components. Activates when creating buttons, forms, modals, inputs, dropdowns, checkboxes, or UI components; replacing HTML form elements with Flux; working with flux: components; or when the user mentions Flux, component library, UI components, form fields, or asks about available Flux components."
+license: MIT
+metadata:
+  author: laravel
 ---
 # Flux UI Development
 

--- a/.ai/fluxui-pro/skill/fluxui-development/SKILL.md
+++ b/.ai/fluxui-pro/skill/fluxui-development/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: fluxui-development
-description: >-
-  Develops UIs with Flux UI Pro components. Activates when creating buttons, forms, modals,
-  inputs, tables, charts, date pickers, or UI components; replacing HTML elements with Flux;
-  working with flux: components; or when the user mentions Flux, component library, UI components,
-  form fields, or asks about available Flux components.
+description: "Develops UIs with Flux UI Pro components. Activates when creating buttons, forms, modals, inputs, tables, charts, date pickers, or UI components; replacing HTML elements with Flux; working with flux: components; or when the user mentions Flux, component library, UI components, form fields, or asks about available Flux components."
+license: MIT
+metadata:
+  author: laravel
 ---
 # Flux UI Development
 

--- a/.ai/folio/skill/folio-routing/SKILL.blade.php
+++ b/.ai/folio/skill/folio-routing/SKILL.blade.php
@@ -1,10 +1,9 @@
 ---
 name: folio-routing
-description: >-
-  Creates file-based routes with Laravel Folio. Activates when creating new pages, setting up
-  routes, working with route parameters or model binding, adding middleware to pages, working with
-  resources/views/pages; or when the user mentions Folio, pages, file-based routing, page routes,
-  or creating a new page for a URL path.
+description: "Creates file-based routes with Laravel Folio. Activates when creating new pages, setting up routes, working with route parameters or model binding, adding middleware to pages, working with resources/views/pages; or when the user mentions Folio, pages, file-based routing, page routes, or creating a new page for a URL path."
+license: MIT
+metadata:
+  author: laravel
 ---
 @php
 /** @var \Laravel\Boost\Install\GuidelineAssist $assist */

--- a/.ai/inertia-react/1/skill/inertia-react-development/SKILL.blade.php
+++ b/.ai/inertia-react/1/skill/inertia-react-development/SKILL.blade.php
@@ -1,9 +1,9 @@
 ---
 name: inertia-react-development
-description: >-
-  Develops Inertia.js v1 React client-side applications. Activates when creating
-  React pages, forms, or navigation; using Link or router; or when user mentions
-  React with Inertia, React pages, React forms, or React navigation.
+description: "Develops Inertia.js v1 React client-side applications. Activates when creating React pages, forms, or navigation; using Link or router; or when user mentions React with Inertia, React pages, React forms, or React navigation."
+license: MIT
+metadata:
+  author: laravel
 ---
 @php
 /** @var \Laravel\Boost\Install\GuidelineAssist $assist */

--- a/.ai/inertia-react/2/skill/inertia-react-development/SKILL.blade.php
+++ b/.ai/inertia-react/2/skill/inertia-react-development/SKILL.blade.php
@@ -1,10 +1,9 @@
 ---
 name: inertia-react-development
-description: >-
-  Develops Inertia.js v2 React client-side applications. Activates when creating
-  React pages, forms, or navigation; using <Link>, <Form>, useForm, or router;
-  working with deferred props, prefetching, or polling; or when user mentions
-  React with Inertia, React pages, React forms, or React navigation.
+description: "Develops Inertia.js v2 React client-side applications. Activates when creating React pages, forms, or navigation; using <Link>, <Form>, useForm, or router; working with deferred props, prefetching, or polling; or when user mentions React with Inertia, React pages, React forms, or React navigation."
+license: MIT
+metadata:
+  author: laravel
 ---
 @php
 /** @var \Laravel\Boost\Install\GuidelineAssist $assist */

--- a/.ai/inertia-svelte/1/skill/inertia-svelte-development/SKILL.blade.php
+++ b/.ai/inertia-svelte/1/skill/inertia-svelte-development/SKILL.blade.php
@@ -1,9 +1,9 @@
 ---
 name: inertia-svelte-development
-description: >-
-  Develops Inertia.js v1 Svelte client-side applications. Activates when creating
-  Svelte pages, forms, or navigation; using Link or router; or when user mentions
-  Svelte with Inertia, Svelte pages, Svelte forms, or Svelte navigation.
+description: "Develops Inertia.js v1 Svelte client-side applications. Activates when creating Svelte pages, forms, or navigation; using Link or router; or when user mentions Svelte with Inertia, Svelte pages, Svelte forms, or Svelte navigation."
+license: MIT
+metadata:
+  author: laravel
 ---
 @php
 /** @var \Laravel\Boost\Install\GuidelineAssist $assist */

--- a/.ai/inertia-svelte/2/skill/inertia-svelte-development/SKILL.blade.php
+++ b/.ai/inertia-svelte/2/skill/inertia-svelte-development/SKILL.blade.php
@@ -1,10 +1,9 @@
 ---
 name: inertia-svelte-development
-description: >-
-  Develops Inertia.js v2 Svelte client-side applications. Activates when creating
-  Svelte pages, forms, or navigation; using Link, Form, or router; working with
-  deferred props, prefetching, or polling; or when user mentions Svelte with Inertia,
-  Svelte pages, Svelte forms, or Svelte navigation.
+description: "Develops Inertia.js v2 Svelte client-side applications. Activates when creating Svelte pages, forms, or navigation; using Link, Form, or router; working with deferred props, prefetching, or polling; or when user mentions Svelte with Inertia, Svelte pages, Svelte forms, or Svelte navigation."
+license: MIT
+metadata:
+  author: laravel
 ---
 @php
 /** @var \Laravel\Boost\Install\GuidelineAssist $assist */

--- a/.ai/inertia-vue/1/skill/inertia-vue-development/SKILL.blade.php
+++ b/.ai/inertia-vue/1/skill/inertia-vue-development/SKILL.blade.php
@@ -1,9 +1,9 @@
 ---
 name: inertia-vue-development
-description: >-
-  Develops Inertia.js v1 Vue client-side applications. Activates when creating
-  Vue pages, forms, or navigation; using Link or router; or when user mentions
-  Vue with Inertia, Vue pages, Vue forms, or Vue navigation.
+description: "Develops Inertia.js v1 Vue client-side applications. Activates when creating Vue pages, forms, or navigation; using Link or router; or when user mentions Vue with Inertia, Vue pages, Vue forms, or Vue navigation."
+license: MIT
+metadata:
+  author: laravel
 ---
 @php
 /** @var \Laravel\Boost\Install\GuidelineAssist $assist */

--- a/.ai/inertia-vue/2/skill/inertia-vue-development/SKILL.blade.php
+++ b/.ai/inertia-vue/2/skill/inertia-vue-development/SKILL.blade.php
@@ -1,10 +1,9 @@
 ---
 name: inertia-vue-development
-description: >-
-  Develops Inertia.js v2 Vue client-side applications. Activates when creating
-  Vue pages, forms, or navigation; using <Link>, <Form>, useForm, or router;
-  working with deferred props, prefetching, or polling; or when user mentions
-  Vue with Inertia, Vue pages, Vue forms, or Vue navigation.
+description: "Develops Inertia.js v2 Vue client-side applications. Activates when creating Vue pages, forms, or navigation; using <Link>, <Form>, useForm, or router; working with deferred props, prefetching, or polling; or when user mentions Vue with Inertia, Vue pages, Vue forms, or Vue navigation."
+license: MIT
+metadata:
+  author: laravel
 ---
 @php
 /** @var \Laravel\Boost\Install\GuidelineAssist $assist */

--- a/.ai/livewire/2/skill/livewire-development/SKILL.blade.php
+++ b/.ai/livewire/2/skill/livewire-development/SKILL.blade.php
@@ -1,10 +1,9 @@
 ---
 name: livewire-development
-description: >-
-  Develops reactive Livewire 2 components. Activates when creating, updating, or modifying
-  Livewire components; working with wire:model, wire:click, wire:loading, or any wire: directives;
-  adding real-time updates, loading states, or reactivity; debugging component behavior;
-  writing Livewire tests; or when the user mentions Livewire, component, counter, or reactive UI.
+description: "Develops reactive Livewire 2 components. Activates when creating, updating, or modifying Livewire components; working with wire:model, wire:click, wire:loading, or any wire: directives; adding real-time updates, loading states, or reactivity; debugging component behavior; writing Livewire tests; or when the user mentions Livewire, component, counter, or reactive UI."
+license: MIT
+metadata:
+  author: laravel
 ---
 @php
 /** @var \Laravel\Boost\Install\GuidelineAssist $assist */

--- a/.ai/livewire/3/skill/livewire-development/SKILL.blade.php
+++ b/.ai/livewire/3/skill/livewire-development/SKILL.blade.php
@@ -1,10 +1,9 @@
 ---
 name: livewire-development
-description: >-
-  Develops reactive Livewire 3 components. Activates when creating, updating, or modifying
-  Livewire components; working with wire:model, wire:click, wire:loading, or any wire: directives;
-  adding real-time updates, loading states, or reactivity; debugging component behavior;
-  writing Livewire tests; or when the user mentions Livewire, component, counter, or reactive UI.
+description: "Develops reactive Livewire 3 components. Activates when creating, updating, or modifying Livewire components; working with wire:model, wire:click, wire:loading, or any wire: directives; adding real-time updates, loading states, or reactivity; debugging component behavior; writing Livewire tests; or when the user mentions Livewire, component, counter, or reactive UI."
+license: MIT
+metadata:
+  author: laravel
 ---
 @php
 /** @var \Laravel\Boost\Install\GuidelineAssist $assist */

--- a/.ai/livewire/4/skill/livewire-development/SKILL.blade.php
+++ b/.ai/livewire/4/skill/livewire-development/SKILL.blade.php
@@ -1,10 +1,9 @@
 ---
 name: livewire-development
-description: >-
-  Develops reactive Livewire 4 components. Activates when creating, updating, or modifying
-  Livewire components; working with wire:model, wire:click, wire:loading, or any wire: directives;
-  adding real-time updates, loading states, or reactivity; debugging component behavior;
-  writing Livewire tests; or when the user mentions Livewire, component, counter, or reactive UI.
+description: "Develops reactive Livewire 4 components. Activates when creating, updating, or modifying Livewire components; working with wire:model, wire:click, wire:loading, or any wire: directives; adding real-time updates, loading states, or reactivity; debugging component behavior; writing Livewire tests; or when the user mentions Livewire, component, counter, or reactive UI."
+license: MIT
+metadata:
+  author: laravel
 ---
 @php
 /** @var \Laravel\Boost\Install\GuidelineAssist $assist */

--- a/.ai/mcp/skill/mcp-development/SKILL.blade.php
+++ b/.ai/mcp/skill/mcp-development/SKILL.blade.php
@@ -1,10 +1,9 @@
 ---
 name: mcp-development
-description: >-
-  Develops MCP servers, tools, resources, and prompts. Activates when creating MCP tools,
-  resources, or prompts; setting up AI integrations; debugging MCP connections; working with
-  routes/ai.php; or when the user mentions MCP, Model Context Protocol, AI tools, AI server,
-  or building tools for AI assistants.
+description: "Develops MCP servers, tools, resources, and prompts. Activates when creating MCP tools, resources, or prompts; setting up AI integrations; debugging MCP connections; working with routes/ai.php; or when the user mentions MCP, Model Context Protocol, AI tools, AI server, or building tools for AI assistants."
+license: MIT
+metadata:
+  author: laravel
 ---
 @php
 /** @var \Laravel\Boost\Install\GuidelineAssist $assist */

--- a/.ai/pennant/skill/pennant-development/SKILL.md
+++ b/.ai/pennant/skill/pennant-development/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: pennant-development
-description: >-
-  Manages feature flags with Laravel Pennant. Activates when creating, checking, or toggling
-  feature flags; showing or hiding features conditionally; implementing A/B testing; working with
-  @feature directive; or when the user mentions feature flags, feature toggles, Pennant, conditional
-  features, rollouts, or gradually enabling features.
+description: "Manages feature flags with Laravel Pennant. Activates when creating, checking, or toggling feature flags; showing or hiding features conditionally; implementing A/B testing; working with @feature directive; or when the user mentions feature flags, feature toggles, Pennant, conditional features, rollouts, or gradually enabling features."
+license: MIT
+metadata:
+  author: laravel
 ---
 # Pennant Features
 

--- a/.ai/pest/3/skill/pest-testing/SKILL.blade.php
+++ b/.ai/pest/3/skill/pest-testing/SKILL.blade.php
@@ -1,10 +1,9 @@
 ---
 name: pest-testing
-description: >-
-  Tests applications using the Pest 3 PHP framework. Activates when writing tests, creating unit or feature
-  tests, adding assertions, testing Livewire components, architecture testing, debugging test failures,
-  working with datasets or mocking; or when the user mentions test, spec, TDD, expects, assertion,
-  coverage, or needs to verify functionality works.
+description: "Tests applications using the Pest 3 PHP framework. Activates when writing tests, creating unit or feature tests, adding assertions, testing Livewire components, architecture testing, debugging test failures, working with datasets or mocking; or when the user mentions test, spec, TDD, expects, assertion, coverage, or needs to verify functionality works."
+license: MIT
+metadata:
+  author: laravel
 ---
 @php
 /** @var \Laravel\Boost\Install\GuidelineAssist $assist */

--- a/.ai/pest/4/skill/pest-testing/SKILL.blade.php
+++ b/.ai/pest/4/skill/pest-testing/SKILL.blade.php
@@ -1,10 +1,9 @@
 ---
 name: pest-testing
-description: >-
-  Tests applications using the Pest 4 PHP framework. Activates when writing tests, creating unit or feature
-  tests, adding assertions, testing Livewire components, browser testing, debugging test failures,
-  working with datasets or mocking; or when the user mentions test, spec, TDD, expects, assertion,
-  coverage, or needs to verify functionality works.
+description: "Tests applications using the Pest 4 PHP framework. Activates when writing tests, creating unit or feature tests, adding assertions, testing Livewire components, browser testing, debugging test failures, working with datasets or mocking; or when the user mentions test, spec, TDD, expects, assertion, coverage, or needs to verify functionality works."
+license: MIT
+metadata:
+  author: laravel
 ---
 @php
 /** @var \Laravel\Boost\Install\GuidelineAssist $assist */

--- a/.ai/tailwindcss/3/skill/tailwindcss-development/SKILL.md
+++ b/.ai/tailwindcss/3/skill/tailwindcss-development/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: tailwindcss-development
-description: >-
-  Styles applications using Tailwind CSS v3 utilities. Activates when adding styles, restyling components,
-  working with gradients, spacing, layout, flex, grid, responsive design, dark mode, colors,
-  typography, or borders; or when the user mentions CSS, styling, classes, Tailwind, restyle,
-  hero section, cards, buttons, or any visual/UI changes.
+description: "Styles applications using Tailwind CSS v3 utilities. Activates when adding styles, restyling components, working with gradients, spacing, layout, flex, grid, responsive design, dark mode, colors, typography, or borders; or when the user mentions CSS, styling, classes, Tailwind, restyle, hero section, cards, buttons, or any visual/UI changes."
+license: MIT
+metadata:
+  author: laravel
 ---
 # Tailwind CSS Development
 

--- a/.ai/tailwindcss/4/skill/tailwindcss-development/SKILL.md
+++ b/.ai/tailwindcss/4/skill/tailwindcss-development/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: tailwindcss-development
-description: >-
-  Styles applications using Tailwind CSS v4 utilities. Activates when adding styles, restyling components,
-  working with gradients, spacing, layout, flex, grid, responsive design, dark mode, colors,
-  typography, or borders; or when the user mentions CSS, styling, classes, Tailwind, restyle,
-  hero section, cards, buttons, or any visual/UI changes.
+description: "Styles applications using Tailwind CSS v4 utilities. Activates when adding styles, restyling components, working with gradients, spacing, layout, flex, grid, responsive design, dark mode, colors, typography, or borders; or when the user mentions CSS, styling, classes, Tailwind, restyle, hero section, cards, buttons, or any visual/UI changes."
+license: MIT
+metadata:
+  author: laravel
 ---
 # Tailwind CSS Development
 

--- a/.ai/volt/skill/volt-development/SKILL.blade.php
+++ b/.ai/volt/skill/volt-development/SKILL.blade.php
@@ -1,10 +1,9 @@
 ---
 name: volt-development
-description: >-
-  Develops single-file Livewire components with Volt. Activates when creating Volt components,
-  converting Livewire to Volt, working with @volt directive, functional or class-based Volt APIs;
-  or when the user mentions Volt, single-file components, functional Livewire, or inline component
-  logic in Blade files.
+description: "Develops single-file Livewire components with Volt. Activates when creating Volt components, converting Livewire to Volt, working with @volt directive, functional or class-based Volt APIs; or when the user mentions Volt, single-file components, functional Livewire, or inline component logic in Blade files."
+license: MIT
+metadata:
+  author: laravel
 ---
 @php
 /** @var \Laravel\Boost\Install\GuidelineAssist $assist */

--- a/.ai/wayfinder/skill/wayfinder-development/SKILL.blade.php
+++ b/.ai/wayfinder/skill/wayfinder-development/SKILL.blade.php
@@ -1,9 +1,9 @@
 ---
 name: wayfinder-development
-description: >-
-  Activates whenever referencing backend routes in frontend components. Use when
-  importing from @/actions or @/routes, calling Laravel routes from TypeScript,
-  or working with Wayfinder route functions.
+description: "Activates whenever referencing backend routes in frontend components. Use when importing from @/actions or @/routes, calling Laravel routes from TypeScript, or working with Wayfinder route functions."
+license: MIT
+metadata:
+  author: laravel
 ---
 @php
 /** @var \Laravel\Boost\Install\GuidelineAssist $assist */


### PR DESCRIPTION
Fixes #532

- SKILL files used `>-` (folded block scalar) YAML syntax for descriptions, causing "Unexpected indentation" warnings in VSCode's YAML linter even though it's valid syntax
- Replaced with quoted single-line descriptions across all 20 skill templates
- Added `license: MIT` and `metadata.author: laravel` frontmatter to all skills
