### PR TITLE
feat: add version checking for Nightwatch

### DIFF
--- a/src/Install/Nightwatch.php
+++ b/src/Install/Nightwatch.php
@@ -15,6 +15,27 @@ class Nightwatch
         return array_key_exists('laravel/nightwatch', Composer::packages());
     }
 
+    public function version(): ?string
+    {
+        $packages = Composer::packages();
+
+        return $packages['laravel/nightwatch'] ?? null;
+    }
+
+    public function meetsMinimumVersion(string $minVersion = '1.0.0'): bool
+    {
+        $version = $this->version();
+
+        if ($version === null) {
+            return false;
+        }
+
+        // Strip 'v' prefix if present
+        $version = ltrim($version, 'v');
+
+        return version_compare($version, $minVersion, '>=');
+    }
+
     public function mcpUrl(): string
     {
         return self::MCP_URL;

--- a/tests/Unit/Install/NightwatchTest.php
+++ b/tests/Unit/Install/NightwatchTest.php
@@ -13,3 +13,15 @@ test('mcpUrl returns the nightwatch mcp url', function (): void {
 test('MCP_URL constant matches mcpUrl return value', function (): void {
     expect(Nightwatch::MCP_URL)->toBe('https://nightwatch.laravel.com/mcp');
 });
+
+test('version returns null when nightwatch is not installed', function (): void {
+    $nightwatch = new Nightwatch;
+
+    expect($nightwatch->version())->toBeNull();
+});
+
+test('meetsMinimumVersion returns false when not installed', function (): void {
+    $nightwatch = new Nightwatch;
+
+    expect($nightwatch->meetsMinimumVersion())->toBeFalse();
+});


### PR DESCRIPTION
## Summary
- Add `version()` method to retrieve installed Nightwatch version
- Add `meetsMinimumVersion()` for version constraint validation
- Add tests for version checking

## Test plan
- [ ] Verify version returns correct value when installed
- [ ] Verify version returns null when not installed
- [ ] Verify minimum version comparison works correctly

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)