### PR TITLE
Fix skill discovery for repos with non-main default branches

### DIFF
--- a/src/Skills/Remote/GitHubSkillProvider.php
+++ b/src/Skills/Remote/GitHubSkillProvider.php
@@ -110,7 +110,7 @@ class GitHubSkillProvider
             'https://api.github.com/repos/%s/%s/git/trees/%s?recursive=1',
             $this->repository->owner,
             $this->repository->repo,
-            $this->resolveDefaultBranch()
+            urlencode($this->resolveDefaultBranch())
         );
 
         $response = $this->client()->get($url);


### PR DESCRIPTION
`boost:add-skill laravel/ai` reported "No valid skills are found" because the `GitHubSkillProvider` hardcoded `main` as the branch to search. Repos like `laravel/ai` use `0.x` as their default branch, so skills at `resources/boost/skills/` were never found.

### Approach

- Resolve the repository's actual default branch from the GitHub API before fetching the tree, with a fallback to `main`
- Add `resources/boost/skills` to the list of common skill paths to search
- Cache the resolved branch so no extra API calls are made for subsequent operations