### PR TITLE
Use configured executable paths when rendering skill templates

### DIFF
--- a/.ai/fluxui-free/skill/fluxui-development/SKILL.blade.php
+++ b/.ai/fluxui-free/skill/fluxui-development/SKILL.blade.php
@@ -5,6 +5,9 @@ license: MIT
 metadata:
   author: laravel
 ---
+@php
+/** @var \Laravel\Boost\Install\GuidelineAssist $assist */
+@endphp
 # Flux UI Development
 
 ## When to Apply
@@ -27,10 +30,9 @@ Flux UI is a component library for Livewire built with Tailwind CSS. It provides
 
 Use Flux UI components when available. Fall back to standard Blade components when no Flux component exists for your needs.
 
-<!-- Basic Button -->
-```blade
+@boostsnippet("Basic Button", "blade")
 <flux:button variant="primary">Click me</flux:button>
-```
+@endboostsnippet
 
 ## Available Components (Free Edition)
 
@@ -40,39 +42,36 @@ Available: avatar, badge, brand, breadcrumbs, button, callout, checkbox, dropdow
 
 Flux includes [Heroicons](https://heroicons.com/) as its default icon set. Search for exact icon names on the Heroicons site - do not guess or invent icon names.
 
-<!-- Icon Button -->
-```blade
+@boostsnippet("Icon Button", "blade")
 <flux:button icon="arrow-down-tray">Export</flux:button>
-```
+@endboostsnippet
 
 For icons not available in Heroicons, use [Lucide](https://lucide.dev/). Import the icons you need with the Artisan command:
 
 ```bash
-php artisan flux:icon crown grip-vertical github
+{{ $assist->artisanCommand('flux:icon crown grip-vertical github') }}
 ```
 
 ## Common Patterns
 
 ### Form Fields
 
-<!-- Form Field -->
-```blade
+@boostsnippet("Form Field", "blade")
 <flux:field>
     <flux:label>Email</flux:label>
     <flux:input type="email" wire:model="email" />
     <flux:error name="email" />
 </flux:field>
-```
+@endboostsnippet
 
 ### Modals
 
-<!-- Modal -->
-```blade
+@boostsnippet("Modal", "blade")
 <flux:modal wire:model="showModal">
     <flux:heading>Title</flux:heading>
     <p>Content</p>
 </flux:modal>
-```
+@endboostsnippet
 
 ## Verification
 

--- a/.ai/fluxui-pro/skill/fluxui-development/SKILL.blade.php
+++ b/.ai/fluxui-pro/skill/fluxui-development/SKILL.blade.php
@@ -5,6 +5,9 @@ license: MIT
 metadata:
   author: laravel
 ---
+@php
+/** @var \Laravel\Boost\Install\GuidelineAssist $assist */
+@endphp
 # Flux UI Development
 
 ## When to Apply
@@ -28,10 +31,9 @@ Flux UI is a component library for Livewire built with Tailwind CSS. It provides
 
 Use Flux UI components when available. Fall back to standard Blade components when no Flux component exists for your needs.
 
-<!-- Basic Button -->
-```blade
+@boostsnippet("Basic Button", "blade")
 <flux:button variant="primary">Click me</flux:button>
-```
+@endboostsnippet
 
 ## Available Components (Pro Edition)
 
@@ -41,34 +43,31 @@ Available: accordion, autocomplete, avatar, badge, brand, breadcrumbs, button, c
 
 Flux includes [Heroicons](https://heroicons.com/) as its default icon set. Search for exact icon names on the Heroicons site - do not guess or invent icon names.
 
-<!-- Icon Button -->
-```blade
+@boostsnippet("Icon Button", "blade")
 <flux:button icon="arrow-down-tray">Export</flux:button>
-```
+@endboostsnippet
 
 For icons not available in Heroicons, use [Lucide](https://lucide.dev/). Import the icons you need with the Artisan command:
 
 ```bash
-php artisan flux:icon crown grip-vertical github
+{{ $assist->artisanCommand('flux:icon crown grip-vertical github') }}
 ```
 
 ## Common Patterns
 
 ### Form Fields
 
-<!-- Form Field -->
-```blade
+@boostsnippet("Form Field", "blade")
 <flux:field>
     <flux:label>Email</flux:label>
     <flux:input type="email" wire:model="email" />
     <flux:error name="email" />
 </flux:field>
-```
+@endboostsnippet
 
 ### Tables
 
-<!-- Table -->
-```blade
+@boostsnippet("Table", "blade")
 <flux:table>
     <flux:table.head>
         <flux:table.row>
@@ -76,7 +75,7 @@ php artisan flux:icon crown grip-vertical github
         </flux:table.row>
     </flux:table.head>
 </flux:table>
-```
+@endboostsnippet
 
 ## Verification
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -14,6 +14,7 @@ use Laravel\Boost\Contracts\SupportsMcp;
 use Laravel\Boost\Contracts\SupportsSkills;
 use Laravel\Boost\Install\Agents\Agent;
 use Laravel\Boost\Install\AgentsDetector;
+use Laravel\Boost\Install\GuidelineAssist;
 use Laravel\Boost\Install\GuidelineComposer;
 use Laravel\Boost\Install\GuidelineConfig;
 use Laravel\Boost\Install\GuidelineWriter;
@@ -119,6 +120,9 @@ class InstallCommand extends Command
 
     protected function performInstallation(): void
     {
+        app()->instance(GuidelineConfig::class, $this->buildGuidelineConfig());
+        app()->forgetInstance(GuidelineAssist::class);
+
         if ($this->selectedBoostFeatures->contains('guidelines')) {
             $this->installGuidelines();
         }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -14,7 +14,6 @@ use Laravel\Boost\Contracts\SupportsMcp;
 use Laravel\Boost\Contracts\SupportsSkills;
 use Laravel\Boost\Install\Agents\Agent;
 use Laravel\Boost\Install\AgentsDetector;
-use Laravel\Boost\Install\GuidelineAssist;
 use Laravel\Boost\Install\GuidelineComposer;
 use Laravel\Boost\Install\GuidelineConfig;
 use Laravel\Boost\Install\GuidelineWriter;
@@ -121,7 +120,6 @@ class InstallCommand extends Command
     protected function performInstallation(): void
     {
         app()->instance(GuidelineConfig::class, $this->buildGuidelineConfig());
-        app()->forgetInstance(GuidelineAssist::class);
 
         if ($this->selectedBoostFeatures->contains('guidelines')) {
             $this->installGuidelines();


### PR DESCRIPTION
Skill files are rendered with hardcoded `php artisan` commands regardless of the project's executable path configuration (Sail, Herd, etc.), creating conflicting guidance with the CLAUDE.md sail rules.

Fixes #637

### Approach

- Convert FluxUI skill files from plain Markdown to Blade templates so they can interpolate the configured artisan command
- Pass the installation's `GuidelineConfig` into `SkillWriter` so Blade skill templates are rendered with the correct executable paths (e.g., `vendor/bin/sail artisan` for Sail projects)