### PR TITLE
Allow custom MCP server configuration via config

### DIFF
--- a/config/boost.php
+++ b/config/boost.php
@@ -48,4 +48,24 @@ return [
         'vendor_bin' => env('BOOST_VENDOR_BIN_EXECUTABLE_PATH'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Boost MCP Server Configuration
+    |--------------------------------------------------------------------------
+    |
+    | These options allow you to customize the MCP server configuration that
+    | Boost uses. When a custom command is specified, it takes precedence
+    | over the automatic configuration. Leave empty to use defaults.
+    |
+    */
+
+    'mcp' => [
+        'server' => [
+            'command' => env('BOOST_MCP_SERVER_COMMAND'),
+            'args' => [],
+            'env' => [],
+            'cwd' => env('BOOST_MCP_SERVER_CWD'),
+        ],
+    ],
+
 ];

--- a/src/Contracts/SupportsMcp.php
+++ b/src/Contracts/SupportsMcp.php
@@ -30,5 +30,5 @@ interface SupportsMcp
      * @param  array<int, string>  $args
      * @param  array<string, string>  $env
      */
-    public function installMcp(string $key, string $command, array $args = [], array $env = []): bool;
+    public function installMcp(string $key, string $command, array $args = [], array $env = [], ?string $cwd = null): bool;
 }

--- a/src/Install/Agents/Agent.php
+++ b/src/Install/Agents/Agent.php
@@ -128,11 +128,11 @@ abstract class Agent
      * @param  array<int, string>  $args
      * @param  array<string, string>  $env
      */
-    public function installMcp(string $key, string $command, array $args = [], array $env = []): bool
+    public function installMcp(string $key, string $command, array $args = [], array $env = [], ?string $cwd = null): bool
     {
         return match ($this->mcpInstallationStrategy()) {
             McpInstallationStrategy::SHELL => $this->installShellMcp($key, $command, $args, $env),
-            McpInstallationStrategy::FILE => $this->installFileMcp($key, $command, $args, $env),
+            McpInstallationStrategy::FILE => $this->installFileMcp($key, $command, $args, $env, $cwd),
             McpInstallationStrategy::NONE => false
         };
     }
@@ -144,13 +144,22 @@ abstract class Agent
      * @param  array<string, string>  $env
      * @return array<string, mixed>
      */
-    public function mcpServerConfig(string $command, array $args = [], array $env = []): array
+    public function mcpServerConfig(string $command, array $args = [], array $env = [], ?string $cwd = null): array
     {
-        return [
+        $config = [
             'command' => $command,
             'args' => $args,
-            'env' => $env,
         ];
+
+        if ($env !== []) {
+            $config['env'] = $env;
+        }
+
+        if (! empty($cwd)) {
+            $config['cwd'] = $cwd;
+        }
+
+        return $config;
     }
 
     /**
@@ -205,7 +214,7 @@ abstract class Agent
      * @param  array<int, string>  $args
      * @param  array<string, string>  $env
      */
-    protected function installFileMcp(string $key, string $command, array $args = [], array $env = []): bool
+    protected function installFileMcp(string $key, string $command, array $args = [], array $env = [], ?string $cwd = null): bool
     {
         $path = $this->mcpConfigPath();
 
@@ -221,7 +230,7 @@ abstract class Agent
 
         return $writer
             ->configKey($this->mcpConfigKey())
-            ->addServerConfig($key, $this->mcpServerConfig($normalized['command'], $normalized['args'], $env))
+            ->addServerConfig($key, $this->mcpServerConfig($normalized['command'], $normalized['args'], $env, $cwd))
             ->save();
     }
 

--- a/src/Install/Agents/Codex.php
+++ b/src/Install/Agents/Codex.php
@@ -62,15 +62,17 @@ class Codex extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSk
         return 'mcp_servers';
     }
 
-    /** {@inheritDoc} */
-    public function mcpServerConfig(string $command, array $args = [], array $env = []): array
+    /** {@inheritDoc}
+     */
+    public function mcpServerConfig(string $command, array $args = [], array $env = [], ?string $cwd = null): array
     {
         return collect([
             'command' => $command,
             'args' => $args,
-            'cwd' => base_path(),
+            'cwd' => $cwd,
             'env' => $env,
-        ])->filter(fn ($value): bool => ! in_array($value, [[], null, ''], true))
+        ])
+            ->filter(fn ($value): bool => ! in_array($value, [[], null, ''], true))
             ->toArray();
     }
 

--- a/src/Install/Agents/OpenCode.php
+++ b/src/Install/Agents/OpenCode.php
@@ -70,7 +70,7 @@ class OpenCode extends Agent implements SupportsGuidelines, SupportsMcp, Support
     }
 
     /** {@inheritDoc} */
-    public function mcpServerConfig(string $command, array $args = [], array $env = []): array
+    public function mcpServerConfig(string $command, array $args = [], array $env = [], ?string $cwd = null): array
     {
         return [
             'type' => 'local',


### PR DESCRIPTION
related #564

## Summary

This PR adds support for customizing the MCP server configuration via `config/boost.php`.

Users can now override:

- `command`
- `args`
- `env`
- `cwd`

through the new `boost.mcp.server` configuration key.

---

## Example

```php
// config/boost.php

'mcp' => [
    'server' => [
        'command' => 'docker',
        'args' => [
            'compose',
            'exec',
            'app',
            'php',
            'artisan',
            'boost:mcp',
        ],
        'cwd' => base_path(),
    ],
],


