### PR TITLE
Add 'json' option for detailed output in ListRoutes

### DIFF
--- a/src/Mcp/Tools/ListRoutes.php
+++ b/src/Mcp/Tools/ListRoutes.php
@@ -38,6 +38,7 @@ class ListRoutes extends Tool
             'except_path' => $schema->string()->description('Do not display the routes matching the given path pattern.'),
             'except_vendor' => $schema->boolean()->description('Do not display routes defined by vendor packages.'),
             'only_vendor' => $schema->boolean()->description('Only display routes defined by vendor packages.'),
+            'json' => $schema->boolean()->description('Output as JSON for full untruncated details.'),
         ];
     }
 
@@ -55,6 +56,7 @@ class ListRoutes extends Tool
             'except_path' => 'except-path', // Convert underscore back to hyphen
             'except_vendor' => 'except-vendor',
             'only_vendor' => 'only-vendor',
+            'json'=>'json'
         ];
 
         $options = [


### PR DESCRIPTION
## The Issue 
Current output truncates routes list which can hide output from the LLM such as middlewares or full file names for Controllers leading to LLM confusion.

## Solution

Expose the --json flag from `php artisan route:list` so that LLM can receive full output in json format

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
