### PR TITLE
Fix table snippet in SKILL.blade.php

### DIFF
--- a/.ai/fluxui-pro/skill/fluxui-development/SKILL.blade.php
+++ b/.ai/fluxui-pro/skill/fluxui-development/SKILL.blade.php
@@ -69,11 +69,12 @@ For icons not available in Heroicons, use [Lucide](https://lucide.dev/). Import 
 
 @boostsnippet("Table", "blade")
 <flux:table>
-    <flux:table.head>
-        <flux:table.row>
-            <flux:table.cell>Name</flux:table.cell>
-        </flux:table.row>
-    </flux:table.head>
+    <flux:table.columns>
+        <flux:table.cell>Column Name</flux:table.cell>
+    </flux:table.columns>
+    <flux:table.row>
+        <flux:table.cell>Value</flux:table.cell>
+    </flux:table.row>
 </flux:table>
 @endboostsnippet
 


### PR DESCRIPTION
Table example snippet fixed, the syntax was possibly from an old version of Flux, and lead towards invalid tables generated by AI. After the fix, AI should generate the proper flux:table syntax.
