### PR TITLE
Support loading guidelines and skills from vendor packages

### DIFF
--- a/src/Install/Concerns/DiscoverPackagePaths.php
+++ b/src/Install/Concerns/DiscoverPackagePaths.php
@@ -12,6 +12,28 @@ use Laravel\Roster\Roster;
 trait DiscoverPackagePaths
 {
     /**
+     * Composer package names for packages that ship guidelines within Boost's .ai/ directory.
+     *
+     * @var array<int, string>
+     */
+    protected const FIRST_PARTY_PACKAGES = [
+        'laravel/framework',
+        'laravel/folio',
+        'laravel/mcp',
+        'laravel/pennant',
+        'laravel/pint',
+        'laravel/sail',
+        'laravel/wayfinder',
+        'livewire/livewire',
+        'livewire/flux',
+        'livewire/flux-pro',
+        'livewire/volt',
+        'inertiajs/inertia-laravel',
+        'pestphp/pest',
+        'phpunit/phpunit',
+    ];
+
+    /**
      * Only include guidelines for these package names if they're a direct requirement.
      * This fixes every Boost user getting the MCP guidelines due to indirect import.
      *
@@ -94,5 +116,28 @@ trait DiscoverPackagePaths
     protected function getBoostAiPath(): string
     {
         return __DIR__.'/../../../.ai';
+    }
+
+    public static function isFirstPartyPackage(string $composerName): bool
+    {
+        return in_array($composerName, self::FIRST_PARTY_PACKAGES, true);
+    }
+
+    protected function getVendorGuidelinePath(Package $package): ?string
+    {
+        $path = base_path('vendor'.DIRECTORY_SEPARATOR
+            .str_replace('/', DIRECTORY_SEPARATOR, $package->rawName())
+            .DIRECTORY_SEPARATOR.'resources'.DIRECTORY_SEPARATOR.'boost'.DIRECTORY_SEPARATOR.'guidelines');
+
+        return is_dir($path) ? $path : null;
+    }
+
+    protected function getVendorSkillPath(Package $package): ?string
+    {
+        $path = base_path('vendor'.DIRECTORY_SEPARATOR
+            .str_replace('/', DIRECTORY_SEPARATOR, $package->rawName())
+            .DIRECTORY_SEPARATOR.'resources'.DIRECTORY_SEPARATOR.'boost'.DIRECTORY_SEPARATOR.'skills');
+
+        return is_dir($path) ? $path : null;
     }
 }

--- a/src/Install/SkillComposer.php
+++ b/src/Install/SkillComposer.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use Laravel\Boost\Concerns\RendersBladeGuidelines;
 use Laravel\Boost\Install\Concerns\DiscoverPackagePaths;
 use Laravel\Boost\Support\Composer;
+use Laravel\Roster\Package;
 use Laravel\Roster\Roster;
 use Symfony\Component\Yaml\Yaml;
 
@@ -60,12 +61,29 @@ class SkillComposer
      */
     protected function getBoostSkills(): Collection
     {
-        return $this->discoverPackagePaths($this->getBoostAiPath())
-            ->flatMap(fn (array $package): Collection => $this->discoverSkillsFromPath(
-                $package['path'],
-                $package['name'],
-                $package['version']
-            ));
+        /** @var Collection<string, Skill> $skills */
+        $skills = $this->getRoster()->packages()
+            ->reject(fn (Package $package): bool => $this->shouldExcludePackage($package))
+            ->collect()
+            ->flatMap(function (Package $package): Collection {
+                $name = $this->normalizePackageName($package->name());
+                $vendorSkillPath = self::isFirstPartyPackage($package->rawName())
+                    ? $this->getVendorSkillPath($package)
+                    : null;
+
+                $vendorSkills = $vendorSkillPath !== null
+                    ? $this->discoverSkillsFromDirectory($vendorSkillPath, $name)
+                    : collect();
+
+                $aiPath = $this->getBoostAiPath().DIRECTORY_SEPARATOR.$name;
+                $aiSkills = is_dir($aiPath)
+                    ? $this->discoverSkillsFromPath($aiPath, $name, $package->majorVersion())
+                    : collect();
+
+                return $aiSkills->merge($vendorSkills);
+            });
+
+        return $skills;
     }
 
     /**
@@ -74,6 +92,7 @@ class SkillComposer
     protected function getThirdPartySkills(): Collection
     {
         $skills = collect(Composer::packagesDirectoriesWithBoostSkills())
+            ->reject(fn (string $path, string $package): bool => self::isFirstPartyPackage($package))
             ->flatMap(fn (string $path, string $package): Collection => $this->discoverSkillsFromDirectory($path, $package));
 
         $selectedPackages = $this->config->aiGuidelines ?? [];

--- a/src/Install/ThirdPartyPackage.php
+++ b/src/Install/ThirdPartyPackage.php
@@ -33,6 +33,7 @@ class ThirdPartyPackage
         ));
 
         return collect($allPackageNames)
+            ->reject(fn (string $name): bool => GuidelineComposer::isFirstPartyPackage($name))
             ->mapWithKeys(fn (string $name): array => [
                 $name => new self(
                     name: $name,

--- a/tests/Fixtures/.ai/guidelines/laravel/core.blade.php
+++ b/tests/Fixtures/.ai/guidelines/laravel/core.blade.php
@@ -1,0 +1,3 @@
+# User Override Laravel Core
+
+This is the user's override for the Laravel core guideline.

--- a/tests/Fixtures/vendor-guidelines/core-only/core.blade.php
+++ b/tests/Fixtures/vendor-guidelines/core-only/core.blade.php
@@ -1,0 +1,3 @@
+# Vendor Core Guideline
+
+This guideline was loaded from the vendor directory.

--- a/tests/Fixtures/vendor-skills/livewire-development/SKILL.md
+++ b/tests/Fixtures/vendor-skills/livewire-development/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: livewire-development
+description: Vendor-overridden Livewire skill
+---
+
+# Livewire Development (Vendor Override)
+
+This skill was discovered from a vendor package and should override the built-in .ai/ version.

--- a/tests/Unit/Install/ThirdPartyPackageTest.php
+++ b/tests/Unit/Install/ThirdPartyPackageTest.php
@@ -44,3 +44,30 @@ it('returns correct display label', function (bool $hasGuidelines, bool $hasSkil
     'guidelines only' => [true, false, 'vendor/package (guideline)'],
     'skills only' => [false, true, 'vendor/package (skills)'],
 ]);
+
+it('excludes first-party packages from discover results', function (): void {
+    $packages = ThirdPartyPackage::discover();
+
+    $firstPartyNames = [
+        'laravel/framework',
+        'livewire/livewire',
+        'pestphp/pest',
+        'phpunit/phpunit',
+        'laravel/folio',
+        'laravel/mcp',
+        'laravel/pennant',
+        'laravel/pint',
+        'laravel/sail',
+        'laravel/wayfinder',
+        'livewire/flux',
+        'livewire/flux-pro',
+        'livewire/volt',
+        'inertiajs/inertia-laravel',
+    ];
+
+    foreach ($firstPartyNames as $name) {
+        expect($packages->has($name))->toBeFalse(
+            "First-party package {$name} should be excluded from discover()"
+        );
+    }
+});


### PR DESCRIPTION
### The Problem

Right now, Boost maintains guidelines for **all** first-party Laravel packages (Livewire, Pennant, Pint, Sail, etc.) inside its own `.ai/` directory. This means:

1. **Boost is the bottleneck**  When Inertia ships a new feature, someone has to update Boost's copy of the Inertia guidelines. The Inertia team can't update them directly.
2. **Guidelines go stale** Package v3 ships, but Boost still has v2 guidelines until someone manually updates them.
3. **Doesn't scale** Every new Laravel ecosystem package means more files for the Boost team to maintain.

### How the Current Solution Handles It

The PR introduces a **three-tier resolution system** for guidelines:

```mermaid
flowchart TD
    A["Package detected in composer.json"] --> B{"Is it a first-party package?"}
    B -->|Yes| C{"Does vendor path exist?"}
    B -->|No| F["Use third-party discovery"]
    C -->|Yes| D{"Does user have override?"}
    C -->|No| E["Fall back to Boost .ai/ copy"]
    D -->|Yes| G["Use USER override - highest priority"]
    D -->|No| H["Use VENDOR guideline"]
    E --> I{"Does user have override?"}
    I -->|Yes| G
    I -->|No| J["Use Boost .ai/ copy - fallback"]
```

### Priority Order (highest to lowest):

| Priority | Source | Who maintains it |
|----------|--------|-----------------|
| 1st | `.ai/guidelines/` in user project | The developer (user) |
| 2nd | `vendor/{pkg}/resources/boost/guidelines/` | The package maintainer |
| 3rd | Boost built-in `.ai/` directory | The Boost team |
