### PR TITLE
Scope Pint guideline to PHP file changes only

### DIFF
--- a/.ai/pint/core.blade.php
+++ b/.ai/pint/core.blade.php
@@ -4,9 +4,9 @@
 # Laravel Pint Code Formatter
 
 @if($assist->supportsPintAgentFormatter())
-- You must run `{{ $assist->binCommand('pint') }} --dirty --format agent` before finalizing changes to ensure your code matches the project's expected style.
+- If you have modified any PHP files, you must run `{{ $assist->binCommand('pint') }} --dirty --format agent` before finalizing changes to ensure your code matches the project's expected style.
 - Do not run `{{ $assist->binCommand('pint') }} --test --format agent`, simply run `{{ $assist->binCommand('pint') }} --format agent` to fix any formatting issues.
 @else
-- You must run `{{ $assist->binCommand('pint') }} --dirty` before finalizing changes to ensure your code matches the project's expected style.
+- If you have modified any PHP files, you must run `{{ $assist->binCommand('pint') }} --dirty` before finalizing changes to ensure your code matches the project's expected style.
 - Do not run `{{ $assist->binCommand('pint') }} --test`, simply run `{{ $assist->binCommand('pint') }}` to fix any formatting issues.
 @endif


### PR DESCRIPTION
Agents were running Pint unconditionally — even for documentation, config, or frontend-only changes — wasting tokens and adding unnecessary latency to every transaction.

Fixes #586

### Approach

- Add an "only if PHP files were modified" condition to the Pint run instruction, giving agents a clear and cheap signal to skip formatting when it isn't needed