### PR TITLE
Widen laravel/mcp version constraint to support v0.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/contracts": "^11.45.3|^12.41.1",
         "illuminate/routing": "^11.45.3|^12.41.1",
         "illuminate/support": "^11.45.3|^12.41.1",
-        "laravel/mcp": "^0.5.1",
+        "laravel/mcp": "^0.5.1|^0.6.0",
         "laravel/prompts": "^0.3.10",
         "laravel/roster": "^0.5.0"
     },


### PR DESCRIPTION
## Summary

- Widens the `laravel/mcp` Composer constraint from `^0.5.1` to `^0.5.1 || ^0.6.0`

Fixes #622

## Test plan

- [x] `composer validate` passes
- [x] Full test suite passes (664 tests, 2591 assertions)
- [x] Pint formatting passes