### PR TITLE
Fix crash in GuidelineAssist when app/ directory does not exist

### DIFF
--- a/src/Install/GuidelineAssist.php
+++ b/src/Install/GuidelineAssist.php
@@ -153,10 +153,13 @@ class GuidelineAssist
             return false;
         }
 
-        return str_contains(
-            file_get_contents(current($this->modelPaths)),
-            'strict_types=1'
-        );
+        $path = current($this->modelPaths);
+
+        if (! is_file($path)) {
+            return false;
+        }
+
+        return str_contains(file_get_contents($path), 'strict_types=1');
     }
 
     public function enumContents(): string
@@ -165,7 +168,13 @@ class GuidelineAssist
             return '';
         }
 
-        return file_get_contents(current($this->enumPaths));
+        $path = current($this->enumPaths);
+
+        if (! is_file($path)) {
+            return '';
+        }
+
+        return file_get_contents($path);
     }
 
     public function inertia(): Inertia

--- a/tests/Unit/Install/GuidelineAssistTest.php
+++ b/tests/Unit/Install/GuidelineAssistTest.php
@@ -144,6 +144,26 @@ test('hasSkills property can be set to true', function (): void {
     expect($config->hasSkills)->toBeTrue();
 });
 
+test('shouldEnforceStrictTypes returns false when app directory does not exist', function (): void {
+    $sentinel = ['app-path-isnt-a-directory' => sys_get_temp_dir()];
+
+    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
+    $assist->shouldAllowMockingProtectedMethods();
+    $assist->shouldReceive('discover')->andReturn($sentinel);
+
+    expect($assist->shouldEnforceStrictTypes())->toBeFalse();
+});
+
+test('enumContents returns empty string when app directory does not exist', function (): void {
+    $sentinel = ['app-path-isnt-a-directory' => sys_get_temp_dir()];
+
+    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
+    $assist->shouldAllowMockingProtectedMethods();
+    $assist->shouldReceive('discover')->andReturn($sentinel);
+
+    expect($assist->enumContents())->toBe('');
+});
+
 test('hasSkillsEnabled returns false when skills are disabled', function (): void {
     $this->config->hasSkills = false;
 


### PR DESCRIPTION
# The Issue

During the installation process (`php artisan boost:install`), `shouldEnforceStrictTypes()` and `enumContents()` calls `file_get_contents()` on the value returned by `current($this->modelPaths / $this->enumPaths)` without checking whether it is a real file. 

When `app_path()` is not a directory, `discover()` returns a sentinel array whose value is the app directory path - causing `file_get_contents()` to receive a directory and throw a fatal error.

This fixes projects using non-standard folder structures where no app/ directory exists.

We're using it in a project with Ports & Adapters architecture and the Laravel app is buried in a folder similar to `src/.../Infrastructure/Laravel`

# Solution

Add `is_file()` guard to both methods so they return their safe defaults (`false` / '') when the path is not a real file, completing the graceful degradation path already established in `discover()`.

While this doesn't really maintain the same level of support for all of the different architectures where Laravel can be used, it will allow the installation to complete successfully with sensible defaults.
