### PR TITLE
Remove redundant "When to Apply" sections from skill bodies

### DIFF
--- a/.ai/fluxui-free/skill/fluxui-development/SKILL.blade.php
+++ b/.ai/fluxui-free/skill/fluxui-development/SKILL.blade.php
@@ -10,14 +10,6 @@ metadata:
 @endphp
 # Flux UI Development
 
-## When to Apply
-
-Activate this skill when:
-
-- Creating UI components or pages
-- Working with forms, modals, or interactive elements
-- Checking available Flux components
-
 ## Documentation
 
 Use `search-docs` for detailed Flux UI patterns and documentation.

--- a/.ai/fluxui-pro/skill/fluxui-development/SKILL.blade.php
+++ b/.ai/fluxui-pro/skill/fluxui-development/SKILL.blade.php
@@ -10,15 +10,6 @@ metadata:
 @endphp
 # Flux UI Development
 
-## When to Apply
-
-Activate this skill when:
-
-- Creating new UI components or pages
-- Working with forms, modals, or interactive elements
-- Styling components with Flux UI patterns
-- Checking available Flux components
-
 ## Documentation
 
 Use `search-docs` for detailed Flux UI patterns and documentation.

--- a/.ai/folio/skill/folio-routing/SKILL.blade.php
+++ b/.ai/folio/skill/folio-routing/SKILL.blade.php
@@ -10,14 +10,6 @@ metadata:
 @endphp
 # Folio Routing
 
-## When to Apply
-
-Activate this skill when:
-
-- Creating pages with file-based routing
-- Working with route parameters and model binding
-- Adding middleware to Folio pages
-
 ## Documentation
 
 Use `search-docs` for detailed Folio patterns and documentation.

--- a/.ai/inertia-react/1/skill/inertia-react-development/SKILL.blade.php
+++ b/.ai/inertia-react/1/skill/inertia-react-development/SKILL.blade.php
@@ -10,15 +10,6 @@ metadata:
 @endphp
 # Inertia React Development
 
-## When to Apply
-
-Activate this skill when:
-
-- Creating or modifying React page components for Inertia
-- Working with forms in React (using `router.post` or `useForm` if available)
-- Implementing client-side navigation with `<Link>` or `router`
-- Building React-specific features with the Inertia protocol
-
 ## Documentation
 
 Use `search-docs` for detailed Inertia v1 React patterns and documentation.

--- a/.ai/inertia-react/2/skill/inertia-react-development/SKILL.blade.php
+++ b/.ai/inertia-react/2/skill/inertia-react-development/SKILL.blade.php
@@ -10,16 +10,6 @@ metadata:
 @endphp
 # Inertia React Development
 
-## When to Apply
-
-Activate this skill when:
-
-- Creating or modifying React page components for Inertia
-- Working with forms in React (using `<Form>` or `useForm`)
-- Implementing client-side navigation with `<Link>` or `router`
-- Using v2 features: deferred props, prefetching, or polling
-- Building React-specific features with the Inertia protocol
-
 ## Documentation
 
 Use `search-docs` for detailed Inertia v2 React patterns and documentation.

--- a/.ai/inertia-svelte/1/skill/inertia-svelte-development/SKILL.blade.php
+++ b/.ai/inertia-svelte/1/skill/inertia-svelte-development/SKILL.blade.php
@@ -10,15 +10,6 @@ metadata:
 @endphp
 # Inertia Svelte Development
 
-## When to Apply
-
-Activate this skill when:
-
-- Creating or modifying Svelte page components for Inertia
-- Working with forms in Svelte (using `router.post`)
-- Implementing client-side navigation with `<Link>` or `router`
-- Building Svelte-specific features with the Inertia protocol
-
 ## Documentation
 
 Use `search-docs` for detailed Inertia v1 Svelte patterns and documentation.

--- a/.ai/inertia-svelte/2/skill/inertia-svelte-development/SKILL.blade.php
+++ b/.ai/inertia-svelte/2/skill/inertia-svelte-development/SKILL.blade.php
@@ -10,16 +10,6 @@ metadata:
 @endphp
 # Inertia Svelte Development
 
-## When to Apply
-
-Activate this skill when:
-
-- Creating or modifying Svelte page components for Inertia
-- Working with forms in Svelte (using `<Form>` or `useForm`)
-- Implementing client-side navigation with `<Link>` or `router`
-- Using v2 features: deferred props, prefetching, or polling
-- Building Svelte-specific features with the Inertia protocol
-
 ## Documentation
 
 Use `search-docs` for detailed Inertia v2 Svelte patterns and documentation.

--- a/.ai/inertia-vue/1/skill/inertia-vue-development/SKILL.blade.php
+++ b/.ai/inertia-vue/1/skill/inertia-vue-development/SKILL.blade.php
@@ -10,15 +10,6 @@ metadata:
 @endphp
 # Inertia Vue Development
 
-## When to Apply
-
-Activate this skill when:
-
-- Creating or modifying Vue page components for Inertia
-- Working with forms in Vue (using `router.post`)
-- Implementing client-side navigation with `<Link>` or `router`
-- Building Vue-specific features with the Inertia protocol
-
 ## Documentation
 
 Use `search-docs` for detailed Inertia v1 Vue patterns and documentation.

--- a/.ai/inertia-vue/2/skill/inertia-vue-development/SKILL.blade.php
+++ b/.ai/inertia-vue/2/skill/inertia-vue-development/SKILL.blade.php
@@ -10,16 +10,6 @@ metadata:
 @endphp
 # Inertia Vue Development
 
-## When to Apply
-
-Activate this skill when:
-
-- Creating or modifying Vue page components for Inertia
-- Working with forms in Vue (using `<Form>` or `useForm`)
-- Implementing client-side navigation with `<Link>` or `router`
-- Using v2 features: deferred props, prefetching, or polling
-- Building Vue-specific features with the Inertia protocol
-
 ## Documentation
 
 Use `search-docs` for detailed Inertia v2 Vue patterns and documentation.

--- a/.ai/livewire/2/skill/livewire-development/SKILL.blade.php
+++ b/.ai/livewire/2/skill/livewire-development/SKILL.blade.php
@@ -10,16 +10,6 @@ metadata:
 @endphp
 # Livewire Development
 
-## When to Apply
-
-Activate this skill when:
-- Creating new Livewire components
-- Modifying existing component state or behavior
-- Debugging reactivity or lifecycle issues
-- Writing Livewire component tests
-- Adding Alpine.js interactivity to components
-- Working with wire: directives
-
 ## Documentation
 
 Use `search-docs` for detailed Livewire 2 patterns and documentation.

--- a/.ai/livewire/3/skill/livewire-development/SKILL.blade.php
+++ b/.ai/livewire/3/skill/livewire-development/SKILL.blade.php
@@ -10,16 +10,6 @@ metadata:
 @endphp
 # Livewire Development
 
-## When to Apply
-
-Activate this skill when:
-- Creating new Livewire components
-- Modifying existing component state or behavior
-- Debugging reactivity or lifecycle issues
-- Writing Livewire component tests
-- Adding Alpine.js interactivity to components
-- Working with wire: directives
-
 ## Documentation
 
 Use `search-docs` for detailed Livewire 3 patterns and documentation.

--- a/.ai/livewire/4/skill/livewire-development/SKILL.blade.php
+++ b/.ai/livewire/4/skill/livewire-development/SKILL.blade.php
@@ -10,15 +10,6 @@ metadata:
 @endphp
 # Livewire Development
 
-## When to Apply
-
-Activate this skill when:
-
-- Creating or modifying Livewire components
-- Using wire: directives (model, click, loading, sort, intersect)
-- Implementing islands or async actions
-- Writing Livewire component tests
-
 ## Documentation
 
 Use `search-docs` for detailed Livewire 4 patterns and documentation.

--- a/.ai/pennant/skill/pennant-development/SKILL.md
+++ b/.ai/pennant/skill/pennant-development/SKILL.md
@@ -7,14 +7,6 @@ metadata:
 ---
 # Pennant Features
 
-## When to Apply
-
-Activate this skill when:
-
-- Creating or checking feature flags
-- Managing feature rollouts
-- Implementing A/B testing
-
 ## Documentation
 
 Use `search-docs` for detailed Pennant patterns and documentation.

--- a/.ai/pest/3/skill/pest-testing/SKILL.blade.php
+++ b/.ai/pest/3/skill/pest-testing/SKILL.blade.php
@@ -10,15 +10,6 @@ metadata:
 @endphp
 # Pest Testing 3
 
-## When to Apply
-
-Activate this skill when:
-- Creating new tests (unit or feature)
-- Modifying existing tests
-- Debugging test failures
-- Working with datasets, mocking, or test organization
-- Writing architecture tests
-
 ## Documentation
 
 Use `search-docs` for detailed Pest 3 patterns and documentation.

--- a/.ai/pest/4/skill/pest-testing/SKILL.blade.php
+++ b/.ai/pest/4/skill/pest-testing/SKILL.blade.php
@@ -10,16 +10,6 @@ metadata:
 @endphp
 # Pest Testing 4
 
-## When to Apply
-
-Activate this skill when:
-
-- Creating new tests (unit, feature, or browser)
-- Modifying existing tests
-- Debugging test failures
-- Working with browser testing or smoke testing
-- Writing architecture tests or visual regression tests
-
 ## Documentation
 
 Use `search-docs` for detailed Pest 4 patterns and documentation.

--- a/.ai/tailwindcss/3/skill/tailwindcss-development/SKILL.md
+++ b/.ai/tailwindcss/3/skill/tailwindcss-development/SKILL.md
@@ -7,15 +7,6 @@ metadata:
 ---
 # Tailwind CSS Development
 
-## When to Apply
-
-Activate this skill when:
-- Adding styles to components or pages
-- Working with responsive design
-- Implementing dark mode
-- Extracting repeated patterns into components
-- Debugging spacing or layout issues
-
 ## Documentation
 
 Use `search-docs` for detailed Tailwind CSS v3 patterns and documentation.

--- a/.ai/tailwindcss/4/skill/tailwindcss-development/SKILL.md
+++ b/.ai/tailwindcss/4/skill/tailwindcss-development/SKILL.md
@@ -7,16 +7,6 @@ metadata:
 ---
 # Tailwind CSS Development
 
-## When to Apply
-
-Activate this skill when:
-
-- Adding styles to components or pages
-- Working with responsive design
-- Implementing dark mode
-- Extracting repeated patterns into components
-- Debugging spacing or layout issues
-
 ## Documentation
 
 Use `search-docs` for detailed Tailwind CSS v4 patterns and documentation.

--- a/.ai/volt/skill/volt-development/SKILL.blade.php
+++ b/.ai/volt/skill/volt-development/SKILL.blade.php
@@ -10,14 +10,6 @@ metadata:
 @endphp
 # Volt Development
 
-## When to Apply
-
-Activate this skill when:
-
-- Creating Volt single-file components
-- Converting traditional Livewire components to Volt
-- Testing Volt components
-
 ## Documentation
 
 Use `search-docs` for detailed Volt patterns and documentation.

--- a/.ai/wayfinder/skill/wayfinder-development/SKILL.blade.php
+++ b/.ai/wayfinder/skill/wayfinder-development/SKILL.blade.php
@@ -10,13 +10,6 @@ metadata:
 @endphp
 # Wayfinder Development
 
-## When to Apply
-
-Activate whenever referencing backend routes in frontend components:
-- Importing from `@/actions/` or `@/routes/`
-- Calling Laravel routes from TypeScript/JavaScript
-- Creating links or navigation to backend endpoints
-
 ## Documentation
 
 Use `search-docs` for detailed Wayfinder patterns and documentation.


### PR DESCRIPTION
## What

Removes the `## When to Apply` section from 19 skill files across all variants (Livewire 2/3/4, Pest 3/4, Inertia React/Vue/Svelte v1/v2, Tailwind v3/v4, Folio, Flux UI free/pro, Volt, Wayfinder, Pennant)

## Why

Both Anthropic's published docs and their internal skill-creator skill say the same thing

The [Skill authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) are clear that the `description` field owns "when to use":

> "The description field enables Skill discovery and should include both what the Skill does and **when to use it**."

It also asks authors to challenge every token: "Does Claude really need this explanation?"

The skill-creator skill (Anthropic's meta-skill for building skills) goes further:

> "All 'when to use' info goes here [in the description], not in the body."

Every removed section was already covered by the skill's `description` frontmatter — nothing was lost, just duplicate content loaded into context on every trigger

## Verification

Each skill's `## When to Apply` bullets were checked against its `description` field before removal — every bullet was already there. No triggering behavior changes, since the description is the only thing Claude reads to decide whether to invoke a skill