### PR TITLE
Prevent duplicate Boost guidelines in CLAUDE.md

### DIFF
--- a/src/Install/Concerns/DiscoverPackagePaths.php
+++ b/src/Install/Concerns/DiscoverPackagePaths.php
@@ -23,12 +23,13 @@ trait DiscoverPackagePaths
     ];
 
     /**
-     * Packages that should be excluded from automatic guideline inclusion.
-     * These packages require explicit configuration to be included.
+     * Packages excluded from Roster-based guideline discovery.
+     * Boost is already loaded by getCoreGuidelines(); Sail requires explicit opt-in.
      *
      * @var array<int, Packages>
      */
-    protected array $optInPackages = [
+    protected array $excludedPackages = [
+        Packages::BOOST,
         Packages::SAIL,
     ];
 
@@ -48,7 +49,7 @@ trait DiscoverPackagePaths
 
     protected function shouldExcludePackage(Package $package): bool
     {
-        if (in_array($package->package(), $this->optInPackages, true)) {
+        if (in_array($package->package(), $this->excludedPackages, true)) {
             return true;
         }
 

--- a/tests/Feature/Install/GuidelineComposerTest.php
+++ b/tests/Feature/Install/GuidelineComposerTest.php
@@ -758,6 +758,21 @@ test('user guidelines are sorted by filename for predictable ordering', function
     expect($userGuidelineKeys)->toBe(['.ai/00-first', '.ai/10-middle', '.ai/20-second']);
 });
 
+test('excludes boost package from Roster discovery to prevent duplicate core guidelines', function (): void {
+    $packages = new PackageCollection([
+        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        new Package(Packages::BOOST, 'laravel/boost', '2.1.0'),
+    ]);
+
+    $this->roster->shouldReceive('packages')->andReturn($packages);
+
+    $guidelines = $this->composer->guidelines();
+    $keys = $guidelines->keys();
+
+    expect($keys->contains('boost'))->toBeTrue()
+        ->and($keys->contains('boost/core'))->toBeFalse();
+});
+
 test('excludes Skills Activation section when skills are disabled', function (): void {
     $packages = new PackageCollection([
         new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),


### PR DESCRIPTION
`boost:install` produces duplicate guidelines — `=== boost rules ===` and `=== boost/core rules ===` with identical content — because `getCoreGuidelines()` and `getPackageGuidelines()` both load the same file under different collection keys.

Fixes #576

### Approach

- Merged `$optInPackages` and a new Boost exclusion into a single `$excludedPackages` array in the `DiscoverPackagePaths` trait, so Boost is skipped during Roster-based discovery (it's already loaded by core guidelines)
- Added a regression test that verifies `'boost'` exists but `'boost/core'` does not when Boost is in the Roster