### PR TITLE
Fix sendBeacon browser logs silently dropped on page unload

### DIFF
--- a/src/BoostServiceProvider.php
+++ b/src/BoostServiceProvider.php
@@ -117,6 +117,12 @@ class BoostServiceProvider extends ServiceProvider
         Route::post('/_boost/browser-logs', function (Request $request) {
             $logs = $request->input('logs', []);
 
+            // Handle sendBeacon's text/plain content type.
+            if (empty($logs) && ! $request->isJson()) {
+                $decoded = json_decode($request->getContent(), true);
+                $logs = $decoded['logs'] ?? [];
+            }
+
             /** @var Logger $logger */
             $logger = Log::channel('browser');
 


### PR DESCRIPTION
`navigator.sendBeacon()` sends `Content-Type: text/plain` when given a string, so `$request->input('logs')` returns `[]` and logs flushed on `beforeunload` are silently lost. Added server-side fallback to parse the raw body.