### PR TITLE
feat: allow overriding Nightwatch MCP URL

### DIFF
--- a/src/Install/Nightwatch.php
+++ b/src/Install/Nightwatch.php
@@ -17,6 +17,8 @@ class Nightwatch
 
     public function mcpUrl(): string
     {
-        return self::MCP_URL;
+        return config('boost.nightwatch.mcp_url')
+            ?? env('NIGHTWATCH_MCP_URL')
+            ?? self::MCP_URL;
     }
 }

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -93,6 +93,18 @@ class Config
         return $this->get('herd_mcp', false);
     }
 
+    public function getNightwatchMcpUrl(): ?string
+    {
+        $url = $this->get('nightwatch_mcp_url');
+
+        return is_string($url) && $url !== '' ? $url : null;
+    }
+
+    public function setNightwatchMcpUrl(?string $url): void
+    {
+        $this->set('nightwatch_mcp_url', $url);
+    }
+
     public function setNightwatchMcp(bool $installed): void
     {
         $this->set('nightwatch_mcp', $installed);

--- a/tests/Unit/Install/NightwatchTest.php
+++ b/tests/Unit/Install/NightwatchTest.php
@@ -4,10 +4,18 @@ declare(strict_types=1);
 
 use Laravel\Boost\Install\Nightwatch;
 
-test('mcpUrl returns the nightwatch mcp url', function (): void {
+test('mcpUrl returns default url', function (): void {
     $nightwatch = new Nightwatch;
 
     expect($nightwatch->mcpUrl())->toBe('https://nightwatch.laravel.com/mcp');
+});
+
+test('mcpUrl can be overridden via config', function (): void {
+    config(['boost.nightwatch.mcp_url' => 'https://custom.nightwatch.com/mcp']);
+
+    $nightwatch = new Nightwatch;
+
+    expect($nightwatch->mcpUrl())->toBe('https://custom.nightwatch.com/mcp');
 });
 
 test('MCP_URL constant matches mcpUrl return value', function (): void {


### PR DESCRIPTION
## Summary
- Allow Nightwatch MCP URL override via `boost.nightwatch.mcp_url` config
- Support `NIGHTWATCH_MCP_URL` environment variable
- Fall back to default `https://nightwatch.laravel.com/mcp`
- Prepares for multi-region Nightwatch deployments

## Test plan
- [ ] Verify default URL unchanged when no override set
- [ ] Verify config override takes precedence
- [ ] Verify env variable works as fallback

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)