### PR TITLE
fix: resolve relative symlinks when skills path is outside project root

### DIFF
--- a/src/Install/SkillWriter.php
+++ b/src/Install/SkillWriter.php
@@ -292,40 +292,25 @@ class SkillWriter
     {
         $resolvedTarget = str_replace('\\', '/', realpath($target) ?: $target);
         $resolvedFrom = str_replace('\\', '/', realpath($from) ?: $from);
-        $base = $this->resolveBaseFromPaths(rtrim(str_replace('\\', '/', base_path()), '/'), $resolvedTarget, $resolvedFrom);
 
-        if (! str_starts_with($resolvedTarget, $base.'/') || ! str_starts_with($resolvedFrom, $base.'/')) {
+        $targetSegments = explode('/', $resolvedTarget);
+        $fromSegments = explode('/', $resolvedFrom);
+
+        $commonDepth = 0;
+        $maxSharedDepth = min(count($targetSegments), count($fromSegments));
+
+        while ($commonDepth < $maxSharedDepth && $targetSegments[$commonDepth] === $fromSegments[$commonDepth]) {
+            $commonDepth++;
+        }
+
+        if ($commonDepth === 0) {
             return $resolvedTarget;
         }
 
-        $targetRel = ltrim(substr($resolvedTarget, strlen($base)), '/');
-        $fromRel = ltrim(substr($resolvedFrom, strlen($base)), '/');
-        $depth = $fromRel === '' ? 0 : count(explode('/', $fromRel));
+        $traversalsUp = count($fromSegments) - $commonDepth;
+        $remainingTarget = array_slice($targetSegments, $commonDepth);
 
-        return str_repeat('../', $depth).$targetRel;
-    }
-
-    protected function resolveBaseFromPaths(string $base, string $resolvedTarget, string $resolvedFrom): string
-    {
-        $targetParts = explode('/', $resolvedTarget);
-        $fromParts = explode('/', $resolvedFrom);
-
-        $commonParts = [];
-        for ($i = 0; $i < min(count($targetParts), count($fromParts)); $i++) {
-            if ($targetParts[$i] === $fromParts[$i]) {
-                $commonParts[] = $targetParts[$i];
-            } else {
-                break;
-            }
-        }
-
-        $commonPath = implode('/', $commonParts);
-
-        if ($commonPath !== '' && str_starts_with($base, $commonPath)) {
-            return $commonPath;
-        }
-
-        return $base;
+        return str_repeat('../', $traversalsUp).implode('/', $remainingTarget);
     }
 
     protected function directoryContainsBladeFiles(string $path): bool

--- a/tests/Unit/Install/SkillWriterTest.php
+++ b/tests/Unit/Install/SkillWriterTest.php
@@ -998,35 +998,6 @@ it('removes extra files when updating skill directory', function (): void {
     cleanupSkillDirectory($absoluteTarget);
 });
 
-it('resolves correct common base from paths', function (string $base, string $target, string $from, string $expected): void {
-    $agent = Mockery::mock(SupportsSkills::class);
-    $writer = new SkillWriter($agent);
-
-    $reflection = new ReflectionMethod($writer, 'resolveBaseFromPaths');
-    $result = $reflection->invoke($writer, $base, $target, $from);
-
-    expect($result)->toBe($expected);
-})->with([
-    'paths share ancestor above base_path' => [
-        '/home/user/project',
-        '/home/user/.claude/skills/my-skill',
-        '/home/user/project/.boost/skills/my-skill',
-        '/home/user',
-    ],
-    'both paths within base_path' => [
-        '/home/user/project',
-        '/home/user/project/.ai/skills/my-skill',
-        '/home/user/project/.boost/skills/my-skill',
-        '/home/user/project',
-    ],
-    'deeply nested common ancestor above base_path' => [
-        '/home/user/projects/app',
-        '/home/user/.config/claude/skills/my-skill',
-        '/home/user/projects/app/.boost/skills/my-skill',
-        '/home/user',
-    ],
-]);
-
 it('computes correct relative path when target is outside project directory', function (): void {
     $agent = Mockery::mock(SupportsSkills::class);
     $writer = new SkillWriter($agent);


### PR DESCRIPTION
When the skills path lives outside the project directory (e.g. ../../.claude/skills), relativePath() produced an absolute path because base_path() was not an ancestor of both paths. Introduce resolveBaseFromPaths() to find the true common ancestor so the symlink target is always relative.

