### PR TITLE
Fix read-only bypass in DatabaseQuery via CTE-wrapped writes

### DIFF
--- a/src/Mcp/Tools/DatabaseQuery.php
+++ b/src/Mcp/Tools/DatabaseQuery.php
@@ -66,8 +66,14 @@ class DatabaseQuery extends Tool
         $isReadOnly = in_array($firstWord, $allowList, true);
 
         // Additional validation for WITH … SELECT.
-        if ($firstWord === 'WITH' && ! preg_match('/with\s+.*select\b/i', $query)) {
-            $isReadOnly = false;
+        if ($firstWord === 'WITH') {
+            if (! preg_match('/\)\s*SELECT\b/i', $query)) {
+                $isReadOnly = false;
+            }
+
+            if (preg_match('/\)\s*(DELETE|UPDATE|INSERT|DROP|ALTER|TRUNCATE|REPLACE|RENAME|CREATE)\b/i', $query)) {
+                $isReadOnly = false;
+            }
         }
 
         if (! $isReadOnly) {


### PR DESCRIPTION
Queries like `WITH x AS (SELECT 1) DELETE FROM users` bypass the read-only guard because the regex only checks that `SELECT` appears somewhere after `WITH`. The fix verifies the statement after the CTE is a `SELECT` and explicitly blocks write keywords after a closing paren.