### PR TITLE
Support proxy environment variables in HTTP client

### DIFF
--- a/src/Concerns/MakesHttpRequests.php
+++ b/src/Concerns/MakesHttpRequests.php
@@ -16,12 +16,48 @@ trait MakesHttpRequests
             'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:140.0) Gecko/20100101 Firefox/140.0 Laravel Boost',
         ]);
 
+        $proxy = $this->getProxyConfig();
+
+        if ($proxy !== []) {
+            $client = $client->withOptions(['proxy' => $proxy]);
+        }
+
         // Disable SSL verification for local development URLs and testing
         if (app()->environment(['local', 'testing']) || str_contains((string) config('boost.hosted.api_url', ''), '.test')) {
             return $client->withoutVerifying();
         }
 
         return $client;
+    }
+
+    /**
+     * Get proxy configuration from environment variables.
+     *
+     * @return array<string, string|array<int, string>>
+     */
+    protected function getProxyConfig(): array
+    {
+        $proxy = [];
+
+        $httpProxy = getenv('HTTP_PROXY') ?: getenv('http_proxy');
+
+        if ($httpProxy !== false && $httpProxy !== '') {
+            $proxy['http'] = $httpProxy;
+        }
+
+        $httpsProxy = getenv('HTTPS_PROXY') ?: getenv('https_proxy');
+
+        if ($httpsProxy !== false && $httpsProxy !== '') {
+            $proxy['https'] = $httpsProxy;
+        }
+
+        $noProxy = getenv('NO_PROXY') ?: getenv('no_proxy');
+
+        if ($noProxy !== false && $noProxy !== '') {
+            $proxy['no'] = array_map('trim', explode(',', $noProxy));
+        }
+
+        return $proxy;
     }
 
     public function get(string $url): Response

--- a/tests/Feature/Mcp/Tools/SearchDocsTest.php
+++ b/tests/Feature/Mcp/Tools/SearchDocsTest.php
@@ -254,6 +254,74 @@ test('it returns error for JSON object string in packages', function (): void {
     expect($response)->isToolResult()->toolHasError();
 });
 
+test('it uses proxy configuration from environment variables', function (): void {
+    $packages = new PackageCollection([]);
+
+    $roster = Mockery::mock(Roster::class);
+    $roster->shouldReceive('packages')->andReturn($packages);
+
+    Http::fake([
+        'https://boost.laravel.com/api/docs' => Http::response('Proxy results', 200),
+    ]);
+
+    putenv('HTTPS_PROXY=http://proxy.example.com:8080');
+    putenv('HTTP_PROXY=http://proxy.example.com:8080');
+    putenv('NO_PROXY=localhost,127.0.0.1');
+
+    try {
+        $tool = new SearchDocs($roster);
+
+        $client = $tool->client();
+        $options = $client->getOptions();
+
+        expect($options['proxy'])->toBe([
+            'http' => 'http://proxy.example.com:8080',
+            'https' => 'http://proxy.example.com:8080',
+            'no' => ['localhost', '127.0.0.1'],
+        ]);
+    } finally {
+        putenv('HTTPS_PROXY');
+        putenv('HTTP_PROXY');
+        putenv('NO_PROXY');
+    }
+});
+
+test('it does not set proxy when environment variables are not set', function (): void {
+    putenv('HTTPS_PROXY');
+    putenv('HTTP_PROXY');
+    putenv('NO_PROXY');
+    putenv('https_proxy');
+    putenv('http_proxy');
+    putenv('no_proxy');
+
+    $tool = new SearchDocs(Mockery::mock(Roster::class));
+
+    $client = $tool->client();
+    $options = $client->getOptions();
+
+    expect($options)->not->toHaveKey('proxy');
+});
+
+test('it supports lowercase proxy environment variables', function (): void {
+    putenv('https_proxy=http://lower.proxy.com:3128');
+    putenv('http_proxy=http://lower.proxy.com:3128');
+
+    try {
+        $tool = new SearchDocs(Mockery::mock(Roster::class));
+
+        $client = $tool->client();
+        $options = $client->getOptions();
+
+        expect($options['proxy'])->toBe([
+            'http' => 'http://lower.proxy.com:3128',
+            'https' => 'http://lower.proxy.com:3128',
+        ]);
+    } finally {
+        putenv('https_proxy');
+        putenv('http_proxy');
+    }
+});
+
 test('it caps token_limit at maximum of 1000000', function (): void {
     $packages = new PackageCollection([]);
 


### PR DESCRIPTION
Reads HTTP_PROXY, HTTPS_PROXY, and NO_PROXY env vars (and lowercase variants) and passes them to Guzzle via `withOptions(['proxy' => ...])` allowing the search-docs tool to work in proxied environments. There is no behavior change when proxy env vars are not set.

I covered this change in tests as well as manually tested with a Squid proxy container routing requests to `boost.laravel.com/api/docs`.

Fixes #599 