### PR TITLE
Use cmd /c for Windows agent detection commands

### DIFF
--- a/src/Install/Agents/ClaudeCode.php
+++ b/src/Install/Agents/ClaudeCode.php
@@ -29,7 +29,7 @@ class ClaudeCode extends Agent implements SupportsGuidelines, SupportsMcp, Suppo
                 'command' => 'command -v claude',
             ],
             Platform::Windows => [
-                'command' => 'where claude 2>nul',
+                'command' => 'cmd /c where claude 2>nul',
             ],
         };
     }

--- a/src/Install/Agents/Codex.php
+++ b/src/Install/Agents/Codex.php
@@ -29,7 +29,7 @@ class Codex extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSk
                 'command' => 'which codex',
             ],
             Platform::Windows => [
-                'command' => 'where codex 2>nul',
+                'command' => 'cmd /c where codex 2>nul',
             ],
         };
     }

--- a/src/Install/Agents/Gemini.php
+++ b/src/Install/Agents/Gemini.php
@@ -37,7 +37,7 @@ class Gemini extends Agent implements SupportsGuidelines, SupportsMcp, SupportsS
                 'command' => 'command -v gemini',
             ],
             Platform::Windows => [
-                'command' => 'where gemini 2>nul',
+                'command' => 'cmd /c where gemini 2>nul',
             ],
         };
     }

--- a/src/Install/Agents/OpenCode.php
+++ b/src/Install/Agents/OpenCode.php
@@ -29,7 +29,7 @@ class OpenCode extends Agent implements SupportsGuidelines, SupportsMcp, Support
                 'command' => 'command -v opencode',
             ],
             Platform::Windows => [
-                'command' => 'where opencode 2>nul',
+                'command' => 'cmd /c where opencode 2>nul',
             ],
         };
     }

--- a/tests/Unit/Install/Agents/CodexTest.php
+++ b/tests/Unit/Install/Agents/CodexTest.php
@@ -122,7 +122,7 @@ test('system detection uses where command on Windows', function (): void {
 
     $config = $codex->systemDetectionConfig(Platform::Windows);
 
-    expect($config['command'])->toBe('where codex 2>nul');
+    expect($config['command'])->toBe('cmd /c where codex 2>nul');
 });
 
 test('installMcp creates TOML config file', function (): void {


### PR DESCRIPTION
## Problem

On Windows, the agent detection commands (e.g. `where claude 2>nul`) use shell  redirection syntax which PHP's `proc_open` cannot handle directly — it needs to be routed through `cmd.exe`. This caused `boost:install` to crash with a 
`ProcessStartFailedException` instead of gracefully detecting whether the agent is installed.

## Fix

Prefixed all Windows detection commands with `cmd /c` across all affected agents:
- `ClaudeCode`
- `Codex`
- `Gemini`
- `OpenCode`


related #556