### PR TITLE
Use major.minor PHP version in guidelines instead of full version

### DIFF
--- a/.ai/foundation.blade.php
+++ b/.ai/foundation.blade.php
@@ -8,7 +8,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 ## Foundational Context
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
-- php - {{ PHP_VERSION }}
+- php - {{ PHP_MAJOR_VERSION }}.{{ PHP_MINOR_VERSION }}
 @foreach (app(\Laravel\Roster\Roster::class)->packages()->unique(fn ($package) => $package->rawName()) as $package)
 - {{ $package->rawName() }} ({{ $package->name() }}) - v{{ $package->majorVersion() }}
 @endforeach

--- a/src/Mcp/Tools/ApplicationInfo.php
+++ b/src/Mcp/Tools/ApplicationInfo.php
@@ -31,7 +31,7 @@ class ApplicationInfo extends Tool
     public function handle(Request $request): Response
     {
         return Response::json([
-            'php_version' => PHP_VERSION,
+            'php_version' => PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION,
             'laravel_version' => app()->version(),
             'database_engine' => config('database.default'),
             'packages' => $this->roster->packages()->map(fn (Package $package): array => ['roster_name' => $package->name(), 'version' => $package->version(), 'package_name' => $package->rawName()]),

--- a/tests/Feature/Mcp/Tools/ApplicationInfoTest.php
+++ b/tests/Feature/Mcp/Tools/ApplicationInfoTest.php
@@ -31,7 +31,7 @@ test('it returns application info with packages', function (): void {
     expect($response)->isToolResult()
         ->toolHasNoError()
         ->toolJsonContentToMatchArray([
-            'php_version' => PHP_VERSION,
+            'php_version' => PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION,
             'laravel_version' => app()->version(),
             'database_engine' => config('database.default'),
             'packages' => [
@@ -66,7 +66,7 @@ test('it returns application info with no packages', function (): void {
     expect($response)->isToolResult()
         ->toolHasNoError()
         ->toolJsonContentToMatchArray([
-            'php_version' => PHP_VERSION,
+            'php_version' => PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION,
             'laravel_version' => app()->version(),
             'database_engine' => config('database.default'),
             'packages' => [],


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Description

This PR updates the PHP version output in generated guidelines and the `ApplicationInfo` MCP tool to use only the major and minor version (e.g. `8.4`) instead of the full version including the patch number (e.g. `8.4.3`).

## Motivation

On teams where different members may be running slightly different patch versions of PHP (e.g. `8.4.1` vs `8.4.3`), the full `PHP_VERSION` constant causes unnecessary churn in guideline files. Every time a team member with a different patch version runs the install command, the guideline file changes, leading to noisy diffs and constant re-generation. Since the patch version is rarely relevant to coding guidelines or API compatibility, using only the major and minor version keeps guideline files stable across the team.

## Changes

- **`.ai/foundation.blade.php`** — Changed `{{ PHP_VERSION }}` to `{{ PHP_MAJOR_VERSION }}.{{ PHP_MINOR_VERSION }}`
- **`src/Mcp/Tools/ApplicationInfo.php`** — Changed `PHP_VERSION` to `PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION`
- **`tests/Feature/Mcp/Tools/ApplicationInfoTest.php`** — Updated test assertions to match the new format

## Impact

- No breaking changes — the version string format changes from `8.x.x` to `8.x`, which is still valid and more appropriate for guidelines
- This is consistent with how package versions are already displayed in the foundation template (using `$package->majorVersion()`)
- All existing tests pass