### PR TITLE
fix: blade skills with code before frontmatter are parsed correctly

### DIFF
--- a/src/Install/SkillComposer.php
+++ b/src/Install/SkillComposer.php
@@ -170,9 +170,11 @@ class SkillComposer
             return null;
         }
 
-        $content = file_get_contents($skillFile);
+        $content = str_ends_with($skillFile, '.blade.php')
+            ? $this->renderBladeFile($skillFile)
+            : file_get_contents($skillFile);
 
-        if ($content === false) {
+        if ($content === false || $content === '') {
             return null;
         }
 
@@ -231,6 +233,6 @@ class SkillComposer
 
     protected function getGuidelineAssist(): GuidelineAssist
     {
-        return new GuidelineAssist($this->roster, $this->config, $this->skills());
+        return new GuidelineAssist($this->roster, $this->config, $this->skills ?? collect());
     }
 }

--- a/tests/Feature/Install/GuidelineComposerTest.php
+++ b/tests/Feature/Install/GuidelineComposerTest.php
@@ -19,6 +19,7 @@ beforeEach(function (): void {
     $this->roster->shouldReceive('nodePackageManager')->andReturnUsing(
         fn (): NodePackageManager => $this->nodePackageManager
     );
+    $this->roster->shouldReceive('usesVersion')->andReturn(false)->byDefault();
 
     $this->herd = Mockery::mock(Herd::class);
     $this->herd->shouldReceive('isInstalled')->andReturn(false)->byDefault();


### PR DESCRIPTION
Hello!

I was trying to make a 3rd party package skill dynamic, but it wasn't working because it wasn't passing the frontmatter test.

The fix is to render blade **before** trying to parse the frontmatter

Thanks!
