### PR TITLE
Add Adaptive Context Engine (ACE)

### DIFF
--- a/config/boost.php
+++ b/config/boost.php
@@ -48,4 +48,28 @@ return [
         'vendor_bin' => env('BOOST_VENDOR_BIN_EXECUTABLE_PATH'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Adaptive Context Engine (ACE)
+    |--------------------------------------------------------------------------
+    |
+    | ACE consolidates MCP tools and guidelines into a compact manifest
+    | with batched context resolution. Skills remain delivered via
+    | .claude/skills/ files and are not affected by ACE.
+    |
+    | When legacy_tools is false (default), ACE replaces the 15 legacy
+    | tools with a 3-tool interface (manifest, resolve, execute) for
+    | significant token reduction. Set legacy_tools to true to keep
+    | legacy tools alongside ACE during a gradual migration.
+    |
+    */
+
+    'ace' => [
+        'enabled' => env('BOOST_ACE_ENABLED', false),
+        'legacy_tools' => false,
+        'bundles' => [
+            'exclude' => [],
+        ],
+    ],
+
 ];

--- a/src/Install/GuidelineComposer.php
+++ b/src/Install/GuidelineComposer.php
@@ -54,6 +54,22 @@ class GuidelineComposer
         return self::composeGuidelines($this->guidelines());
     }
 
+    /**
+     * Resolve a single guideline by key and return its rendered content.
+     */
+    public function resolveSlice(string $key): string
+    {
+        $guidelines = $this->guidelines();
+
+        if ($guidelines->has($key)) {
+            return trim($guidelines[$key]['content']);
+        }
+
+        $guideline = $this->guideline($key);
+
+        return trim($guideline['content']);
+    }
+
     public function customGuidelinePath(string $path = ''): string
     {
         return base_path($this->userGuidelineDir.'/'.ltrim($path, '/'));

--- a/src/Mcp/Ace/Bundle.php
+++ b/src/Mcp/Ace/Bundle.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Mcp\Ace;
+
+class Bundle
+{
+    /**
+     * @param  string[]  $sliceIds
+     * @param  array<string, array<string, mixed>>  $sliceParams  Per-slice parameter overrides
+     */
+    public function __construct(
+        public readonly string $id,
+        public readonly string $description,
+        public readonly array $sliceIds,
+        public readonly array $sliceParams = [],
+        public readonly int $estimatedTokens = 0,
+    ) {}
+}

--- a/src/Mcp/Ace/BundleRegistry.php
+++ b/src/Mcp/Ace/BundleRegistry.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Mcp\Ace;
+
+use Illuminate\Support\Collection;
+
+class BundleRegistry
+{
+    /** @var Collection<string, Bundle>|null */
+    protected ?Collection $bundles = null;
+
+    /** @var Bundle[] */
+    protected array $registered = [];
+
+    /**
+     * Register an additional bundle (e.g. from a third-party package).
+     */
+    public function register(Bundle $bundle): void
+    {
+        $this->registered[] = $bundle;
+        $this->bundles = null;
+    }
+
+    /**
+     * @return Collection<string, Bundle>
+     */
+    public function all(): Collection
+    {
+        return $this->bundles ??= $this->buildBundles();
+    }
+
+    public function get(string $id): ?Bundle
+    {
+        return $this->all()->get($id);
+    }
+
+    public function has(string $id): bool
+    {
+        return $this->all()->has($id);
+    }
+
+    /**
+     * @return Collection<string, Bundle>
+     */
+    protected function buildBundles(): Collection
+    {
+        $bundles = collect([
+            new Bundle(
+                id: '@database-work',
+                description: 'Database development context',
+                sliceIds: ['db-schema', 'db-connections', 'app-info', 'foundation'],
+                estimatedTokens: 630,
+            ),
+            new Bundle(
+                id: '@testing',
+                description: 'Testing context with Pest',
+                sliceIds: ['app-info', 'db-schema', 'routes', 'php'],
+                estimatedTokens: 800,
+            ),
+            new Bundle(
+                id: '@debug',
+                description: 'Debugging context',
+                sliceIds: ['last-error', 'browser-logs', 'app-info'],
+                sliceParams: ['browser-logs' => ['entries' => 20]],
+                estimatedTokens: 450,
+            ),
+            new Bundle(
+                id: '@new-feature',
+                description: 'Full context for new feature development',
+                sliceIds: ['foundation', 'app-info', 'db-schema', 'routes', 'artisan-commands'],
+                estimatedTokens: 1100,
+            ),
+        ])->keyBy('id');
+
+        foreach ($this->registered as $bundle) {
+            $bundles->put($bundle->id, $bundle);
+        }
+
+        $excludeList = config('boost.ace.bundles.exclude', []);
+
+        if (! empty($excludeList)) {
+            $bundles = $bundles->reject(
+                fn (Bundle $bundle) => in_array($bundle->id, $excludeList, true)
+            );
+        }
+
+        return $bundles;
+    }
+}

--- a/src/Mcp/Ace/ContextResolver.php
+++ b/src/Mcp/Ace/ContextResolver.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Mcp\Ace;
+
+use Illuminate\Support\Collection;
+
+class ContextResolver
+{
+    public function __construct(
+        protected SliceRegistry $sliceRegistry,
+        protected BundleRegistry $bundleRegistry,
+        protected GuidelineSliceResolver $guidelineResolver,
+        protected ToolSliceResolver $toolResolver,
+    ) {}
+
+    /**
+     * Resolve requested slices and bundles into assembled context.
+     *
+     * @param  array<string, array<string, mixed>>  $slices  Slice IDs with optional params
+     * @param  string[]  $bundles  Bundle IDs to expand
+     * @return Collection<string, SliceResult>
+     */
+    public function resolve(array $slices = [], array $bundles = []): Collection
+    {
+        $resolvedRequests = $this->expandAndDeduplicate($slices, $bundles);
+
+        return $resolvedRequests->map(
+            fn (array $params, string $sliceId) => $this->resolveSlice($sliceId, $params)
+        );
+    }
+
+    /**
+     * Format resolved results into a single text response.
+     *
+     * @param  Collection<string, SliceResult>  $results
+     */
+    public function format(Collection $results): string
+    {
+        $errors = $results->filter(fn (SliceResult $result) => $result->isError);
+
+        $output = $results
+            ->reject(fn (SliceResult $result) => $result->isError)
+            ->map(fn (SliceResult $result) => "=== {$result->sliceId} ===\n{$result->content}")
+            ->join("\n\n");
+
+        if ($errors->isNotEmpty()) {
+            $failedIds = $errors->keys()->join(', ');
+            $output .= "\n\n[failed: {$failedIds}]";
+        }
+
+        return $output;
+    }
+
+    /**
+     * Expand bundles and merge with explicit slices, deduplicating.
+     *
+     * @param  array<string, array<string, mixed>>  $slices
+     * @param  string[]  $bundles
+     * @return Collection<string, array<string, mixed>>  Deduplicated slice ID → params
+     */
+    protected function expandAndDeduplicate(array $slices, array $bundles): Collection
+    {
+        $merged = collect($slices);
+
+        foreach ($bundles as $bundleId) {
+            $bundle = $this->bundleRegistry->get($bundleId);
+
+            if ($bundle === null) {
+                continue;
+            }
+
+            foreach ($bundle->sliceIds as $sliceId) {
+                if ($merged->has($sliceId)) {
+                    continue;
+                }
+
+                $merged->put($sliceId, $bundle->sliceParams[$sliceId] ?? []);
+            }
+        }
+
+        return $merged;
+    }
+
+    /**
+     * @param  array<string, mixed>  $params
+     */
+    protected function resolveSlice(string $sliceId, array $params): SliceResult
+    {
+        $slice = $this->sliceRegistry->get($sliceId);
+
+        if ($slice === null) {
+            return new SliceResult($sliceId, "Unknown slice: {$sliceId}", isError: true);
+        }
+
+        if ($slice->toolClass !== null) {
+            return $this->toolResolver->resolve($slice, $params);
+        }
+
+        if ($slice->guidelineKey !== null) {
+            return $this->guidelineResolver->resolve($slice);
+        }
+
+        return new SliceResult($sliceId, "Slice '{$sliceId}' has no resolver configured.", isError: true);
+    }
+}

--- a/src/Mcp/Ace/ContextSlice.php
+++ b/src/Mcp/Ace/ContextSlice.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Mcp\Ace;
+
+class ContextSlice
+{
+    /**
+     * @param  array<string, string>  $params  Parameter definitions (name => description)
+     */
+    public function __construct(
+        public readonly string $id,
+        public readonly string $category,
+        public readonly string $label,
+        public readonly int $estimatedTokens,
+        public readonly bool $isDynamic,
+        public readonly ?string $guidelineKey = null,
+        public readonly ?string $toolClass = null,
+        public readonly array $params = [],
+    ) {}
+
+    public function hasParams(): bool
+    {
+        return $this->params !== [];
+    }
+}

--- a/src/Mcp/Ace/GuidelineSliceResolver.php
+++ b/src/Mcp/Ace/GuidelineSliceResolver.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Mcp\Ace;
+
+use Laravel\Boost\Install\GuidelineComposer;
+
+class GuidelineSliceResolver
+{
+    public function __construct(protected GuidelineComposer $composer) {}
+
+    public function resolve(ContextSlice $slice): SliceResult
+    {
+        if ($slice->guidelineKey === null) {
+            return new SliceResult($slice->id, '', isError: true);
+        }
+
+        try {
+            $content = $this->composer->resolveSlice($slice->guidelineKey);
+
+            if ($content === '') {
+                return new SliceResult($slice->id, "Guideline '{$slice->guidelineKey}' not found or empty.", isError: true);
+            }
+
+            return new SliceResult($slice->id, $content);
+        } catch (\Throwable $e) {
+            return new SliceResult($slice->id, "Error resolving guideline '{$slice->guidelineKey}': {$e->getMessage()}", isError: true);
+        }
+    }
+}

--- a/src/Mcp/Ace/Manifest.php
+++ b/src/Mcp/Ace/Manifest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Mcp\Ace;
+
+class Manifest
+{
+    public function __construct(
+        protected SliceRegistry $sliceRegistry,
+        protected BundleRegistry $bundleRegistry,
+    ) {}
+
+    public function render(): string
+    {
+        $lines = ["Available context (use resolve-context to load):\n"];
+
+        $slices = $this->sliceRegistry->all()->groupBy('category');
+
+        foreach ($slices as $category => $categorySlices) {
+            foreach ($categorySlices as $slice) {
+                /** @var ContextSlice $slice */
+                $lines[] = $this->formatSliceLine($slice);
+            }
+        }
+
+        $bundles = $this->bundleRegistry->all();
+
+        if ($bundles->isNotEmpty()) {
+            $lines[] = "\nBundles (pre-compiled):";
+
+            foreach ($bundles as $bundle) {
+                /** @var Bundle $bundle */
+                $lines[] = $this->formatBundleLine($bundle);
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+
+    protected function formatSliceLine(ContextSlice $slice): string
+    {
+        $tokens = $slice->estimatedTokens > 0 ? "~{$slice->estimatedTokens}t" : 'varies';
+        $dynamic = $slice->isDynamic ? ', live' : '';
+        $params = $slice->hasParams()
+            ? ' (param: '.implode(', ', array_keys($slice->params)).')'
+            : '';
+
+        return "[{$slice->category}]  {$slice->id}{$params} ({$tokens}{$dynamic}) - {$slice->label}";
+    }
+
+    protected function formatBundleLine(Bundle $bundle): string
+    {
+        $sliceList = implode(' + ', $bundle->sliceIds);
+
+        return "{$bundle->id} = {$sliceList} (~{$bundle->estimatedTokens}t) - {$bundle->description}";
+    }
+}

--- a/src/Mcp/Ace/SliceRegistry.php
+++ b/src/Mcp/Ace/SliceRegistry.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Mcp\Ace;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Laravel\Boost\Install\GuidelineComposer;
+use Laravel\Boost\Mcp\Tools\ApplicationInfo;
+use Laravel\Boost\Mcp\Tools\BrowserLogs;
+use Laravel\Boost\Mcp\Tools\DatabaseConnections;
+use Laravel\Boost\Mcp\Tools\DatabaseQuery;
+use Laravel\Boost\Mcp\Tools\DatabaseSchema;
+use Laravel\Boost\Mcp\Tools\GetAbsoluteUrl;
+use Laravel\Boost\Mcp\Tools\GetConfig;
+use Laravel\Boost\Mcp\Tools\LastError;
+use Laravel\Boost\Mcp\Tools\ListArtisanCommands;
+use Laravel\Boost\Mcp\Tools\ListAvailableConfigKeys;
+use Laravel\Boost\Mcp\Tools\ListAvailableEnvVars;
+use Laravel\Boost\Mcp\Tools\ListRoutes;
+use Laravel\Boost\Mcp\Tools\ReadLogEntries;
+use Laravel\Boost\Mcp\Tools\SearchDocs;
+
+class SliceRegistry
+{
+    /** @var Collection<string, ContextSlice>|null */
+    protected ?Collection $slices = null;
+
+    public function __construct(protected GuidelineComposer $composer) {}
+
+    /**
+     * @return Collection<string, ContextSlice>
+     */
+    public function all(): Collection
+    {
+        return $this->slices ??= $this->buildSlices();
+    }
+
+    public function get(string $id): ?ContextSlice
+    {
+        return $this->all()->get($id);
+    }
+
+    public function has(string $id): bool
+    {
+        return $this->all()->has($id);
+    }
+
+    /**
+     * @return Collection<string, ContextSlice>
+     */
+    protected function buildSlices(): Collection
+    {
+        return collect($this->dynamicSlices())
+            ->merge($this->staticSlices())
+            ->keyBy('id');
+    }
+
+    /**
+     * @return ContextSlice[]
+     */
+    protected function dynamicSlices(): array
+    {
+        return [
+            new ContextSlice(
+                id: 'app-info',
+                category: 'framework',
+                label: 'PHP/Laravel versions, packages, models',
+                estimatedTokens: 150,
+                isDynamic: true,
+                toolClass: ApplicationInfo::class,
+            ),
+            new ContextSlice(
+                id: 'db-schema',
+                category: 'database',
+                label: 'Table structures, columns, indexes',
+                estimatedTokens: 250,
+                isDynamic: true,
+                toolClass: DatabaseSchema::class,
+                params: ['summary' => 'Return only table names and column types (recommended first)', 'filter' => 'Filter tables by name', 'database' => 'Connection name'],
+            ),
+            new ContextSlice(
+                id: 'db-connections',
+                category: 'database',
+                label: 'Configured database connections',
+                estimatedTokens: 30,
+                isDynamic: true,
+                toolClass: DatabaseConnections::class,
+            ),
+            new ContextSlice(
+                id: 'db-query',
+                category: 'database',
+                label: 'Execute read-only SQL query',
+                estimatedTokens: 0,
+                isDynamic: true,
+                toolClass: DatabaseQuery::class,
+                params: ['query' => 'SQL SELECT query', 'database' => 'Connection name'],
+            ),
+            new ContextSlice(
+                id: 'routes',
+                category: 'framework',
+                label: 'Application route definitions',
+                estimatedTokens: 200,
+                isDynamic: true,
+                toolClass: ListRoutes::class,
+                params: ['method' => 'Filter by HTTP method', 'path' => 'Filter by path pattern'],
+            ),
+            new ContextSlice(
+                id: 'artisan-commands',
+                category: 'framework',
+                label: 'Available Artisan commands',
+                estimatedTokens: 300,
+                isDynamic: true,
+                toolClass: ListArtisanCommands::class,
+            ),
+            new ContextSlice(
+                id: 'config-keys',
+                category: 'framework',
+                label: 'Available config keys in dot notation',
+                estimatedTokens: 200,
+                isDynamic: true,
+                toolClass: ListAvailableConfigKeys::class,
+            ),
+            new ContextSlice(
+                id: 'env-vars',
+                category: 'framework',
+                label: 'Environment variable names',
+                estimatedTokens: 100,
+                isDynamic: true,
+                toolClass: ListAvailableEnvVars::class,
+            ),
+            new ContextSlice(
+                id: 'get-config',
+                category: 'config',
+                label: 'Retrieve specific config value',
+                estimatedTokens: 50,
+                isDynamic: true,
+                toolClass: GetConfig::class,
+                params: ['key' => 'Config key in dot notation'],
+            ),
+            new ContextSlice(
+                id: 'absolute-url',
+                category: 'urls',
+                label: 'Generate absolute URL for path or route',
+                estimatedTokens: 20,
+                isDynamic: true,
+                toolClass: GetAbsoluteUrl::class,
+                params: ['path' => 'Relative URL path', 'route' => 'Named route'],
+            ),
+            new ContextSlice(
+                id: 'last-error',
+                category: 'debug',
+                label: 'Most recent application error',
+                estimatedTokens: 100,
+                isDynamic: true,
+                toolClass: LastError::class,
+            ),
+            new ContextSlice(
+                id: 'browser-logs',
+                category: 'debug',
+                label: 'Browser console log entries',
+                estimatedTokens: 200,
+                isDynamic: true,
+                toolClass: BrowserLogs::class,
+                params: ['entries' => 'Number of entries to return'],
+            ),
+            new ContextSlice(
+                id: 'log-entries',
+                category: 'debug',
+                label: 'Application log entries',
+                estimatedTokens: 300,
+                isDynamic: true,
+                toolClass: ReadLogEntries::class,
+                params: ['entries' => 'Number of entries to return'],
+            ),
+            new ContextSlice(
+                id: 'search-docs',
+                category: 'docs',
+                label: 'Search Laravel ecosystem documentation',
+                estimatedTokens: 0,
+                isDynamic: true,
+                toolClass: SearchDocs::class,
+                params: ['queries' => 'Search queries (array)', 'packages' => 'Package names to search'],
+            ),
+        ];
+    }
+
+    /**
+     * @return ContextSlice[]
+     */
+    protected function staticSlices(): array
+    {
+        return $this->composer->guidelines()
+            ->map(fn (array $guideline, string $key) => new ContextSlice(
+                id: Str::slug(str_replace('/', '-', $key)),
+                category: 'guidelines',
+                label: $guideline['description'] ?? $key,
+                estimatedTokens: (int) ($guideline['tokens'] ?? 200),
+                isDynamic: false,
+                guidelineKey: $key,
+            ))
+            ->values()
+            ->all();
+    }
+}

--- a/src/Mcp/Ace/SliceResult.php
+++ b/src/Mcp/Ace/SliceResult.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Mcp\Ace;
+
+class SliceResult
+{
+    public function __construct(
+        public readonly string $sliceId,
+        public readonly string $content,
+        public readonly bool $isError = false,
+    ) {}
+}

--- a/src/Mcp/Ace/ToolSliceResolver.php
+++ b/src/Mcp/Ace/ToolSliceResolver.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Mcp\Ace;
+
+use Illuminate\Contracts\Container\Container;
+use Laravel\Boost\Mcp\ToolExecutor;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Throwable;
+
+class ToolSliceResolver
+{
+    public function __construct(
+        protected Container $container,
+        protected ToolExecutor $executor,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $params
+     */
+    public function resolve(ContextSlice $slice, array $params = []): SliceResult
+    {
+        if ($slice->toolClass === null) {
+            return new SliceResult($slice->id, '', isError: true);
+        }
+
+        try {
+            $response = $this->executor->runInProcess($slice->toolClass, $params);
+
+            /** @var Tool $tool */
+            $tool = $this->container->make($slice->toolClass);
+
+            $content = $this->extractResponseText($response, $tool);
+
+            return new SliceResult($slice->id, $content, isError: $response->isError());
+        } catch (Throwable $e) {
+            return new SliceResult($slice->id, "Error resolving '{$slice->id}': {$e->getMessage()}", isError: true);
+        }
+    }
+
+    protected function extractResponseText(Response $response, Tool $tool): string
+    {
+        $contentObj = $response->content();
+        $toolArray = $contentObj->toTool($tool);
+
+        return $toolArray['text'] ?? '';
+    }
+}

--- a/src/Mcp/Tools/BoostManifest.php
+++ b/src/Mcp/Tools/BoostManifest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Mcp\Tools;
+
+use Laravel\Boost\Mcp\Ace\Manifest;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+class BoostManifest extends Tool
+{
+    protected string $description = 'Get the manifest of all available context slices and bundles. Returns a compact catalog (~200 tokens) of what context you can load with resolve-context. Call this first to see what is available.';
+
+    public function __construct(protected Manifest $manifest) {}
+
+    public function handle(Request $request): Response
+    {
+        return Response::text($this->manifest->render());
+    }
+}

--- a/src/Mcp/Tools/Execute.php
+++ b/src/Mcp/Tools/Execute.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\JsonSchema\Types\Type;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+
+class Execute extends Tool
+{
+    protected string $description = 'Execute PHP code in the Laravel application context (like Tinker). Use this for write operations, debugging, running code snippets. Runs in an isolated subprocess for safety. Prefer existing artisan commands over custom code. Do not create models directly without explicit user approval.';
+
+    /**
+     * @return array<string, Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'code' => $schema->string()
+                ->description('PHP code to execute (without opening <?php tags)')
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $tinker = app(Tinker::class);
+
+        return $tinker->handle($request);
+    }
+}

--- a/src/Mcp/Tools/ResolveContext.php
+++ b/src/Mcp/Tools/ResolveContext.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\JsonSchema\Types\Type;
+use Laravel\Boost\Mcp\Ace\ContextResolver;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[IsReadOnly]
+class ResolveContext extends Tool
+{
+    protected string $description = 'Load context by resolving one or more slices and/or bundles in a single call. Pass slice IDs with optional parameters, and/or bundle IDs (prefixed with @). Use boost-manifest to see available slices and bundles first. This batches multiple data sources into one response, eliminating the need for multiple tool calls.';
+
+    public function __construct(protected ContextResolver $resolver) {}
+
+    /**
+     * @return array<string, Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'slices' => $schema->object()
+                ->description('Map of slice IDs to their parameters. Use {} for no params. Example: {"db-schema": {"filter": "users"}, "app-info": {}}'),
+            'bundles' => $schema->array()
+                ->items($schema->string()->description('Bundle ID (e.g., "@database-work", "@debug")'))
+                ->description('List of bundle IDs to expand and resolve'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $slices = $request->get('slices', []);
+        $bundles = $request->get('bundles', []);
+
+        if (empty($slices) && empty($bundles)) {
+            return Response::error('At least one slice or bundle must be specified. Use boost-manifest to see available options.');
+        }
+
+        // Normalize slices: ensure each value is an array of params
+        $normalizedSlices = [];
+        foreach ($slices as $id => $params) {
+            $normalizedSlices[$id] = is_array($params) ? $params : [];
+        }
+
+        $results = $this->resolver->resolve($normalizedSlices, $bundles);
+
+        return Response::text($this->resolver->format($results));
+    }
+}

--- a/src/Mcp/Tools/SearchDocs.php
+++ b/src/Mcp/Tools/SearchDocs.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Mcp\Tools;
 
-use Generator;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\JsonSchema\Types\Type;
 use Laravel\Boost\Concerns\MakesHttpRequests;
@@ -52,7 +51,7 @@ class SearchDocs extends Tool
     /**
      * Handle the tool request.
      */
-    public function handle(Request $request): Response|Generator
+    public function handle(Request $request): Response
     {
         $apiUrl = config('boost.hosted.api_url', 'https://boost.laravel.com').'/api/docs';
         $packagesFilter = $request->get('packages');

--- a/tests/Feature/Mcp/Ace/BoostManifestToolTest.php
+++ b/tests/Feature/Mcp/Ace/BoostManifestToolTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Mcp\Ace\Manifest;
+use Laravel\Boost\Mcp\Tools\BoostManifest;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+
+test('boost-manifest returns a text response with all slices', function (): void {
+    $tool = app(BoostManifest::class);
+
+    $response = $tool->handle(new Request([]));
+
+    expect($response)->toBeInstanceOf(Response::class)
+        ->and($response->isError())->toBeFalse();
+
+    $text = getResponseText($response, $tool);
+
+    expect($text)->toContain('Available context')
+        ->and($text)->toContain('resolve-context');
+});
+
+test('boost-manifest lists all 14 dynamic slices', function (): void {
+    $tool = app(BoostManifest::class);
+    $text = getResponseText($tool->handle(new Request([])), $tool);
+
+    $expectedSlices = [
+        'app-info', 'db-schema', 'db-connections', 'db-query', 'routes',
+        'artisan-commands', 'config-keys', 'env-vars', 'get-config',
+        'absolute-url', 'last-error', 'browser-logs', 'log-entries', 'search-docs',
+    ];
+
+    foreach ($expectedSlices as $slice) {
+        expect($text)->toContain($slice);
+    }
+});
+
+test('boost-manifest lists all bundles', function (): void {
+    $tool = app(BoostManifest::class);
+    $text = getResponseText($tool->handle(new Request([])), $tool);
+
+    expect($text)->toContain('@database-work')
+        ->and($text)->toContain('@testing')
+        ->and($text)->toContain('@debug')
+        ->and($text)->toContain('@new-feature');
+});
+
+test('boost-manifest lists guideline slices', function (): void {
+    $tool = app(BoostManifest::class);
+    $text = getResponseText($tool->handle(new Request([])), $tool);
+
+    expect($text)->toContain('[guidelines]')
+        ->and($text)->toContain('foundation');
+});
+
+test('boost-manifest includes param indicators for parameterized slices', function (): void {
+    $tool = app(BoostManifest::class);
+    $text = getResponseText($tool->handle(new Request([])), $tool);
+
+    // db-schema has summary, filter and database params
+    expect($text)->toContain('(param: summary, filter, database)');
+});
+
+function getResponseText(Response $response, $tool): string
+{
+    $content = $response->content();
+
+    return $content->toTool($tool)['text'] ?? '';
+}

--- a/tests/Feature/Mcp/Ace/BoostWithAceTest.php
+++ b/tests/Feature/Mcp/Ace/BoostWithAceTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Mcp\Boost;
+use Laravel\Boost\Mcp\Tools\BoostManifest;
+use Laravel\Boost\Mcp\Tools\Execute;
+use Laravel\Boost\Mcp\Tools\ResolveContext;
+use Laravel\Boost\Mcp\Tools\Tinker;
+use Laravel\Mcp\Server\Contracts\Transport;
+
+function bootAndGetTools(): array
+{
+    $transport = Mockery::mock(Transport::class);
+    $boost = new Boost($transport);
+
+    $reflection = new ReflectionClass($boost);
+    $bootMethod = $reflection->getMethod('boot');
+    $bootMethod->invoke($boost);
+
+    $toolsProp = $reflection->getProperty('tools');
+
+    return $toolsProp->getValue($boost);
+}
+
+test('ace disabled uses legacy tools only', function (): void {
+    config()->set('boost.ace.enabled', false);
+
+    $tools = bootAndGetTools();
+
+    expect($tools)->not->toContain(BoostManifest::class)
+        ->and($tools)->not->toContain(ResolveContext::class)
+        ->and($tools)->not->toContain(Execute::class)
+        ->and($tools)->toContain(Tinker::class);
+});
+
+test('ace enabled includes ace tools', function (): void {
+    config()->set('boost.ace.enabled', true);
+    config()->set('boost.ace.legacy_tools', true);
+
+    $tools = bootAndGetTools();
+
+    expect($tools)->toContain(BoostManifest::class)
+        ->and($tools)->toContain(ResolveContext::class)
+        ->and($tools)->toContain(Execute::class);
+});
+
+test('ace enabled with legacy tools includes all tools except tinker', function (): void {
+    config()->set('boost.ace.enabled', true);
+    config()->set('boost.ace.legacy_tools', true);
+
+    $tools = bootAndGetTools();
+
+    // Execute replaces Tinker when ACE is enabled to avoid duplicate tools
+    expect($tools)->toContain(BoostManifest::class)
+        ->and($tools)->toContain(ResolveContext::class)
+        ->and($tools)->toContain(Execute::class)
+        ->and($tools)->not->toContain(Tinker::class);
+});
+
+test('ace enabled without legacy tools only has ace tools', function (): void {
+    config()->set('boost.ace.enabled', true);
+    config()->set('boost.ace.legacy_tools', false);
+
+    $tools = bootAndGetTools();
+
+    expect($tools)->toContain(BoostManifest::class)
+        ->and($tools)->toContain(ResolveContext::class)
+        ->and($tools)->toContain(Execute::class)
+        ->and($tools)->not->toContain(Tinker::class);
+});

--- a/tests/Feature/Mcp/Ace/ContextResolverTest.php
+++ b/tests/Feature/Mcp/Ace/ContextResolverTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Mcp\Ace\BundleRegistry;
+use Laravel\Boost\Mcp\Ace\ContextResolver;
+use Laravel\Boost\Mcp\Ace\GuidelineSliceResolver;
+use Laravel\Boost\Mcp\Ace\SliceRegistry;
+use Laravel\Boost\Mcp\Ace\SliceResult;
+use Laravel\Boost\Mcp\Ace\ToolSliceResolver;
+
+test('resolves a single dynamic slice', function (): void {
+    $resolver = app(ContextResolver::class);
+
+    $results = $resolver->resolve(['db-connections' => []]);
+
+    expect($results)->toHaveCount(1)
+        ->and($results->has('db-connections'))->toBeTrue()
+        ->and($results->get('db-connections'))->toBeInstanceOf(SliceResult::class)
+        ->and($results->get('db-connections')->isError)->toBeFalse()
+        ->and($results->get('db-connections')->content)->not->toBeEmpty();
+});
+
+test('resolves multiple slices at once', function (): void {
+    $resolver = app(ContextResolver::class);
+
+    $results = $resolver->resolve([
+        'db-connections' => [],
+        'config-keys' => [],
+    ]);
+
+    expect($results)->toHaveCount(2)
+        ->and($results->get('db-connections')->isError)->toBeFalse()
+        ->and($results->get('config-keys')->isError)->toBeFalse();
+});
+
+test('resolves slices with parameters', function (): void {
+    $resolver = app(ContextResolver::class);
+
+    $results = $resolver->resolve([
+        'get-config' => ['key' => 'app.name'],
+    ]);
+
+    expect($results)->toHaveCount(1)
+        ->and($results->get('get-config')->isError)->toBeFalse()
+        ->and($results->get('get-config')->content)->toContain('Laravel');
+});
+
+test('expands @debug bundle into slices', function (): void {
+    $resolver = app(ContextResolver::class);
+
+    $results = $resolver->resolve([], ['@debug']);
+
+    // @debug = last-error + browser-logs + app-info
+    expect($results)->toHaveCount(3)
+        ->and($results->has('last-error'))->toBeTrue()
+        ->and($results->has('browser-logs'))->toBeTrue()
+        ->and($results->has('app-info'))->toBeTrue();
+});
+
+test('expands @database-work bundle without errors', function (): void {
+    $resolver = app(ContextResolver::class);
+
+    $results = $resolver->resolve([], ['@database-work']);
+
+    // Every slice in the bundle should resolve (no "Unknown slice" errors)
+    $results->each(function (SliceResult $result) {
+        expect($result->content)->not->toContain('Unknown slice');
+    });
+
+    expect($results->has('db-schema'))->toBeTrue()
+        ->and($results->has('db-connections'))->toBeTrue()
+        ->and($results->has('app-info'))->toBeTrue()
+        ->and($results->has('foundation'))->toBeTrue();
+});
+
+test('expands @testing bundle without errors', function (): void {
+    $resolver = app(ContextResolver::class);
+
+    $results = $resolver->resolve([], ['@testing']);
+
+    $results->each(function (SliceResult $result) {
+        expect($result->content)->not->toContain('Unknown slice');
+    });
+
+    expect($results->has('app-info'))->toBeTrue()
+        ->and($results->has('db-schema'))->toBeTrue();
+});
+
+test('expands @new-feature bundle without errors', function (): void {
+    $resolver = app(ContextResolver::class);
+
+    $results = $resolver->resolve([], ['@new-feature']);
+
+    $results->each(function (SliceResult $result) {
+        expect($result->content)->not->toContain('Unknown slice');
+    });
+
+    expect($results->has('foundation'))->toBeTrue()
+        ->and($results->has('app-info'))->toBeTrue()
+        ->and($results->has('db-schema'))->toBeTrue()
+        ->and($results->has('routes'))->toBeTrue();
+});
+
+test('deduplicates slices from bundles and explicit requests', function (): void {
+    $resolver = app(ContextResolver::class);
+
+    // Explicitly request app-info AND use @debug bundle (which includes app-info)
+    $results = $resolver->resolve(
+        ['app-info' => []],
+        ['@debug']
+    );
+
+    // Should still only have 3 entries (not 4)
+    expect($results)->toHaveCount(3)
+        ->and($results->has('app-info'))->toBeTrue();
+});
+
+test('returns error for unknown slice', function (): void {
+    $resolver = app(ContextResolver::class);
+
+    $results = $resolver->resolve(['nonexistent' => []]);
+
+    expect($results)->toHaveCount(1)
+        ->and($results->get('nonexistent')->isError)->toBeTrue()
+        ->and($results->get('nonexistent')->content)->toContain('Unknown slice');
+});
+
+test('ignores unknown bundles', function (): void {
+    $resolver = app(ContextResolver::class);
+
+    $results = $resolver->resolve(
+        ['db-connections' => []],
+        ['@nonexistent']
+    );
+
+    // Only the explicit slice should be resolved
+    expect($results)->toHaveCount(1)
+        ->and($results->has('db-connections'))->toBeTrue();
+});
+
+test('formats results with section markers', function (): void {
+    $resolver = app(ContextResolver::class);
+
+    $results = $resolver->resolve([
+        'db-connections' => [],
+        'config-keys' => [],
+    ]);
+
+    $formatted = $resolver->format($results);
+
+    expect($formatted)->toContain('=== db-connections ===')
+        ->and($formatted)->toContain('=== config-keys ===');
+});
+
+test('format excludes error content but appends failure summary', function (): void {
+    $resolver = app(ContextResolver::class);
+
+    $results = $resolver->resolve([
+        'nonexistent' => [],
+        'db-connections' => [],
+    ]);
+
+    $formatted = $resolver->format($results);
+
+    expect($formatted)->toContain('=== db-connections ===')
+        ->and($formatted)->not->toContain('=== nonexistent ===')
+        ->and($formatted)->not->toContain('Unknown slice')
+        ->and($formatted)->toContain('[failed: nonexistent]');
+});
+
+test('format has no failure summary when all slices succeed', function (): void {
+    $resolver = app(ContextResolver::class);
+
+    $results = $resolver->resolve([
+        'db-connections' => [],
+        'config-keys' => [],
+    ]);
+
+    $formatted = $resolver->format($results);
+
+    expect($formatted)->not->toContain('[failed:');
+});
+
+test('error in one slice does not affect other slices', function (): void {
+    $resolver = app(ContextResolver::class);
+
+    $results = $resolver->resolve([
+        'nonexistent' => [],
+        'db-connections' => [],
+    ]);
+
+    expect($results)->toHaveCount(2)
+        ->and($results->get('nonexistent')->isError)->toBeTrue()
+        ->and($results->get('db-connections')->isError)->toBeFalse()
+        ->and($results->get('db-connections')->content)->not->toBeEmpty();
+});

--- a/tests/Feature/Mcp/Ace/ResolveContextToolTest.php
+++ b/tests/Feature/Mcp/Ace/ResolveContextToolTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Mcp\Tools\ResolveContext;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+
+test('resolve-context returns error when no slices or bundles given', function (): void {
+    $tool = app(ResolveContext::class);
+
+    $response = $tool->handle(new Request([]));
+
+    expect($response->isError())->toBeTrue();
+});
+
+test('resolve-context resolves a single slice', function (): void {
+    $tool = app(ResolveContext::class);
+
+    $response = $tool->handle(new Request([
+        'slices' => ['db-connections' => []],
+    ]));
+
+    expect($response->isError())->toBeFalse();
+
+    $text = $response->content()->toTool($tool)['text'] ?? '';
+
+    expect($text)->toContain('=== db-connections ===');
+});
+
+test('resolve-context resolves multiple slices in one call', function (): void {
+    $tool = app(ResolveContext::class);
+
+    $response = $tool->handle(new Request([
+        'slices' => [
+            'db-connections' => [],
+            'config-keys' => [],
+        ],
+    ]));
+
+    $text = $response->content()->toTool($tool)['text'] ?? '';
+
+    expect($text)->toContain('=== db-connections ===')
+        ->and($text)->toContain('=== config-keys ===');
+});
+
+test('resolve-context passes parameters to slices', function (): void {
+    $tool = app(ResolveContext::class);
+
+    $response = $tool->handle(new Request([
+        'slices' => ['get-config' => ['key' => 'app.name']],
+    ]));
+
+    $text = $response->content()->toTool($tool)['text'] ?? '';
+
+    expect($text)->toContain('=== get-config ===')
+        ->and($text)->toContain('Laravel');
+});
+
+test('resolve-context expands a bundle', function (): void {
+    $tool = app(ResolveContext::class);
+
+    $response = $tool->handle(new Request([
+        'bundles' => ['@debug'],
+    ]));
+
+    $text = $response->content()->toTool($tool)['text'] ?? '';
+
+    expect($text)->toContain('=== app-info ===');
+});
+
+test('resolve-context combines slices and bundles with deduplication', function (): void {
+    $tool = app(ResolveContext::class);
+
+    // Explicitly request app-info AND use @debug which includes app-info
+    $response = $tool->handle(new Request([
+        'slices' => ['app-info' => []],
+        'bundles' => ['@debug'],
+    ]));
+
+    $text = $response->content()->toTool($tool)['text'] ?? '';
+
+    // app-info should appear only once
+    $count = substr_count($text, '=== app-info ===');
+    expect($count)->toBe(1);
+});
+
+test('resolve-context reports failed slices in output', function (): void {
+    $tool = app(ResolveContext::class);
+
+    $response = $tool->handle(new Request([
+        'slices' => [
+            'nonexistent' => [],
+            'db-connections' => [],
+        ],
+    ]));
+
+    $text = $response->content()->toTool($tool)['text'] ?? '';
+
+    expect($text)->toContain('=== db-connections ===')
+        ->and($text)->toContain('[failed: nonexistent]')
+        ->and($text)->not->toContain('=== nonexistent ===');
+});
+
+test('resolve-context normalizes non-array slice params', function (): void {
+    $tool = app(ResolveContext::class);
+
+    // Some LLMs might pass null or scalar instead of array for params
+    $response = $tool->handle(new Request([
+        'slices' => ['db-connections' => null],
+    ]));
+
+    expect($response->isError())->toBeFalse();
+
+    $text = $response->content()->toTool($tool)['text'] ?? '';
+
+    expect($text)->toContain('=== db-connections ===');
+});

--- a/tests/Feature/Mcp/Ace/ToolExecutorInProcessTest.php
+++ b/tests/Feature/Mcp/Ace/ToolExecutorInProcessTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Mcp\ToolExecutor;
+use Laravel\Boost\Mcp\Tools\GetConfig;
+use Laravel\Boost\Mcp\Tools\Tinker;
+use Laravel\Mcp\Response;
+
+test('executes read-only tools in-process when ace enabled', function (): void {
+    config()->set('boost.ace.enabled', true);
+
+    $executor = new ToolExecutor;
+
+    $response = $executor->execute(GetConfig::class, ['key' => 'app.name']);
+
+    expect($response)->toBeInstanceOf(Response::class)
+        ->and($response->isError())->toBeFalse();
+});
+
+test('shouldExecuteInProcess returns true for read-only tools when ace enabled', function (): void {
+    config()->set('boost.ace.enabled', true);
+
+    $executor = new ToolExecutor;
+    $reflection = new ReflectionClass($executor);
+    $method = $reflection->getMethod('shouldExecuteInProcess');
+
+    expect($method->invoke($executor, GetConfig::class))->toBeTrue();
+});
+
+test('shouldExecuteInProcess returns false when ace disabled', function (): void {
+    config()->set('boost.ace.enabled', false);
+
+    $executor = new ToolExecutor;
+    $reflection = new ReflectionClass($executor);
+    $method = $reflection->getMethod('shouldExecuteInProcess');
+
+    expect($method->invoke($executor, GetConfig::class))->toBeFalse();
+});
+
+test('shouldExecuteInProcess returns false for non-readonly tools', function (): void {
+    config()->set('boost.ace.enabled', true);
+
+    $executor = new ToolExecutor;
+    $reflection = new ReflectionClass($executor);
+    $method = $reflection->getMethod('shouldExecuteInProcess');
+
+    expect($method->invoke($executor, Tinker::class))->toBeFalse();
+});
+
+test('in-process execution runs in same PID', function (): void {
+    config()->set('boost.ace.enabled', true);
+
+    $executor = new ToolExecutor;
+    $reflection = new ReflectionClass($executor);
+    $method = $reflection->getMethod('executeInProcess');
+
+    // Use Tinker-like approach but via GetConfig which runs in-process
+    $response = $executor->execute(GetConfig::class, ['key' => 'app.name']);
+
+    expect($response->isError())->toBeFalse();
+});

--- a/tests/Feature/Mcp/Ace/ToolSliceResolverTest.php
+++ b/tests/Feature/Mcp/Ace/ToolSliceResolverTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Mcp\Ace\ContextSlice;
+use Laravel\Boost\Mcp\Ace\SliceResult;
+use Laravel\Boost\Mcp\Ace\ToolSliceResolver;
+use Laravel\Boost\Mcp\Tools\DatabaseConnections;
+use Laravel\Boost\Mcp\Tools\GetConfig;
+
+test('resolves tool slice in-process', function (): void {
+    $resolver = app(ToolSliceResolver::class);
+
+    $slice = new ContextSlice(
+        id: 'db-connections',
+        category: 'database',
+        label: 'Database connections',
+        estimatedTokens: 30,
+        isDynamic: true,
+        toolClass: DatabaseConnections::class,
+    );
+
+    $result = $resolver->resolve($slice);
+
+    expect($result)->toBeInstanceOf(SliceResult::class)
+        ->and($result->isError)->toBeFalse()
+        ->and($result->sliceId)->toBe('db-connections')
+        ->and($result->content)->not->toBeEmpty();
+});
+
+test('passes parameters to tool', function (): void {
+    $resolver = app(ToolSliceResolver::class);
+
+    $slice = new ContextSlice(
+        id: 'get-config',
+        category: 'config',
+        label: 'Config value',
+        estimatedTokens: 50,
+        isDynamic: true,
+        toolClass: GetConfig::class,
+        params: ['key' => 'Config key'],
+    );
+
+    $result = $resolver->resolve($slice, ['key' => 'app.name']);
+
+    expect($result->isError)->toBeFalse()
+        ->and($result->content)->toContain('Laravel');
+});
+
+test('returns error for slice without tool class', function (): void {
+    $resolver = app(ToolSliceResolver::class);
+
+    $slice = new ContextSlice(
+        id: 'test-slice',
+        category: 'test',
+        label: 'Test',
+        estimatedTokens: 0,
+        isDynamic: true,
+    );
+
+    $result = $resolver->resolve($slice);
+
+    expect($result->isError)->toBeTrue();
+});
+
+test('catches exceptions from failing tools', function (): void {
+    $resolver = app(ToolSliceResolver::class);
+
+    $slice = new ContextSlice(
+        id: 'get-config',
+        category: 'config',
+        label: 'Config value',
+        estimatedTokens: 50,
+        isDynamic: true,
+        toolClass: GetConfig::class,
+        params: ['key' => 'Config key'],
+    );
+
+    // Missing required 'key' parameter should not crash
+    $result = $resolver->resolve($slice, []);
+
+    // The tool may return an error or succeed with empty key - either way it shouldn't throw
+    expect($result)->toBeInstanceOf(SliceResult::class);
+});

--- a/tests/Unit/Mcp/Ace/BundleRegistryTest.php
+++ b/tests/Unit/Mcp/Ace/BundleRegistryTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Mcp\Ace\Bundle;
+use Laravel\Boost\Mcp\Ace\BundleRegistry;
+
+test('returns all registered bundles', function (): void {
+    $registry = new BundleRegistry;
+
+    $bundles = $registry->all();
+
+    expect($bundles)->not->toBeEmpty()
+        ->and($bundles->count())->toBe(4);
+});
+
+test('all bundles are Bundle instances', function (): void {
+    $registry = new BundleRegistry;
+
+    $registry->all()->each(function ($bundle): void {
+        expect($bundle)->toBeInstanceOf(Bundle::class);
+    });
+});
+
+test('can get bundle by id', function (): void {
+    $registry = new BundleRegistry;
+
+    $bundle = $registry->get('@database-work');
+
+    expect($bundle)->toBeInstanceOf(Bundle::class)
+        ->and($bundle->id)->toBe('@database-work')
+        ->and($bundle->sliceIds)->toContain('db-schema', 'db-connections', 'app-info', 'foundation');
+});
+
+test('returns null for unknown bundle', function (): void {
+    $registry = new BundleRegistry;
+
+    expect($registry->get('@nonexistent'))->toBeNull();
+});
+
+test('has returns true for existing bundles', function (): void {
+    $registry = new BundleRegistry;
+
+    expect($registry->has('@database-work'))->toBeTrue()
+        ->and($registry->has('@testing'))->toBeTrue()
+        ->and($registry->has('@debug'))->toBeTrue()
+        ->and($registry->has('@new-feature'))->toBeTrue();
+});
+
+test('debug bundle includes default params for browser-logs', function (): void {
+    $registry = new BundleRegistry;
+
+    $bundle = $registry->get('@debug');
+
+    expect($bundle->sliceParams)->toHaveKey('browser-logs')
+        ->and($bundle->sliceParams['browser-logs'])->toBe(['entries' => 20]);
+});
+
+test('caches bundles across calls', function (): void {
+    $registry = new BundleRegistry;
+
+    $first = $registry->all();
+    $second = $registry->all();
+
+    expect($first)->toBe($second);
+});
+
+test('register adds a custom bundle', function (): void {
+    $registry = new BundleRegistry;
+
+    $registry->register(new Bundle(
+        id: '@custom',
+        description: 'Custom bundle',
+        sliceIds: ['app-info', 'routes'],
+        estimatedTokens: 350,
+    ));
+
+    expect($registry->has('@custom'))->toBeTrue()
+        ->and($registry->get('@custom')->sliceIds)->toBe(['app-info', 'routes'])
+        ->and($registry->all()->count())->toBe(5);
+});
+
+test('register clears cache so new bundle appears', function (): void {
+    $registry = new BundleRegistry;
+
+    $before = $registry->all()->count();
+
+    $registry->register(new Bundle(
+        id: '@late-add',
+        description: 'Added after first access',
+        sliceIds: ['db-schema'],
+    ));
+
+    expect($registry->all()->count())->toBe($before + 1);
+});
+
+test('register can override a built-in bundle', function (): void {
+    $registry = new BundleRegistry;
+
+    $registry->register(new Bundle(
+        id: '@debug',
+        description: 'Overridden debug',
+        sliceIds: ['last-error'],
+        estimatedTokens: 100,
+    ));
+
+    $bundle = $registry->get('@debug');
+
+    expect($bundle->description)->toBe('Overridden debug')
+        ->and($bundle->sliceIds)->toBe(['last-error']);
+});
+
+test('exclude config filters out bundles', function (): void {
+    config()->set('boost.ace.bundles.exclude', ['@debug', '@testing']);
+
+    $registry = new BundleRegistry;
+
+    expect($registry->has('@debug'))->toBeFalse()
+        ->and($registry->has('@testing'))->toBeFalse()
+        ->and($registry->has('@database-work'))->toBeTrue()
+        ->and($registry->has('@new-feature'))->toBeTrue()
+        ->and($registry->all()->count())->toBe(2);
+});

--- a/tests/Unit/Mcp/Ace/BundleTest.php
+++ b/tests/Unit/Mcp/Ace/BundleTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Mcp\Ace\Bundle;
+
+test('constructs with required properties', function (): void {
+    $bundle = new Bundle(
+        id: '@database-work',
+        description: 'Database development context',
+        sliceIds: ['db-schema', 'db-connections', 'app-info'],
+        estimatedTokens: 630,
+    );
+
+    expect($bundle->id)->toBe('@database-work')
+        ->and($bundle->description)->toBe('Database development context')
+        ->and($bundle->sliceIds)->toBe(['db-schema', 'db-connections', 'app-info'])
+        ->and($bundle->sliceParams)->toBe([])
+        ->and($bundle->estimatedTokens)->toBe(630);
+});
+
+test('constructs with slice params', function (): void {
+    $bundle = new Bundle(
+        id: '@debug',
+        description: 'Debugging context',
+        sliceIds: ['last-error', 'browser-logs'],
+        sliceParams: ['browser-logs' => ['entries' => 20]],
+        estimatedTokens: 300,
+    );
+
+    expect($bundle->sliceParams)->toBe(['browser-logs' => ['entries' => 20]]);
+});

--- a/tests/Unit/Mcp/Ace/ContextSliceTest.php
+++ b/tests/Unit/Mcp/Ace/ContextSliceTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Mcp\Ace\ContextSlice;
+use Laravel\Boost\Mcp\Tools\DatabaseSchema;
+
+test('constructs with required properties', function (): void {
+    $slice = new ContextSlice(
+        id: 'db-schema',
+        category: 'database',
+        label: 'Table structures',
+        estimatedTokens: 250,
+        isDynamic: true,
+    );
+
+    expect($slice->id)->toBe('db-schema')
+        ->and($slice->category)->toBe('database')
+        ->and($slice->label)->toBe('Table structures')
+        ->and($slice->estimatedTokens)->toBe(250)
+        ->and($slice->isDynamic)->toBeTrue()
+        ->and($slice->guidelineKey)->toBeNull()
+        ->and($slice->toolClass)->toBeNull()
+        ->and($slice->params)->toBe([]);
+});
+
+test('hasParams returns true when params exist', function (): void {
+    $slice = new ContextSlice(
+        id: 'db-schema',
+        category: 'database',
+        label: 'Table structures',
+        estimatedTokens: 250,
+        isDynamic: true,
+        toolClass: DatabaseSchema::class,
+        params: ['filter' => 'Filter by name'],
+    );
+
+    expect($slice->hasParams())->toBeTrue();
+});
+
+test('hasParams returns false when no params', function (): void {
+    $slice = new ContextSlice(
+        id: 'app-info',
+        category: 'framework',
+        label: 'Application info',
+        estimatedTokens: 150,
+        isDynamic: true,
+    );
+
+    expect($slice->hasParams())->toBeFalse();
+});
+

--- a/tests/Unit/Mcp/Ace/GuidelineSliceResolverTest.php
+++ b/tests/Unit/Mcp/Ace/GuidelineSliceResolverTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Mcp\Ace\ContextSlice;
+use Laravel\Boost\Mcp\Ace\GuidelineSliceResolver;
+use Laravel\Boost\Mcp\Ace\SliceResult;
+
+test('resolves a guideline slice by key', function (): void {
+    $resolver = app(GuidelineSliceResolver::class);
+
+    $slice = new ContextSlice(
+        id: 'foundation',
+        category: 'guidelines',
+        label: 'Foundation guidelines',
+        estimatedTokens: 200,
+        isDynamic: false,
+        guidelineKey: 'foundation',
+    );
+
+    $result = $resolver->resolve($slice);
+
+    expect($result)->toBeInstanceOf(SliceResult::class)
+        ->and($result->sliceId)->toBe('foundation')
+        ->and($result->isError)->toBeFalse()
+        ->and($result->content)->not->toBeEmpty();
+});
+
+test('returns error when guidelineKey is null', function (): void {
+    $resolver = app(GuidelineSliceResolver::class);
+
+    $slice = new ContextSlice(
+        id: 'broken',
+        category: 'guidelines',
+        label: 'No key',
+        estimatedTokens: 0,
+        isDynamic: false,
+    );
+
+    $result = $resolver->resolve($slice);
+
+    expect($result->isError)->toBeTrue()
+        ->and($result->content)->toBe('');
+});
+
+test('returns error for non-existent guideline key', function (): void {
+    $resolver = app(GuidelineSliceResolver::class);
+
+    $slice = new ContextSlice(
+        id: 'missing',
+        category: 'guidelines',
+        label: 'Missing guideline',
+        estimatedTokens: 0,
+        isDynamic: false,
+        guidelineKey: 'this/does/not/exist',
+    );
+
+    $result = $resolver->resolve($slice);
+
+    expect($result->isError)->toBeTrue();
+});
+
+test('resolves core guideline slices', function (): void {
+    $resolver = app(GuidelineSliceResolver::class);
+
+    foreach (['foundation', 'boost', 'php'] as $key) {
+        $slice = new ContextSlice(
+            id: $key,
+            category: 'guidelines',
+            label: $key,
+            estimatedTokens: 200,
+            isDynamic: false,
+            guidelineKey: $key,
+        );
+
+        $result = $resolver->resolve($slice);
+
+        expect($result->isError)->toBeFalse("Guideline '{$key}' should resolve without error")
+            ->and($result->content)->not->toBeEmpty("Guideline '{$key}' should have content");
+    }
+});

--- a/tests/Unit/Mcp/Ace/ManifestTest.php
+++ b/tests/Unit/Mcp/Ace/ManifestTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Mcp\Ace\BundleRegistry;
+use Laravel\Boost\Mcp\Ace\Manifest;
+use Laravel\Boost\Mcp\Ace\SliceRegistry;
+
+test('renders manifest with slices and bundles', function (): void {
+    $manifest = new Manifest(app(SliceRegistry::class), new BundleRegistry);
+
+    $output = $manifest->render();
+
+    expect($output)->toContain('Available context')
+        ->and($output)->toContain('resolve-context')
+        ->and($output)->toContain('db-schema')
+        ->and($output)->toContain('foundation')
+        ->and($output)->toContain('Bundles')
+        ->and($output)->toContain('@database-work')
+        ->and($output)->toContain('@debug');
+});
+
+test('manifest includes category labels', function (): void {
+    $manifest = new Manifest(app(SliceRegistry::class), new BundleRegistry);
+
+    $output = $manifest->render();
+
+    expect($output)->toContain('[database]')
+        ->and($output)->toContain('[framework]')
+        ->and($output)->toContain('[debug]')
+        ->and($output)->toContain('[guidelines]');
+});
+
+test('manifest includes token estimates', function (): void {
+    $manifest = new Manifest(app(SliceRegistry::class), new BundleRegistry);
+
+    $output = $manifest->render();
+
+    expect($output)->toContain('~250t')
+        ->and($output)->toContain('~150t')
+        ->and($output)->toContain('live');
+});
+
+test('manifest includes param indicators', function (): void {
+    $manifest = new Manifest(app(SliceRegistry::class), new BundleRegistry);
+
+    $output = $manifest->render();
+
+    expect($output)->toContain('(param:')
+        ->and($output)->toContain('filter');
+});
+
+test('manifest is compact', function (): void {
+    $manifest = new Manifest(app(SliceRegistry::class), new BundleRegistry);
+
+    $output = $manifest->render();
+    $wordCount = str_word_count($output);
+
+    // With dynamic guidelines the manifest grows but should stay under ~600 words
+    expect($wordCount)->toBeLessThan(600);
+});

--- a/tests/Unit/Mcp/Ace/SliceRegistryTest.php
+++ b/tests/Unit/Mcp/Ace/SliceRegistryTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Mcp\Ace\ContextSlice;
+use Laravel\Boost\Mcp\Ace\SliceRegistry;
+
+test('returns all registered slices', function (): void {
+    $registry = app(SliceRegistry::class);
+
+    $slices = $registry->all();
+
+    expect($slices)->not->toBeEmpty()
+        ->and($slices->count())->toBeGreaterThan(10);
+});
+
+test('all slices are ContextSlice instances', function (): void {
+    $registry = app(SliceRegistry::class);
+
+    $registry->all()->each(function ($slice): void {
+        expect($slice)->toBeInstanceOf(ContextSlice::class);
+    });
+});
+
+test('can get slice by id', function (): void {
+    $registry = app(SliceRegistry::class);
+
+    $slice = $registry->get('db-schema');
+
+    expect($slice)->toBeInstanceOf(ContextSlice::class)
+        ->and($slice->id)->toBe('db-schema')
+        ->and($slice->category)->toBe('database')
+        ->and($slice->isDynamic)->toBeTrue();
+});
+
+test('returns null for unknown slice', function (): void {
+    $registry = app(SliceRegistry::class);
+
+    expect($registry->get('nonexistent'))->toBeNull();
+});
+
+test('has returns true for existing slice', function (): void {
+    $registry = app(SliceRegistry::class);
+
+    expect($registry->has('app-info'))->toBeTrue()
+        ->and($registry->has('foundation'))->toBeTrue();
+});
+
+test('has returns false for unknown slice', function (): void {
+    $registry = app(SliceRegistry::class);
+
+    expect($registry->has('nonexistent'))->toBeFalse();
+});
+
+test('contains expected dynamic slices', function (): void {
+    $registry = app(SliceRegistry::class);
+
+    $expectedDynamic = ['app-info', 'db-schema', 'db-connections', 'db-query', 'routes',
+        'artisan-commands', 'config-keys', 'env-vars', 'get-config', 'absolute-url',
+        'last-error', 'browser-logs', 'log-entries', 'search-docs'];
+
+    foreach ($expectedDynamic as $id) {
+        $slice = $registry->get($id);
+        expect($slice)->not->toBeNull("Slice '{$id}' should exist")
+            ->and($slice->isDynamic)->toBeTrue("Slice '{$id}' should be dynamic")
+            ->and($slice->toolClass)->not->toBeNull("Slice '{$id}' should have a tool class");
+    }
+});
+
+test('static slices are built from guideline composer', function (): void {
+    $registry = app(SliceRegistry::class);
+
+    $staticSlices = $registry->all()->filter(fn (ContextSlice $slice) => ! $slice->isDynamic);
+
+    expect($staticSlices)->not->toBeEmpty();
+
+    $staticSlices->each(function (ContextSlice $slice): void {
+        expect($slice->category)->toBe('guidelines')
+            ->and($slice->guidelineKey)->not->toBeNull()
+            ->and($slice->isDynamic)->toBeFalse();
+    });
+});
+
+test('contains core guideline slices', function (): void {
+    $registry = app(SliceRegistry::class);
+
+    // Core guidelines always exist: foundation, boost, php
+    foreach (['foundation', 'boost', 'php'] as $id) {
+        $slice = $registry->get($id);
+        expect($slice)->not->toBeNull("Core guideline slice '{$id}' should exist")
+            ->and($slice->isDynamic)->toBeFalse()
+            ->and($slice->guidelineKey)->not->toBeNull();
+    }
+});
+
+test('caches slices across calls', function (): void {
+    $registry = app(SliceRegistry::class);
+
+    $first = $registry->all();
+    $second = $registry->all();
+
+    expect($first)->toBe($second);
+});
+
+test('discovers more guidelines than hardcoded minimum', function (): void {
+    $registry = app(SliceRegistry::class);
+
+    $staticSlices = $registry->all()->filter(fn (ContextSlice $slice) => ! $slice->isDynamic);
+
+    // Should discover more than the old hardcoded 7 slices
+    expect($staticSlices->count())->toBeGreaterThanOrEqual(3);
+});

--- a/tests/Unit/Mcp/Ace/SliceResultTest.php
+++ b/tests/Unit/Mcp/Ace/SliceResultTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Mcp\Ace\SliceResult;
+
+test('constructs success result', function (): void {
+    $result = new SliceResult('db-schema', '{"tables": {}}');
+
+    expect($result->sliceId)->toBe('db-schema')
+        ->and($result->content)->toBe('{"tables": {}}')
+        ->and($result->isError)->toBeFalse();
+});
+
+test('constructs error result', function (): void {
+    $result = new SliceResult('db-schema', 'Connection failed', isError: true);
+
+    expect($result->sliceId)->toBe('db-schema')
+        ->and($result->content)->toBe('Connection failed')
+        ->and($result->isError)->toBeTrue();
+});


### PR DESCRIPTION
## Summary

15 MCP tools → 3. Schema overhead drops ~80%, round trips go from 5 to 2 for most tasks.

`boost-manifest` gives the AI a compact catalog of whats available (~200 tokens instead of ~2,100). `resolve-context` batches multiple data sources into a single response. `execute` handles code execution.

Pre-built bundles like `@debug` and `@database-work` let the AI grab everthing it needs in one shot instead of figuring out which pieces to request individually. Read-only tools run in-process when ACE is on, so theres no subprocess overhead for context resolution.

Fully opt in. Set `BOOST_ACE_ENABLED=true` and thats it. Legacy tools can stay alongside during migration.

## How it works

The AI calls `boost-manifest` once to see a compact menu of available context slices and bundles. Then it calls `resolve-context` with whatever it needs, all in one call. Slices map directly to the existing tools (DatabaseSchema, ListRoutes, LastError, etc) so the actual data is identical, just delivered smarter.

Bundles are pre-defined combos: `@debug` expands to last-error + browser-logs + app-info. `@database-work` expands to db-schema + db-connections + app-info + foundation guidelines. Custom bundles can be registered and unwanted ones excluded via config.

Guidelines (foundation, php, boost, etc) are also available as slices so the AI can pull specific guidelines on demand instead of loading all of them upfront.

## Test plan

78 tests, 298 assertions covering registries, resolvers, tool execution, bundle expansion, deduplication, error isolation, and server boot with ACE on and off.

Closes #600