### PR TITLE
Fix post-install Next steps URL

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -136,7 +136,7 @@ class InstallCommand extends Command
 
     protected function outro(): void
     {
-        $url = 'https://laravel.com/docs/master/boost';
+        $url = 'https://laravel.com/docs/boost';
         $link = $this->hyperlink($url, $url);
         $text = 'Enjoy the boost 🚀 Next steps: ';
 


### PR DESCRIPTION
The `boost:install` outro links to `boost.laravel.com/installed/` which 302 redirects to the marketing page instead of actual next steps. Updated to point to the docs page.