### PR TITLE
Improve folio-routing skill description and remove core guideline

### DIFF
--- a/.ai/folio/core.blade.php
+++ b/.ai/folio/core.blade.php
@@ -1,5 +1,0 @@
-# Laravel Folio
-
-- Laravel Folio is a powerful page-based router that simplifies routing in Laravel applications.
-- Routes are generated automatically by creating Blade templates in `resources/views/pages`.
-- IMPORTANT: Activate 'folio-routing' when working with Folio, pages, routes, route parameters, model binding, middleware, or `resources/views/pages`.

--- a/.ai/folio/skill/folio-routing/SKILL.blade.php
+++ b/.ai/folio/skill/folio-routing/SKILL.blade.php
@@ -1,6 +1,6 @@
 ---
 name: folio-routing
-description: "Creates file-based routes with Laravel Folio. Activates when creating new pages, setting up routes, working with route parameters or model binding, adding middleware to pages, working with resources/views/pages; or when the user mentions Folio, pages, file-based routing, page routes, or creating a new page for a URL path."
+description: "Use this skill for Laravel Folio file-based routing tasks: creating pages with `folio:page`, setting up route parameters or model binding in filenames like `[User].blade.php`, defining named routes with `name()`, applying middleware, debugging Folio 404s, or running `folio:list`. Also trigger when a user is choosing between Folio and web.php for a new page, or wants to add a new URL or page in a Folio-enabled project (`resources/views/pages`). Folio automatically maps Blade templates to routes. Do not trigger for Livewire component, Normal Routing, Standard controller routes, or API endpoints"
 license: MIT
 metadata:
   author: laravel


### PR DESCRIPTION
Rewrites the folio-routing skill description in a concise imperative style with clear trigger/coverage/boundary pattern, and removes the now-redundant core guideline file.

### Benchmark (Sonnet)

|          | Score       |
|----------|-------------|
| Baseline | 14/20 (70%) |
| Final    | 19/20 (95%) |