### PR TITLE
Support JSON-formatted log entries in log reading tools

### DIFF
--- a/src/Concerns/ReadsLogs.php
+++ b/src/Concerns/ReadsLogs.php
@@ -114,6 +114,10 @@ trait ReadsLogs
      */
     protected function isErrorEntry(string $line): bool
     {
+        if (str_starts_with(trim($line), '{')) {
+            return $this->isJsonErrorEntry($line);
+        }
+
         return preg_match($this->getErrorEntryRegex(), $line) === 1;
     }
 
@@ -166,6 +170,44 @@ trait ReadsLogs
     }
 
     /**
+     * Determine if the log content uses JSON format (one JSON object per line).
+     */
+    protected function isJsonLogFormat(string $content): bool
+    {
+        $firstLine = strtok($content, "\n");
+
+        if ($firstLine === false || trim($firstLine) === '') {
+            return false;
+        }
+
+        $trimmed = trim($firstLine);
+
+        if (! str_starts_with($trimmed, '{')) {
+            return false;
+        }
+
+        json_decode($trimmed);
+
+        return json_last_error() === JSON_ERROR_NONE;
+    }
+
+    /**
+     * Determine if the given entry is a JSON-formatted ERROR log entry.
+     */
+    protected function isJsonErrorEntry(string $entry): bool
+    {
+        $decoded = json_decode(trim($entry), true);
+
+        if (! is_array($decoded)) {
+            return false;
+        }
+
+        $level = $decoded['level'] ?? $decoded['level_name'] ?? '';
+
+        return strtoupper((string) $level) === 'ERROR' || (int) ($decoded['level'] ?? 0) >= 400;
+    }
+
+    /**
      * Scan the last $chunkSize bytes of the log file and return an array of
      * complete log entries (oldest ➜ newest).
      *
@@ -195,6 +237,13 @@ trait ReadsLogs
             }
 
             $content = stream_get_contents($handle);
+
+            if ($this->isJsonLogFormat($content)) {
+                return array_values(array_filter(
+                    explode("\n", $content),
+                    fn (string $line): bool => trim($line) !== '',
+                ));
+            }
 
             // Split by beginning-of-entry look-ahead (PSR-3 timestamp pattern).
             $entries = preg_split($this->getEntrySplitRegex(), $content, -1, PREG_SPLIT_NO_EMPTY);

--- a/src/Mcp/Tools/ReadLogEntries.php
+++ b/src/Mcp/Tools/ReadLogEntries.php
@@ -20,7 +20,7 @@ class ReadLogEntries extends Tool
     /**
      * The tool's description.
      */
-    protected string $description = 'Read the last N log entries from the application log, correctly handling multi-line PSR-3 formatted logs. Only works for log files.';
+    protected string $description = 'Read the last N log entries from the application log, correctly handling multi-line PSR-3 formatted logs and JSON-formatted logs. Only works for log files.';
 
     /**
      * Get the tool's input schema.

--- a/tests/Feature/Mcp/Tools/LastErrorTest.php
+++ b/tests/Feature/Mcp/Tools/LastErrorTest.php
@@ -140,6 +140,82 @@ it('falls back to log file when cache is unreachable', function (): void {
         ->toolTextContains('Fallback error from log file');
 });
 
+it('finds error in JSON-formatted log entries', function (): void {
+    $logFile = storage_path('logs'.DIRECTORY_SEPARATOR.'laravel.log');
+
+    Config::set('logging.default', 'single');
+    Config::set('logging.channels.single', [
+        'driver' => 'single',
+        'path' => $logFile,
+    ]);
+
+    $logContent = implode("\n", [
+        '{"message":"Info message","context":{},"level":200,"level_name":"INFO","channel":"local","datetime":"2024-01-15T10:00:00+00:00"}',
+        '{"message":"JSON error message","context":{},"level":400,"level_name":"ERROR","channel":"local","datetime":"2024-01-15T10:01:00+00:00"}',
+        '{"message":"Warning message","context":{},"level":300,"level_name":"WARNING","channel":"local","datetime":"2024-01-15T10:02:00+00:00"}',
+    ]);
+
+    File::put($logFile, $logContent);
+
+    $tool = new LastError;
+    $response = $tool->handle(new Request([]));
+
+    expect($response)->isToolResult()
+        ->toolHasNoError()
+        ->toolTextContains('JSON error message')
+        ->toolTextDoesNotContain('Info message', 'Warning message');
+});
+
+it('finds error in Logstash-formatted log entries', function (): void {
+    $logFile = storage_path('logs'.DIRECTORY_SEPARATOR.'laravel.log');
+
+    Config::set('logging.default', 'single');
+    Config::set('logging.channels.single', [
+        'driver' => 'single',
+        'path' => $logFile,
+    ]);
+
+    $logContent = implode("\n", [
+        '{"@timestamp":"2024-01-15T10:00:00.000Z","@version":1,"host":"server","message":"Logstash info","type":"app","channel":"local","level":"INFO","monolog_level":200}',
+        '{"@timestamp":"2024-01-15T10:01:00.000Z","@version":1,"host":"server","message":"Logstash error found","type":"app","channel":"local","level":"ERROR","monolog_level":400}',
+        '{"@timestamp":"2024-01-15T10:02:00.000Z","@version":1,"host":"server","message":"Logstash warning","type":"app","channel":"local","level":"WARNING","monolog_level":300}',
+    ]);
+
+    File::put($logFile, $logContent);
+
+    $tool = new LastError;
+    $response = $tool->handle(new Request([]));
+
+    expect($response)->isToolResult()
+        ->toolHasNoError()
+        ->toolTextContains('Logstash error found')
+        ->toolTextDoesNotContain('Logstash info', 'Logstash warning');
+});
+
+it('returns error when no error entry in JSON-formatted logs', function (): void {
+    $logFile = storage_path('logs'.DIRECTORY_SEPARATOR.'laravel.log');
+
+    Config::set('logging.default', 'single');
+    Config::set('logging.channels.single', [
+        'driver' => 'single',
+        'path' => $logFile,
+    ]);
+
+    $logContent = implode("\n", [
+        '{"message":"Info message","context":{},"level":200,"level_name":"INFO","channel":"local","datetime":"2024-01-15T10:00:00+00:00"}',
+        '{"message":"Debug message","context":{},"level":100,"level_name":"DEBUG","channel":"local","datetime":"2024-01-15T10:01:00+00:00"}',
+    ]);
+
+    File::put($logFile, $logContent);
+
+    $tool = new LastError;
+    $response = $tool->handle(new Request([]));
+
+    expect($response)->isToolResult()
+        ->toolHasError()
+        ->toolTextContains('Unable to find an ERROR entry');
+});
+
 it('does not return info or warning entries', function (): void {
     $logFile = storage_path('logs'.DIRECTORY_SEPARATOR.'laravel.log');
 

--- a/tests/Feature/Mcp/Tools/ReadLogEntriesTest.php
+++ b/tests/Feature/Mcp/Tools/ReadLogEntriesTest.php
@@ -240,6 +240,108 @@ it('returns error when log file does not exist', function (): void {
         ->toolTextContains('Log file not found');
 });
 
+it('handles JSON-formatted log entries', function (): void {
+    $logFile = storage_path('logs'.DIRECTORY_SEPARATOR.'laravel.log');
+
+    Config::set('logging.default', 'single');
+    Config::set('logging.channels.single', [
+        'driver' => 'single',
+        'path' => $logFile,
+    ]);
+
+    $logContent = implode("\n", [
+        '{"message":"First message","context":{},"level":200,"level_name":"INFO","channel":"local","datetime":"2024-01-15T10:00:00+00:00"}',
+        '{"message":"Second message","context":{},"level":400,"level_name":"ERROR","channel":"local","datetime":"2024-01-15T10:01:00+00:00"}',
+        '{"message":"Third message","context":{},"level":200,"level_name":"INFO","channel":"local","datetime":"2024-01-15T10:02:00+00:00"}',
+    ]);
+
+    createLogFile($logFile, $logContent);
+
+    $tool = new ReadLogEntries;
+    $response = $tool->handle(new Request(['entries' => 2]));
+
+    expect($response)->isToolResult()
+        ->toolHasNoError()
+        ->toolTextContains('Second message', 'Third message')
+        ->toolTextDoesNotContain('First message');
+});
+
+it('handles Logstash-formatted log entries', function (): void {
+    $logFile = storage_path('logs'.DIRECTORY_SEPARATOR.'laravel.log');
+
+    Config::set('logging.default', 'single');
+    Config::set('logging.channels.single', [
+        'driver' => 'single',
+        'path' => $logFile,
+    ]);
+
+    $logContent = implode("\n", [
+        '{"@timestamp":"2024-01-15T10:00:00.000Z","@version":1,"host":"server","message":"Logstash info","type":"app","channel":"local","level":"INFO","monolog_level":200}',
+        '{"@timestamp":"2024-01-15T10:01:00.000Z","@version":1,"host":"server","message":"Logstash error","type":"app","channel":"local","level":"ERROR","monolog_level":400}',
+        '{"@timestamp":"2024-01-15T10:02:00.000Z","@version":1,"host":"server","message":"Logstash warning","type":"app","channel":"local","level":"WARNING","monolog_level":300}',
+    ]);
+
+    createLogFile($logFile, $logContent);
+
+    $tool = new ReadLogEntries;
+    $response = $tool->handle(new Request(['entries' => 2]));
+
+    expect($response)->isToolResult()
+        ->toolHasNoError()
+        ->toolTextContains('Logstash error', 'Logstash warning')
+        ->toolTextDoesNotContain('Logstash info');
+});
+
+it('handles Loggly-formatted log entries', function (): void {
+    $logFile = storage_path('logs'.DIRECTORY_SEPARATOR.'laravel.log');
+
+    Config::set('logging.default', 'single');
+    Config::set('logging.channels.single', [
+        'driver' => 'single',
+        'path' => $logFile,
+    ]);
+
+    $logContent = implode("\n", [
+        '{"message":"Loggly first","context":{},"level":200,"level_name":"INFO","channel":"local","timestamp":"2024-01-15T10:00:00.000000+00:00"}',
+        '{"message":"Loggly second","context":{},"level":400,"level_name":"ERROR","channel":"local","timestamp":"2024-01-15T10:01:00.000000+00:00"}',
+    ]);
+
+    createLogFile($logFile, $logContent);
+
+    $tool = new ReadLogEntries;
+    $response = $tool->handle(new Request(['entries' => 1]));
+
+    expect($response)->isToolResult()
+        ->toolHasNoError()
+        ->toolTextContains('Loggly second')
+        ->toolTextDoesNotContain('Loggly first');
+});
+
+it('returns correct count of JSON log entries', function (): void {
+    $logFile = storage_path('logs'.DIRECTORY_SEPARATOR.'laravel.log');
+
+    Config::set('logging.default', 'single');
+    Config::set('logging.channels.single', [
+        'driver' => 'single',
+        'path' => $logFile,
+    ]);
+
+    $entries = [];
+    for ($i = 1; $i <= 10; $i++) {
+        $entries[] = '{"message":"Log entry '.$i.'","context":{},"level":200,"level_name":"INFO","channel":"local","datetime":"2024-01-15T10:'.str_pad((string) $i, 2, '0', STR_PAD_LEFT).':00+00:00"}';
+    }
+
+    createLogFile($logFile, implode("\n", $entries));
+
+    $tool = new ReadLogEntries;
+    $response = $tool->handle(new Request(['entries' => 3]));
+
+    expect($response)->isToolResult()
+        ->toolHasNoError()
+        ->toolTextContains('Log entry 8', 'Log entry 9', 'Log entry 10')
+        ->toolTextDoesNotContain('Log entry 7');
+});
+
 it('returns error when log file is empty', function (): void {
     $logFile = storage_path('logs'.DIRECTORY_SEPARATOR.'laravel.log');
 


### PR DESCRIPTION
This PR does the following:

  - Auto-detect JSON log format in the ReadsLogs trait and split entries by newlines instead of PSR-3 timestamps
  - Handle JSON error detection in LastError tool, supporting both numeric level (level >= 400) and string level (level_name = "ERROR") fields
  - No behavior change for PSR-3 formatted logs
  - Tested against LogstashFormatter and LogglyFormatter in addition to JsonFormatter since these are the other Monolog formatters that write JSON to log files and would hit the same issue

Fixes #275

**Test plan**
  - 7 new tests across ReadLogEntriesTest and LastErrorTest covering JsonFormatter, LogstashFormatter, and LogglyFormatter output formats
  - Tests verify correct entry count, error detection, and exclusion of non-error entries for each format