### PR TITLE
feat: add token/account guidance when installing Nightwatch MCP

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -213,7 +213,29 @@ class InstallCommand extends Command
 
         if ($this->nightwatch->isInstalled() && $this->shouldConfigureNightwatchMcp()) {
             $this->selectedBoostFeatures->push('nightwatch_mcp');
+
+            if (! $this->hasNightwatchToken()) {
+                $this->newLine();
+                $this->warn('Nightwatch MCP requires authentication. Sign up at https://nightwatch.laravel.com and add NIGHTWATCH_TOKEN to your .env file.');
+            }
         }
+    }
+
+    protected function hasNightwatchToken(): bool
+    {
+        $envPath = base_path('.env');
+
+        if (! file_exists($envPath)) {
+            return false;
+        }
+
+        $envContent = file_get_contents($envPath);
+
+        if ($envContent === false) {
+            return false;
+        }
+
+        return (bool) preg_match('/^NIGHTWATCH_TOKEN=.+$/m', $envContent);
     }
 
     protected function shouldConfigureSail(): bool


### PR DESCRIPTION
## Summary
- Check for `NIGHTWATCH_TOKEN` in `.env` during Nightwatch MCP installation
- Display warning with signup URL when token is missing
- Helps users understand authentication requirements before hitting errors

## Test plan
- [ ] Install Nightwatch MCP without NIGHTWATCH_TOKEN in .env — verify warning appears
- [ ] Install with NIGHTWATCH_TOKEN set — verify no warning
- [ ] Verify normal install flow continues after warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)