### PR TITLE
Fix normalizeCommand() splitting absolute paths containing spaces

### DIFF
--- a/src/Install/Agents/Agent.php
+++ b/src/Install/Agents/Agent.php
@@ -236,7 +236,7 @@ abstract class Agent
      */
     protected function normalizeCommand(string $command, array $args = []): array
     {
-        if (str_starts_with($command, '/') || preg_match('/^[a-zA-Z]:[\\\\\/]/', $command)) {
+        if (str_starts_with($command, '/') || preg_match('#^[a-zA-Z]:[/\\\\]#', $command)) {
             return [
                 'command' => $command,
                 'args' => $args,


### PR DESCRIPTION
## Summary

- Skip splitting in `normalizeCommand()` when the command is an absolute path (Unix `/` or Windows drive letter `C:\`), as these may contain spaces (e.g. macOS `Application Support`)
- Preserves existing behavior for relative/compound commands like `valet php` or `docker exec container php`

Fixes #549
Related: #411, #539

## Test Plan

- [x] Added test: absolute Unix path with spaces is preserved intact
- [x] Added test: absolute Unix path without spaces is preserved intact
- [x] Added test: absolute Windows path with spaces is preserved intact
- [x] Added test: file-based MCP installation writes correct config for paths with spaces
- [x] All 584 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)