### PR TITLE
fix: remove orphaned Nightwatch MCP config when package is uninstalled

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -214,6 +214,12 @@ class InstallCommand extends Command
         if ($this->nightwatch->isInstalled() && $this->shouldConfigureNightwatchMcp()) {
             $this->selectedBoostFeatures->push('nightwatch_mcp');
         }
+
+        if (! $this->nightwatch->isInstalled() && $this->config->getNightwatchMcp()) {
+            $this->info('Laravel Nightwatch is no longer installed. Nightwatch MCP will be removed.');
+            $this->config->setNightwatchMcp(false);
+            $this->selectedBoostFeatures->push('nightwatch_mcp_cleanup');
+        }
     }
 
     protected function shouldConfigureSail(): bool
@@ -458,6 +464,10 @@ class InstallCommand extends Command
 
     protected function installMcpServerConfig(): void
     {
+        if ($this->selectedBoostFeatures->contains('nightwatch_mcp_cleanup')) {
+            $this->uninstallNightwatchMcp();
+        }
+
         $this->installFeature(
             agents: $this->agentsWithMcp(),
             emptyMessage: 'No agents are selected for MCP installation.',
@@ -471,6 +481,23 @@ class InstallCommand extends Command
             featureName: 'MCP servers',
             withDelay: true,
         );
+    }
+
+    protected function uninstallNightwatchMcp(): void
+    {
+        $mcpAgents = $this->agentsWithMcp();
+
+        if ($mcpAgents->isEmpty()) {
+            return;
+        }
+
+        foreach ($mcpAgents as $agent) {
+            try {
+                (new McpWriter($agent))->uninstallNightwatchMcp();
+            } catch (\Exception $e) {
+                $this->warn("Could not remove Nightwatch MCP from {$agent->displayName()}: {$e->getMessage()}");
+            }
+        }
     }
 
     /**

--- a/src/Contracts/SupportsMcp.php
+++ b/src/Contracts/SupportsMcp.php
@@ -36,4 +36,9 @@ interface SupportsMcp
      * Install an HTTP MCP server configuration in this IDE.
      */
     public function installHttpMcp(string $key, string $url): bool;
+
+    /**
+     * Uninstall an HTTP MCP server configuration from this IDE.
+     */
+    public function uninstallHttpMcp(string $key): bool;
 }

--- a/src/Install/Agents/Agent.php
+++ b/src/Install/Agents/Agent.php
@@ -172,6 +172,27 @@ abstract class Agent
     }
 
     /**
+     * Uninstall an HTTP MCP server from the file-based configuration.
+     */
+    public function uninstallHttpMcp(string $key): bool
+    {
+        $path = $this->mcpConfigPath();
+
+        if (! $path) {
+            return false;
+        }
+
+        $writer = str_ends_with($path, '.toml')
+            ? new TomlFileWriter($path, $this->defaultMcpConfig())
+            : new FileWriter($path, $this->defaultMcpConfig());
+
+        return $writer
+            ->configKey($this->mcpConfigKey())
+            ->removeServerConfig($key)
+            ->save();
+    }
+
+    /**
      * Build the MCP server configuration payload for file-based installation.
      *
      * @param  array<int, string>  $args

--- a/src/Install/Mcp/FileWriter.php
+++ b/src/Install/Mcp/FileWriter.php
@@ -42,6 +42,9 @@ class FileWriter
         ])->filter(fn ($value): bool => ! in_array($value, [[], null, ''], true))->toArray());
     }
 
+    /** @var array<int, string> */
+    protected array $serversToRemove = [];
+
     /**
      * @param  array<string, mixed>  $config
      */
@@ -50,6 +53,13 @@ class FileWriter
         $this->serversToAdd[$key] = collect($config)
             ->filter(fn ($value): bool => ! in_array($value, [[], null, ''], true))
             ->toArray();
+
+        return $this;
+    }
+
+    public function removeServerConfig(string $key): self
+    {
+        $this->serversToRemove[] = $key;
 
         return $this;
     }
@@ -90,6 +100,8 @@ class FileWriter
 
     protected function updateJson5File(string $content): bool
     {
+        $content = $this->removeServersFromJson5($content);
+
         $configKeyPattern = '/["\']'.preg_quote($this->configKey, '/').'["\']\\s*:\\s*\\{/';
 
         if (preg_match($configKeyPattern, $content, $matches, PREG_OFFSET_CAPTURE)) {
@@ -97,6 +109,61 @@ class FileWriter
         }
 
         return $this->injectNewConfigKey($content);
+    }
+
+    protected function removeServersFromJson5(string $content): string
+    {
+        foreach ($this->serversToRemove as $key) {
+            $configKeyPattern = '/["\']'.preg_quote($this->configKey, '/').'["\']\\s*:\\s*\\{/';
+
+            if (! preg_match($configKeyPattern, $content, $matches, PREG_OFFSET_CAPTURE)) {
+                continue;
+            }
+
+            $openBracePos = strpos($content, '{', $matches[0][1]);
+
+            if ($openBracePos === false) {
+                continue;
+            }
+
+            $closeBracePos = $this->findMatchingClosingBrace($content, $openBracePos);
+
+            if ($closeBracePos === false) {
+                continue;
+            }
+
+            $configContent = substr($content, $openBracePos + 1, $closeBracePos - $openBracePos - 1);
+
+            if (! $this->serverExistsInContent($configContent, $key)) {
+                continue;
+            }
+
+            // Find and remove the server entry including its key and value object
+            $quotedPattern = '/,?\s*["\']'.preg_quote($key, '/').  '["\']\\s*:\\s*\\{/';
+            $unquotedPattern = '/,?\s*(?<=^|\\s|,|{)'.preg_quote($key, '/').'\\s*:\\s*\\{/m';
+
+            $pattern = preg_match($quotedPattern, $configContent, $m, PREG_OFFSET_CAPTURE)
+                ? $quotedPattern
+                : $unquotedPattern;
+
+            if (! preg_match($pattern, $configContent, $m, PREG_OFFSET_CAPTURE)) {
+                continue;
+            }
+
+            $serverStart = $openBracePos + 1 + $m[0][1];
+            $keyEnd = $serverStart + strlen($m[0][0]);
+            $valueBracePos = $keyEnd - 1; // position of the opening brace
+
+            $serverCloseBrace = $this->findMatchingClosingBrace($content, $valueBracePos);
+
+            if ($serverCloseBrace === false) {
+                continue;
+            }
+
+            $content = substr($content, 0, $serverStart).substr($content, $serverCloseBrace + 1);
+        }
+
+        return $content;
     }
 
     protected function injectIntoExistingConfigKey(string $content, array $matches): bool
@@ -413,8 +480,17 @@ class FileWriter
 
     protected function addServersToConfig(array &$config): void
     {
+        $this->removeServersFromConfig($config);
+
         foreach ($this->serversToAdd as $key => $serverConfig) {
             $config[$this->configKey][$key] = $serverConfig;
+        }
+    }
+
+    protected function removeServersFromConfig(array &$config): void
+    {
+        foreach ($this->serversToRemove as $key) {
+            unset($config[$this->configKey][$key]);
         }
     }
 

--- a/src/Install/Mcp/TomlFileWriter.php
+++ b/src/Install/Mcp/TomlFileWriter.php
@@ -13,6 +13,9 @@ class TomlFileWriter
     /** @var array<string, array<string, mixed>> */
     protected array $serversToAdd = [];
 
+    /** @var array<int, string> */
+    protected array $serversToRemove = [];
+
     /** @param array<string, mixed> $baseConfig */
     public function __construct(protected string $filePath, protected array $baseConfig = [])
     {
@@ -32,6 +35,13 @@ class TomlFileWriter
         $this->serversToAdd[$key] = collect($config)
             ->filter(fn ($value): bool => ! in_array($value, [[], null, ''], true))
             ->toArray();
+
+        return $this;
+    }
+
+    public function removeServerConfig(string $key): self
+    {
+        $this->serversToRemove[] = $key;
 
         return $this;
     }
@@ -71,6 +81,12 @@ class TomlFileWriter
     protected function updateExistingFile(): bool
     {
         $content = File::get($this->filePath);
+
+        foreach ($this->serversToRemove as $key) {
+            if ($this->serverExists($content, $key)) {
+                $content = $this->removeExistingServer($content, $key);
+            }
+        }
 
         foreach ($this->serversToAdd as $key => $config) {
             if ($this->serverExists($content, $key)) {

--- a/src/Install/McpWriter.php
+++ b/src/Install/McpWriter.php
@@ -69,6 +69,13 @@ class McpWriter
         return ! empty(getenv('WSL_DISTRO_NAME')) || ! empty(getenv('IS_WSL'));
     }
 
+    public function uninstallNightwatchMcp(): void
+    {
+        if (! $this->agent->uninstallHttpMcp('nightwatch')) {
+            throw new RuntimeException('Failed to uninstall Nightwatch MCP: could not write configuration');
+        }
+    }
+
     protected function installNightwatchMcp(Nightwatch $nightwatch): void
     {
         if (! $this->agent->installHttpMcp('nightwatch', $nightwatch->mcpUrl())) {


### PR DESCRIPTION
## Summary
- Detect when `laravel/nightwatch` is removed but MCP config remains orphaned
- Add `removeServerConfig()` to FileWriter and TomlFileWriter
- Add `uninstallHttpMcp()` to Agent base class and SupportsMcp contract
- Add `uninstallNightwatchMcp()` to McpWriter
- Wire cleanup into `configureMcpOptions()` and `installMcpServerConfig()` in InstallCommand
- Inform user when Nightwatch MCP is being removed

## Test plan
- [ ] Remove `laravel/nightwatch`, run `boost:install`, verify MCP config cleaned up
- [ ] Verify normal Nightwatch install flow still works
- [ ] Verify `boost.json` `nightwatch_mcp` flag is reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)