### PR TITLE
Update usePoll usage in skill

### DIFF
--- a/.ai/inertia-react/2/skill/inertia-react-development/SKILL.blade.php
+++ b/.ai/inertia-react/2/skill/inertia-react-development/SKILL.blade.php
@@ -315,11 +315,7 @@ export default function Dashboard({ stats }) {
 }
 @endboostsnippet
 
-#### Polling With Request Options and Manual Control
-
-Pass `router.reload`-compatible options as the second argument and hook options as the third:
-
-@boostsnippet("Polling With Options", "react")
+@boostsnippet("Polling With Request Options and Manual Control", "react")
 import { usePoll } from '@inertiajs/react'
 
 export default function Dashboard({ stats }) {

--- a/.ai/inertia-svelte/2/skill/inertia-svelte-development/SKILL.blade.php
+++ b/.ai/inertia-svelte/2/skill/inertia-svelte-development/SKILL.blade.php
@@ -276,11 +276,7 @@ usePoll(5000)
 </div>
 @endboostsnippet
 
-#### Polling With Request Options and Manual Control
-
-Pass `router.reload`-compatible options as the second argument and hook options as the third:
-
-@boostsnippet("Polling With Options", "svelte")
+@boostsnippet("Polling With Request Options and Manual Control", "svelte")
 <script>
 import { usePoll } from '@inertiajs/svelte'
 

--- a/.ai/inertia-vue/2/skill/inertia-vue-development/SKILL.blade.php
+++ b/.ai/inertia-vue/2/skill/inertia-vue-development/SKILL.blade.php
@@ -330,7 +330,6 @@ defineProps({
 
 Use the `usePoll` composable to automatically refresh data at intervals. It handles cleanup on unmount and throttles polling when the tab is inactive.
 
-@verbatim
 @boostsnippet("Basic Polling", "vue")
 <script setup>
 import { usePoll } from '@inertiajs/vue3'
@@ -349,14 +348,8 @@ usePoll(5000)
     </div>
 </template>
 @endboostsnippet
-@endverbatim
 
-#### Polling With Request Options and Manual Control
-
-Pass `router.reload`-compatible options as the second argument and hook options as the third:
-
-@verbatim
-@boostsnippet("Polling With Options", "vue")
+@boostsnippet("Polling With Request Options and Manual Control", "vue")
 <script setup>
 import { usePoll } from '@inertiajs/vue3'
 
@@ -387,7 +380,6 @@ const { start, stop } = usePoll(5000, {
     </div>
 </template>
 @endboostsnippet
-@endverbatim
 
 - `autoStart` (default `true`) — set to `false` to start polling manually via the returned `start()` function
 - `keepAlive` (default `false`) — set to `true` to prevent throttling when the browser tab is inactive


### PR DESCRIPTION
Summary

- Replace manual `setInterval/router.reload` polling pattern with Inertia v2's usePoll composable across Vue, React, and Svelte skill files
- Add examples for advanced usage (request options, manual start/stop, keepAlive, autoStart)