### PR TITLE
Allow overriding the browser log channel

### DIFF
--- a/src/BoostServiceProvider.php
+++ b/src/BoostServiceProvider.php
@@ -181,6 +181,10 @@ class BoostServiceProvider extends ServiceProvider
 
     protected function registerBrowserLogger(): void
     {
+        if (config('logging.channels.browser') !== null) {
+            return;
+        }
+
         config([
             'logging.channels.browser' => [
                 'driver' => 'single',

--- a/tests/Feature/BoostServiceProviderTest.php
+++ b/tests/Feature/BoostServiceProviderTest.php
@@ -35,6 +35,22 @@ describe('boost.enabled configuration', function (): void {
         expect(app()->bound(Laravel\Roster\Roster::class))->toBeTrue()
             ->and(config('logging.channels.browser'))->not->toBeNull();
     });
+
+    it('does not override an existing browser log channel', function (): void {
+        Config::set('boost.enabled', true);
+        Config::set('logging.channels.browser', [
+            'driver' => 'daily',
+            'path' => storage_path('logs/custom-browser.log'),
+        ]);
+        app()->detectEnvironment(fn (): string => 'local');
+
+        $provider = new BoostServiceProvider(app());
+        $provider->register();
+        $provider->boot(app('router'));
+
+        expect(config('logging.channels.browser.driver'))->toBe('daily')
+            ->and(config('logging.channels.browser.path'))->toBe(storage_path('logs/custom-browser.log'));
+    });
 });
 
 describe('environment restrictions', function (): void {


### PR DESCRIPTION
`registerBrowserLogger()` unconditionally overwrote `logging.channels.browser` at runtime, making it impossible for users to customize the browser log channel in their `config/logging.php`.

Ports #589 by @SanderMuller to main.

### Approach

- Add a null check so the default browser channel is only applied when the user hasn't defined their own