### PR TITLE
Add support for Mistral Vibe agent

### DIFF
--- a/src/BoostManager.php
+++ b/src/BoostManager.php
@@ -14,6 +14,7 @@ use Laravel\Boost\Install\Agents\Cursor;
 use Laravel\Boost\Install\Agents\Gemini;
 use Laravel\Boost\Install\Agents\Junie;
 use Laravel\Boost\Install\Agents\OpenCode;
+use Laravel\Boost\Install\Agents\Vibe;
 
 class BoostManager
 {
@@ -27,6 +28,7 @@ class BoostManager
         'copilot' => Copilot::class,
         'opencode' => OpenCode::class,
         'gemini' => Gemini::class,
+        'vibe' => Vibe::class,
     ];
 
     /**

--- a/src/Install/Agents/Vibe.php
+++ b/src/Install/Agents/Vibe.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install\Agents;
+
+use Illuminate\Support\Facades\File;
+use Laravel\Boost\Contracts\SupportsGuidelines;
+use Laravel\Boost\Contracts\SupportsMcp;
+use Laravel\Boost\Contracts\SupportsSkills;
+use Laravel\Boost\Install\Enums\McpInstallationStrategy;
+use Laravel\Boost\Install\Enums\Platform;
+
+class Vibe extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSkills
+{
+    public function name(): string
+    {
+        return 'vibe';
+    }
+
+    public function displayName(): string
+    {
+        return 'Mistral Vibe';
+    }
+
+    public function systemDetectionConfig(Platform $platform): array
+    {
+        return match ($platform) {
+            Platform::Darwin, Platform::Linux => [
+                'command' => 'command -v vibe',
+            ],
+            Platform::Windows => [
+                'command' => 'cmd /c where vibe 2>nul',
+            ],
+        };
+    }
+
+    public function projectDetectionConfig(): array
+    {
+        return [
+            'paths' => ['.vibe'],
+            'files' => ['.vibe/config.toml'],
+        ];
+    }
+
+    public function mcpInstallationStrategy(): McpInstallationStrategy
+    {
+        return McpInstallationStrategy::FILE;
+    }
+
+    public function mcpConfigPath(): string
+    {
+        return '.vibe/config.toml';
+    }
+
+    public function mcpConfigKey(): string
+    {
+        return 'mcp_servers';
+    }
+
+    /** {@inheritDoc} */
+    public function httpMcpServerConfig(string $url): array
+    {
+        return [
+            'transport' => 'http',
+            'url' => $url,
+        ];
+    }
+
+    /** {@inheritDoc} */
+    public function mcpServerConfig(string $command, array $args = [], array $env = []): array
+    {
+        return collect([
+            'transport' => 'stdio',
+            'command' => $command,
+            'args' => $args,
+            'env' => $env,
+        ])->filter(fn ($value): bool => ! in_array($value, [[], null, ''], true))
+            ->toArray();
+    }
+
+    /**
+     * Install MCP server using Vibe's [[mcp_servers]] TOML array-of-tables format.
+     *
+     * @param  array<int, string>  $args
+     * @param  array<string, string>  $env
+     */
+    protected function installFileMcp(string $key, string $command, array $args = [], array $env = []): bool
+    {
+        $normalized = $this->normalizeCommand($command, $args);
+
+        return $this->writeVibeServerBlock($key, $this->mcpServerConfig($normalized['command'], $normalized['args'], $env));
+    }
+
+    /**
+     * Install an HTTP MCP server using Vibe's [[mcp_servers]] TOML array-of-tables format.
+     */
+    public function installHttpMcp(string $key, string $url): bool
+    {
+        return $this->writeVibeServerBlock($key, $this->httpMcpServerConfig($url));
+    }
+
+    /**
+     * Write a [[mcp_servers]] block to the Vibe config file.
+     *
+     * @param  array<string, mixed>  $config
+     */
+    protected function writeVibeServerBlock(string $key, array $config): bool
+    {
+        $path = $this->mcpConfigPath();
+
+        File::ensureDirectoryExists(dirname($path));
+
+        $content = '';
+
+        if (File::exists($path) && File::size($path) >= 3) {
+            $content = File::get($path);
+            $content = $this->removeVibeServer($content, $key);
+        }
+
+        $block = $this->buildVibeTomlBlock($key, $config);
+        $trimmed = rtrim($content);
+        $separator = $trimmed === '' ? '' : PHP_EOL.PHP_EOL;
+        $content = $trimmed.$separator.$block.PHP_EOL;
+
+        return File::put($path, $content) !== false;
+    }
+
+    /**
+     * Build a [[mcp_servers]] TOML block for a server.
+     *
+     * @param  array<string, mixed>  $config
+     */
+    protected function buildVibeTomlBlock(string $key, array $config): string
+    {
+        $lines = [];
+        $lines[] = '[[mcp_servers]]';
+        $lines[] = 'name = "'.$this->escapeTomlString($key).'"';
+
+        $envData = [];
+
+        foreach ($config as $field => $value) {
+            if ($field === 'env' && is_array($value)) {
+                $envData = $value;
+
+                continue;
+            }
+
+            $lines[] = $field.' = '.$this->formatTomlValue($value);
+        }
+
+        if ($envData !== []) {
+            foreach ($envData as $envKey => $envValue) {
+                $lines[] = $envKey.' = '.$this->formatTomlValue($envValue);
+            }
+        }
+
+        return implode(PHP_EOL, $lines);
+    }
+
+    /**
+     * Remove an existing [[mcp_servers]] block with the given name.
+     */
+    protected function removeVibeServer(string $content, string $key): string
+    {
+        $escapedKey = preg_quote($key, '/');
+        $pattern = '/(\r?\n)*\[\[mcp_servers\]\]\s*\r?\nname\s*=\s*"'.$escapedKey.'".*?(?=\r?\n\[\[|\r?\n\[(?!\[)|\Z)/s';
+
+        return preg_replace($pattern, '', $content) ?? $content;
+    }
+
+    protected function formatTomlValue(mixed $value): string
+    {
+        if (is_string($value)) {
+            return '"'.$this->escapeTomlString($value).'"';
+        }
+
+        if (is_array($value)) {
+            $items = array_map($this->formatTomlValue(...), $value);
+
+            return '['.implode(', ', $items).']';
+        }
+
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        return (string) $value;
+    }
+
+    protected function escapeTomlString(string $value): string
+    {
+        return strtr($value, [
+            '\\' => '\\\\',
+            '"' => '\\"',
+            "\n" => '\\n',
+            "\r" => '\\r',
+            "\t" => '\\t',
+        ]);
+    }
+
+    public function guidelinesPath(): string
+    {
+        return config('boost.agents.vibe.guidelines_path', 'AGENTS.md');
+    }
+
+    public function skillsPath(): string
+    {
+        return config('boost.agents.vibe.skills_path', '.agents/skills');
+    }
+}

--- a/tests/Unit/BoostManagerTest.php
+++ b/tests/Unit/BoostManagerTest.php
@@ -11,6 +11,7 @@ use Laravel\Boost\Install\Agents\Cursor;
 use Laravel\Boost\Install\Agents\Gemini;
 use Laravel\Boost\Install\Agents\Junie;
 use Laravel\Boost\Install\Agents\OpenCode;
+use Laravel\Boost\Install\Agents\Vibe;
 use Tests\Unit\Install\ExampleAgent;
 
 it('returns default agents', function (): void {
@@ -26,6 +27,7 @@ it('returns default agents', function (): void {
         'copilot' => Copilot::class,
         'opencode' => OpenCode::class,
         'gemini' => Gemini::class,
+        'vibe' => Vibe::class,
     ]);
 });
 

--- a/tests/Unit/Install/Agents/VibeTest.php
+++ b/tests/Unit/Install/Agents/VibeTest.php
@@ -1,0 +1,306 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Install\Agents;
+
+use Illuminate\Support\Facades\File;
+use Laravel\Boost\Install\Agents\Vibe;
+use Laravel\Boost\Install\Detection\DetectionStrategyFactory;
+use Laravel\Boost\Install\Enums\McpInstallationStrategy;
+use Laravel\Boost\Install\Enums\Platform;
+use Mockery;
+
+beforeEach(function (): void {
+    $this->strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
+});
+
+test('name returns vibe', function (): void {
+    $agent = new Vibe($this->strategyFactory);
+
+    expect($agent->name())->toBe('vibe');
+});
+
+test('displayName returns Mistral Vibe', function (): void {
+    $agent = new Vibe($this->strategyFactory);
+
+    expect($agent->displayName())->toBe('Mistral Vibe');
+});
+
+test('mcpInstallationStrategy returns FILE', function (): void {
+    $agent = new Vibe($this->strategyFactory);
+
+    expect($agent->mcpInstallationStrategy())->toBe(McpInstallationStrategy::FILE);
+});
+
+test('mcpConfigPath returns .vibe/config.toml', function (): void {
+    $agent = new Vibe($this->strategyFactory);
+
+    expect($agent->mcpConfigPath())->toBe('.vibe/config.toml');
+});
+
+test('mcpConfigKey returns mcp_servers', function (): void {
+    $agent = new Vibe($this->strategyFactory);
+
+    expect($agent->mcpConfigKey())->toBe('mcp_servers');
+});
+
+test('guidelinesPath returns AGENTS.md by default', function (): void {
+    $agent = new Vibe($this->strategyFactory);
+
+    expect($agent->guidelinesPath())->toBe('AGENTS.md');
+});
+
+test('skillsPath returns .agents/skills by default', function (): void {
+    $agent = new Vibe($this->strategyFactory);
+
+    expect($agent->skillsPath())->toBe('.agents/skills');
+});
+
+test('projectDetectionConfig uses .vibe directory and config.toml', function (): void {
+    $agent = new Vibe($this->strategyFactory);
+
+    expect($agent->projectDetectionConfig())->toBe([
+        'paths' => ['.vibe'],
+        'files' => ['.vibe/config.toml'],
+    ]);
+});
+
+test('system detection uses command -v on Darwin', function (): void {
+    $agent = new Vibe($this->strategyFactory);
+
+    $config = $agent->systemDetectionConfig(Platform::Darwin);
+
+    expect($config['command'])->toBe('command -v vibe');
+});
+
+test('system detection uses command -v on Linux', function (): void {
+    $agent = new Vibe($this->strategyFactory);
+
+    $config = $agent->systemDetectionConfig(Platform::Linux);
+
+    expect($config['command'])->toBe('command -v vibe');
+});
+
+test('system detection uses where command on Windows', function (): void {
+    $agent = new Vibe($this->strategyFactory);
+
+    $config = $agent->systemDetectionConfig(Platform::Windows);
+
+    expect($config['command'])->toBe('cmd /c where vibe 2>nul');
+});
+
+test('mcpServerConfig includes transport stdio', function (): void {
+    $agent = new Vibe($this->strategyFactory);
+
+    $config = $agent->mcpServerConfig('php', ['artisan', 'boost:mcp']);
+
+    expect($config)->toBe([
+        'transport' => 'stdio',
+        'command' => 'php',
+        'args' => ['artisan', 'boost:mcp'],
+    ]);
+});
+
+test('mcpServerConfig includes env when provided', function (): void {
+    $agent = new Vibe($this->strategyFactory);
+
+    $config = $agent->mcpServerConfig('php', ['artisan'], ['APP_ENV' => 'local']);
+
+    expect($config)->toBe([
+        'transport' => 'stdio',
+        'command' => 'php',
+        'args' => ['artisan'],
+        'env' => ['APP_ENV' => 'local'],
+    ]);
+});
+
+test('mcpServerConfig filters empty values', function (): void {
+    $agent = new Vibe($this->strategyFactory);
+
+    $config = $agent->mcpServerConfig('php', [], []);
+
+    expect($config)->toBe([
+        'transport' => 'stdio',
+        'command' => 'php',
+    ]);
+});
+
+test('httpMcpServerConfig returns http transport config', function (): void {
+    $agent = new Vibe($this->strategyFactory);
+
+    expect($agent->httpMcpServerConfig('https://nightwatch.laravel.com/mcp'))->toBe([
+        'transport' => 'http',
+        'url' => 'https://nightwatch.laravel.com/mcp',
+    ]);
+});
+
+test('installMcp creates TOML config with [[mcp_servers]] array format', function (): void {
+    $agent = new Vibe($this->strategyFactory);
+    $capturedContent = '';
+
+    File::shouldReceive('ensureDirectoryExists')
+        ->once()
+        ->with('.vibe');
+
+    File::shouldReceive('exists')
+        ->once()
+        ->with('.vibe/config.toml')
+        ->andReturn(false);
+
+    File::shouldReceive('put')
+        ->once()
+        ->with(Mockery::any(), Mockery::capture($capturedContent))
+        ->andReturn(true);
+
+    $result = $agent->installMcp('laravel-boost', 'php', ['artisan', 'boost:mcp']);
+
+    expect($result)->toBeTrue()
+        ->and($capturedContent)->toContain('[[mcp_servers]]')
+        ->and($capturedContent)->toContain('name = "laravel-boost"')
+        ->and($capturedContent)->toContain('transport = "stdio"')
+        ->and($capturedContent)->toContain('command = "php"')
+        ->and($capturedContent)->toContain('args = ["artisan", "boost:mcp"]');
+});
+
+test('installMcp with env vars includes them in the block', function (): void {
+    $agent = new Vibe($this->strategyFactory);
+    $capturedContent = '';
+
+    File::shouldReceive('ensureDirectoryExists')
+        ->once()
+        ->with('.vibe');
+
+    File::shouldReceive('exists')
+        ->once()
+        ->with('.vibe/config.toml')
+        ->andReturn(false);
+
+    File::shouldReceive('put')
+        ->once()
+        ->with(Mockery::any(), Mockery::capture($capturedContent))
+        ->andReturn(true);
+
+    $result = $agent->installMcp('herd', 'herd php', ['/path/to/mcp'], ['SITE_PATH' => '/project']);
+
+    expect($result)->toBeTrue()
+        ->and($capturedContent)->toContain('[[mcp_servers]]')
+        ->and($capturedContent)->toContain('name = "herd"')
+        ->and($capturedContent)->toContain('transport = "stdio"')
+        ->and($capturedContent)->toContain('command = "herd"')
+        ->and($capturedContent)->toContain('SITE_PATH = "/project"');
+});
+
+test('installHttpMcp creates TOML config with http transport', function (): void {
+    $agent = new Vibe($this->strategyFactory);
+    $capturedContent = '';
+
+    File::shouldReceive('ensureDirectoryExists')
+        ->once()
+        ->with('.vibe');
+
+    File::shouldReceive('exists')
+        ->once()
+        ->with('.vibe/config.toml')
+        ->andReturn(false);
+
+    File::shouldReceive('put')
+        ->once()
+        ->with(Mockery::any(), Mockery::capture($capturedContent))
+        ->andReturn(true);
+
+    $result = $agent->installHttpMcp('nightwatch', 'https://nightwatch.laravel.com/mcp');
+
+    expect($result)->toBeTrue()
+        ->and($capturedContent)->toContain('[[mcp_servers]]')
+        ->and($capturedContent)->toContain('name = "nightwatch"')
+        ->and($capturedContent)->toContain('transport = "http"')
+        ->and($capturedContent)->toContain('url = "https://nightwatch.laravel.com/mcp"');
+});
+
+test('installMcp preserves existing config and appends new server', function (): void {
+    $agent = new Vibe($this->strategyFactory);
+    $capturedContent = '';
+
+    $existingConfig = <<<'TOML'
+[[mcp_servers]]
+name = "other-server"
+transport = "stdio"
+command = "other"
+args = ["run"]
+TOML;
+
+    File::shouldReceive('ensureDirectoryExists')
+        ->once()
+        ->with('.vibe');
+
+    File::shouldReceive('exists')
+        ->once()
+        ->with('.vibe/config.toml')
+        ->andReturn(true);
+
+    File::shouldReceive('size')
+        ->once()
+        ->with('.vibe/config.toml')
+        ->andReturn(strlen($existingConfig));
+
+    File::shouldReceive('get')
+        ->once()
+        ->with('.vibe/config.toml')
+        ->andReturn($existingConfig);
+
+    File::shouldReceive('put')
+        ->once()
+        ->with(Mockery::any(), Mockery::capture($capturedContent))
+        ->andReturn(true);
+
+    $result = $agent->installMcp('laravel-boost', 'php', ['artisan', 'boost:mcp']);
+
+    expect($result)->toBeTrue()
+        ->and($capturedContent)->toContain('name = "other-server"')
+        ->and($capturedContent)->toContain('name = "laravel-boost"');
+});
+
+test('installMcp replaces existing server with same name', function (): void {
+    $agent = new Vibe($this->strategyFactory);
+    $capturedContent = '';
+
+    $existingConfig = <<<'TOML'
+[[mcp_servers]]
+name = "laravel-boost"
+transport = "stdio"
+command = "old-php"
+args = ["old-artisan"]
+TOML;
+
+    File::shouldReceive('ensureDirectoryExists')
+        ->once()
+        ->with('.vibe');
+
+    File::shouldReceive('exists')
+        ->once()
+        ->with('.vibe/config.toml')
+        ->andReturn(true);
+
+    File::shouldReceive('size')
+        ->once()
+        ->with('.vibe/config.toml')
+        ->andReturn(strlen($existingConfig));
+
+    File::shouldReceive('get')
+        ->once()
+        ->with('.vibe/config.toml')
+        ->andReturn($existingConfig);
+
+    File::shouldReceive('put')
+        ->once()
+        ->with(Mockery::any(), Mockery::capture($capturedContent))
+        ->andReturn(true);
+
+    $result = $agent->installMcp('laravel-boost', 'php', ['artisan', 'boost:mcp']);
+
+    expect($result)->toBeTrue()
+        ->and($capturedContent)->toContain('name = "laravel-boost"')
+        ->and($capturedContent)->toContain('command = "php"')
+        ->and($capturedContent)->not->toContain('old-php');
+});

--- a/tests/Unit/Install/AgentsDetectorTest.php
+++ b/tests/Unit/Install/AgentsDetectorTest.php
@@ -14,6 +14,7 @@ use Laravel\Boost\Install\Agents\Cursor;
 use Laravel\Boost\Install\Agents\Gemini;
 use Laravel\Boost\Install\Agents\Junie;
 use Laravel\Boost\Install\Agents\OpenCode;
+use Laravel\Boost\Install\Agents\Vibe;
 use Laravel\Boost\Install\AgentsDetector;
 use Laravel\Boost\Install\Enums\Platform;
 
@@ -31,9 +32,9 @@ it('returns collection of all registered agents', function (): void {
     $agents = $this->detector->getAgents();
 
     expect($agents)->toBeInstanceOf(Collection::class)
-        ->and($agents->count())->toBe(8)
+        ->and($agents->count())->toBe(9)
         ->and($agents->keys()->toArray())->toBe([
-            'amp', 'junie', 'cursor', 'claude_code', 'codex', 'copilot', 'opencode', 'gemini',
+            'amp', 'junie', 'cursor', 'claude_code', 'codex', 'copilot', 'opencode', 'gemini', 'vibe',
         ]);
 
     $agents->each(function ($agent): void {
@@ -62,6 +63,7 @@ it('returns an array of detected agents names for system discovery', function ()
     $this->container->bind(Copilot::class, fn () => $mockOther);
     $this->container->bind(OpenCode::class, fn () => $mockOther);
     $this->container->bind(Gemini::class, fn () => $mockOther);
+    $this->container->bind(Vibe::class, fn () => $mockOther);
 
     $detector = new AgentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverSystemInstalledAgents();
@@ -82,6 +84,7 @@ it('returns an empty array when no agents are detected for system discovery', fu
     $this->container->bind(Copilot::class, fn () => $mockAgent);
     $this->container->bind(OpenCode::class, fn () => $mockAgent);
     $this->container->bind(Gemini::class, fn () => $mockAgent);
+    $this->container->bind(Vibe::class, fn () => $mockAgent);
 
     $detector = new AgentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverSystemInstalledAgents();
@@ -112,6 +115,7 @@ it('returns an array of detected agent names for project discovery', function ()
     $this->container->bind(Copilot::class, fn () => $mockOther);
     $this->container->bind(OpenCode::class, fn () => $mockOther);
     $this->container->bind(Gemini::class, fn () => $mockOther);
+    $this->container->bind(Vibe::class, fn () => $mockOther);
 
     $detector = new AgentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverProjectInstalledAgents($basePath);
@@ -134,6 +138,7 @@ it('returns an empty array when no agents are detected for project discovery', f
     $this->container->bind(Copilot::class, fn () => $mockAgent);
     $this->container->bind(OpenCode::class, fn () => $mockAgent);
     $this->container->bind(Gemini::class, fn () => $mockAgent);
+    $this->container->bind(Vibe::class, fn () => $mockAgent);
 
     $detector = new AgentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverProjectInstalledAgents($basePath);


### PR DESCRIPTION
The PR does the following:

  - Registers mistral-vibe (vibe CLI) as a supported agent with guidelines, MCP, and skills support
  - Writes MCP config to .vibe/config.toml using Vibe's [[mcp_servers]] TOML array-of-tables format with stdio and HTTP transports
  - Detects Vibe via command -v vibe (system) and .vibe directory (project)

  Closes #618

**Testing:**

  - 20 unit tests covering properties, detection, MCP config generation, and TOML writing (including update/replace of existing servers)
  - Manually verified boost:install detects Vibe, generates correct .vibe/config.toml, and is idempotent on re-run
  
  
**Note:** I don't have a Mistral API key so I wasn't able to fully test that this work, someone else will have to go that final step.