### PR TITLE
Detect and suggest Nightwatch Cursor plugin for Cursor users

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -239,7 +239,7 @@ class InstallCommand extends Command
         return confirm(
             label: 'Would you like to install Nightwatch MCP alongside Boost MCP?',
             default: $this->config->getNightwatchMcp(),
-            hint: 'The Nightwatch MCP provides tools for browsing issues, viewing stack traces, and managing application errors',
+            hint: 'The Nightwatch MCP provides tools for browsing issues, viewing stack traces, and managing application errors. Cursor users may also install laravel/nightwatch-cursor-plugin for enhanced IDE integration',
         );
     }
 

--- a/src/Install/Agents/Cursor.php
+++ b/src/Install/Agents/Cursor.php
@@ -8,6 +8,7 @@ use Laravel\Boost\Contracts\SupportsGuidelines;
 use Laravel\Boost\Contracts\SupportsMcp;
 use Laravel\Boost\Contracts\SupportsSkills;
 use Laravel\Boost\Install\Enums\Platform;
+use Laravel\Boost\Support\Composer;
 
 class Cursor extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSkills
 {
@@ -72,5 +73,11 @@ class Cursor extends Agent implements SupportsGuidelines, SupportsMcp, SupportsS
     public function skillsPath(): string
     {
         return config('boost.agents.cursor.skills_path', '.cursor/skills');
+    }
+
+    public function hasNightwatchCursorPlugin(): bool
+    {
+        return class_exists(\Laravel\NightwatchCursor\NightwatchCursorServiceProvider::class)
+            || array_key_exists('laravel/nightwatch-cursor-plugin', Composer::packages());
     }
 }

--- a/src/Install/McpWriter.php
+++ b/src/Install/McpWriter.php
@@ -71,6 +71,11 @@ class McpWriter
 
     protected function installNightwatchMcp(Nightwatch $nightwatch): void
     {
+        if ($this->agent instanceof \Laravel\Boost\Install\Agents\Cursor
+            && $this->agent->hasNightwatchCursorPlugin()) {
+            return;
+        }
+
         if (! $this->agent->installHttpMcp('nightwatch', $nightwatch->mcpUrl())) {
             throw new RuntimeException('Failed to install Nightwatch MCP: could not write configuration');
         }

--- a/tests/Unit/Install/McpWriterTest.php
+++ b/tests/Unit/Install/McpWriterTest.php
@@ -336,6 +336,62 @@ it('installs with both herd and nightwatch', function (): void {
     expect($result)->toBe(McpWriter::SUCCESS);
 });
 
+it('skips nightwatch mcp when cursor agent has nightwatch cursor plugin', function (): void {
+    $agent = Mockery::mock(\Laravel\Boost\Install\Agents\Cursor::class);
+    $agent->shouldReceive('getPhpPath')
+        ->once()
+        ->andReturn('php');
+    $agent->shouldReceive('getArtisanPath')
+        ->once()
+        ->andReturn('artisan');
+    $agent->shouldReceive('installMcp')
+        ->with('laravel-boost', 'php', ['artisan', 'boost:mcp'])
+        ->once()
+        ->andReturn(true);
+    $agent->shouldReceive('hasNightwatchCursorPlugin')
+        ->once()
+        ->andReturn(true);
+    $agent->shouldNotReceive('installHttpMcp');
+
+    $nightwatch = Mockery::mock(Nightwatch::class);
+
+    $writer = new McpWriter($agent);
+    $result = $writer->write(null, null, $nightwatch);
+
+    expect($result)->toBe(McpWriter::SUCCESS);
+});
+
+it('installs nightwatch mcp when cursor agent does not have nightwatch cursor plugin', function (): void {
+    $agent = Mockery::mock(\Laravel\Boost\Install\Agents\Cursor::class);
+    $agent->shouldReceive('getPhpPath')
+        ->once()
+        ->andReturn('php');
+    $agent->shouldReceive('getArtisanPath')
+        ->once()
+        ->andReturn('artisan');
+    $agent->shouldReceive('installMcp')
+        ->with('laravel-boost', 'php', ['artisan', 'boost:mcp'])
+        ->once()
+        ->andReturn(true);
+    $agent->shouldReceive('hasNightwatchCursorPlugin')
+        ->once()
+        ->andReturn(false);
+    $agent->shouldReceive('installHttpMcp')
+        ->with('nightwatch', 'https://nightwatch.laravel.com/mcp')
+        ->once()
+        ->andReturn(true);
+
+    $nightwatch = Mockery::mock(Nightwatch::class);
+    $nightwatch->shouldReceive('mcpUrl')
+        ->once()
+        ->andReturn('https://nightwatch.laravel.com/mcp');
+
+    $writer = new McpWriter($agent);
+    $result = $writer->write(null, null, $nightwatch);
+
+    expect($result)->toBe(McpWriter::SUCCESS);
+});
+
 it('installs with sail, herd, and nightwatch', function (): void {
     $agent = Mockery::mock(SupportsMcp::class);
     $agent->shouldReceive('installMcp')


### PR DESCRIPTION
## Summary
- Detect `laravel/nightwatch-cursor-plugin` for Cursor agent
- Skip generic HTTP MCP registration when Cursor plugin is installed
- Update install hint to mention Cursor plugin availability

## Test plan
- [ ] Verify Cursor agent skips Nightwatch HTTP MCP when plugin is detected
- [ ] Verify other agents still get Nightwatch HTTP MCP normally
- [ ] Verify hint text shows Cursor plugin info

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)