### PR TITLE
Add `--discover` flag to `boost:update`

### DIFF
--- a/src/Console/UpdateCommand.php
+++ b/src/Console/UpdateCommand.php
@@ -27,7 +27,7 @@ class UpdateCommand extends Command
             return self::FAILURE;
         }
 
-        if ($this->shouldDiscover()) {
+        if ($this->option('discover')) {
             $this->discoverNewContent($config);
         }
 
@@ -80,10 +80,5 @@ class UpdateCommand extends Command
 
         return ThirdPartyPackage::discover()
             ->filter(fn (ThirdPartyPackage $pkg, string $name): bool => ! in_array($name, $configuredPackages, true));
-    }
-
-    protected function shouldDiscover(): bool
-    {
-        return (bool) $this->option('discover');
     }
 }

--- a/tests/Feature/Console/UpdateCommandTest.php
+++ b/tests/Feature/Console/UpdateCommandTest.php
@@ -72,10 +72,8 @@ it('calls install command with a guidelines flag when guidelines are enabled', f
     $config->setGuidelines(true);
     $config->setSkills([]);
 
-    $command = Mockery::mock(UpdateCommand::class)
-        ->makePartial()
-        ->shouldAllowMockingProtectedMethods();
-    $command->shouldReceive('shouldDiscover')->andReturn(false);
+    $command = Mockery::mock(UpdateCommand::class)->makePartial();
+    $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
@@ -100,10 +98,8 @@ it('calls install command with skills flag when skills are configured', function
     $config->setGuidelines(false);
     $config->setSkills(['test-skill']);
 
-    $command = Mockery::mock(UpdateCommand::class)
-        ->makePartial()
-        ->shouldAllowMockingProtectedMethods();
-    $command->shouldReceive('shouldDiscover')->andReturn(false);
+    $command = Mockery::mock(UpdateCommand::class)->makePartial();
+    $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
@@ -128,10 +124,8 @@ it('calls install command with both flags when guidelines and skills are enabled
     $config->setGuidelines(true);
     $config->setSkills(['test-skill']);
 
-    $command = Mockery::mock(UpdateCommand::class)
-        ->makePartial()
-        ->shouldAllowMockingProtectedMethods();
-    $command->shouldReceive('shouldDiscover')->andReturn(false);
+    $command = Mockery::mock(UpdateCommand::class)->makePartial();
+    $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
@@ -156,10 +150,8 @@ it('preserves sail configuration when updating guidelines', function (): void {
     $config->setGuidelines(true);
     $config->setSail(true);
 
-    $command = Mockery::mock(UpdateCommand::class)
-        ->makePartial()
-        ->shouldAllowMockingProtectedMethods();
-    $command->shouldReceive('shouldDiscover')->andReturn(false);
+    $command = Mockery::mock(UpdateCommand::class)->makePartial();
+    $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
@@ -185,10 +177,8 @@ it('preserves non-sail configuration when updating guidelines', function (): voi
     $config->setGuidelines(true);
     $config->setSail(false);
 
-    $command = Mockery::mock(UpdateCommand::class)
-        ->makePartial()
-        ->shouldAllowMockingProtectedMethods();
-    $command->shouldReceive('shouldDiscover')->andReturn(false);
+    $command = Mockery::mock(UpdateCommand::class)->makePartial();
+    $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
@@ -214,10 +204,8 @@ it('preserves sail configuration when updating skills', function (): void {
     $config->setSkills(['commit']);
     $config->setSail(true);
 
-    $command = Mockery::mock(UpdateCommand::class)
-        ->makePartial()
-        ->shouldAllowMockingProtectedMethods();
-    $command->shouldReceive('shouldDiscover')->andReturn(false);
+    $command = Mockery::mock(UpdateCommand::class)->makePartial();
+    $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
@@ -237,8 +225,6 @@ it('preserves sail configuration when updating skills', function (): void {
         ->and($config->getSail())->toBeTrue();
 });
 
-// Detects skills when .ai/skills directory exists even if no skills are explicitly in boost.json config.
-// This ensures users who manually created skill directories still get them updated.
 it('calls install command with skills flag when .ai/skills directory exists but skills are not in config', function (): void {
     $config = new Config;
     $config->setAgents(['claude_code']);
@@ -246,10 +232,8 @@ it('calls install command with skills flag when .ai/skills directory exists but 
 
     mkdir(base_path('.ai/skills'), 0755, true);
 
-    $command = Mockery::mock(UpdateCommand::class)
-        ->makePartial()
-        ->shouldAllowMockingProtectedMethods();
-    $command->shouldReceive('shouldDiscover')->andReturn(false);
+    $command = Mockery::mock(UpdateCommand::class)->makePartial();
+    $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
@@ -280,9 +264,6 @@ it('defaults to non-sail when config is missing', function (): void {
     expect($config->getSail())->toBeFalse();
 });
 
-// --discover flag tests: the discover flag enables opt-in detection of new third-party
-// packages that provide guidelines/skills, prompting the user to select which to add.
-
 it('does not run discovery when --discover flag is not set', function (): void {
     $config = new Config;
     $config->setAgents(['claude_code']);
@@ -291,7 +272,7 @@ it('does not run discovery when --discover flag is not set', function (): void {
     $command = Mockery::mock(UpdateCommand::class)
         ->makePartial()
         ->shouldAllowMockingProtectedMethods();
-    $command->shouldReceive('shouldDiscover')->andReturn(false);
+    $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldNotReceive('discoverNewContent');
     $command->shouldReceive('callSilently')
         ->once()
@@ -311,7 +292,6 @@ it('does not run discovery when --discover flag is not set', function (): void {
         ->and($config->getSkills())->toBe(['existing-skill']);
 });
 
-// When --discover finds no new packages, config remains unchanged.
 it('does not change config when no new packages are found with --discover', function (): void {
     $config = new Config;
     $config->setAgents(['claude_code']);
@@ -321,7 +301,7 @@ it('does not change config when no new packages are found with --discover', func
     $command = Mockery::mock(UpdateCommand::class)
         ->makePartial()
         ->shouldAllowMockingProtectedMethods();
-    $command->shouldReceive('shouldDiscover')->andReturn(true);
+    $command->shouldReceive('option')->with('discover')->andReturn(true);
     $command->shouldReceive('resolveNewPackages')->andReturn(collect());
     $command->shouldReceive('callSilently')->once()->andReturn(0);
     $command->setLaravel($this->app);
@@ -335,7 +315,6 @@ it('does not change config when no new packages are found with --discover', func
         ->and($config->getPackages())->toBe([]);
 });
 
-// When --discover finds new packages and the user selects one, it gets added to config.
 it('adds selected new packages to config when using --discover', function (): void {
     $config = new Config;
     $config->setAgents(['claude_code']);
@@ -349,7 +328,7 @@ it('adds selected new packages to config when using --discover', function (): vo
     $command = Mockery::mock(UpdateCommand::class)
         ->makePartial()
         ->shouldAllowMockingProtectedMethods();
-    $command->shouldReceive('shouldDiscover')->andReturn(true);
+    $command->shouldReceive('option')->with('discover')->andReturn(true);
     $command->shouldReceive('resolveNewPackages')
         ->andReturn(collect(['vendor/awesome-pkg' => $newPackage]));
     $command->shouldReceive('callSilently')->andReturn(0);


### PR DESCRIPTION
## Summary
Introduces an opt-in discovery mode for `boost:update` via the `--discover` flag. Discovery now detects both new guideline packages and new skills and prompts the user to select which to add.

<img width="620" height="399" alt="image" src="https://github.com/user-attachments/assets/2d41dd56-8326-493b-be39-8a47cbf86003" />