### PR TITLE
Update Junie agent to use configurable mcp path

### DIFF
--- a/src/Install/Agents/Junie.php
+++ b/src/Install/Agents/Junie.php
@@ -73,7 +73,7 @@ class Junie extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSk
 
     public function guidelinesPath(): string
     {
-        return config('boost.agents.junie.guidelines_path', '.junie/guidelines.md');
+        return config('boost.agents.junie.guidelines_path', 'AGENTS.md');
     }
 
     public function skillsPath(): string


### PR DESCRIPTION
While Junie expects the MCP config in a default location, this is restrictive when collaborating with colleagues using various IDEs. The project should allow for a customizable MCP configuration path.