### PR TITLE
feat: add support for custom schema drivers

### DIFF
--- a/src/Mcp/Tools/DatabaseSchema/SchemaDriverFactory.php
+++ b/src/Mcp/Tools/DatabaseSchema/SchemaDriverFactory.php
@@ -4,10 +4,29 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Mcp\Tools\DatabaseSchema;
 
+use Closure;
 use Illuminate\Support\Facades\DB;
 
 class SchemaDriverFactory
 {
+    /**
+     * @var array<string, Closure(?string): DatabaseSchemaDriver>
+     */
+    protected static array $customDrivers = [];
+
+    /**
+     * @param  Closure(?string): DatabaseSchemaDriver|class-string<DatabaseSchemaDriver>  $resolver
+     */
+    public static function register(string $driverName, Closure|string $resolver): void
+    {
+        static::$customDrivers[$driverName] = static::resolveCustomDriverResolver($resolver);
+    }
+
+    public static function flush(): void
+    {
+        static::$customDrivers = [];
+    }
+
     public static function make(?string $connection = null): DatabaseSchemaDriver
     {
         $connectionName = $connection ?? config('database.default');
@@ -17,11 +36,28 @@ class SchemaDriverFactory
             $driverName = DB::connection($connectionName)->getDriverName();
         }
 
+        if (isset(static::$customDrivers[$driverName])) {
+            return (static::$customDrivers[$driverName])($connection);
+        }
+
         return match ($driverName) {
             'mysql', 'mariadb' => new MySQLSchemaDriver($connection),
             'pgsql' => new PostgreSQLSchemaDriver($connection),
             'sqlite' => new SQLiteSchemaDriver($connection),
             default => new NullSchemaDriver($connection),
         };
+    }
+
+    /**
+     * @param  Closure(?string): DatabaseSchemaDriver|class-string<DatabaseSchemaDriver>  $resolver
+     * @return Closure(?string): DatabaseSchemaDriver
+     */
+    protected static function resolveCustomDriverResolver(Closure|string $resolver): Closure
+    {
+        if ($resolver instanceof Closure) {
+            return $resolver;
+        }
+
+        return static fn (?string $connection): DatabaseSchemaDriver => new $resolver($connection);
     }
 }

--- a/tests/Fixtures/Mcp/Tools/DatabaseSchema/ExampleSchemaDriver.php
+++ b/tests/Fixtures/Mcp/Tools/DatabaseSchema/ExampleSchemaDriver.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Mcp\Tools\DatabaseSchema;
+
+use Laravel\Boost\Mcp\Tools\DatabaseSchema\DatabaseSchemaDriver;
+
+class ExampleSchemaDriver extends DatabaseSchemaDriver
+{
+    public function getViews(): array
+    {
+        return [];
+    }
+
+    public function getStoredProcedures(): array
+    {
+        return [];
+    }
+
+    public function getFunctions(): array
+    {
+        return [];
+    }
+
+    public function getTriggers(?string $table = null): array
+    {
+        return [];
+    }
+
+    public function getCheckConstraints(string $table): array
+    {
+        return [];
+    }
+
+    public function getSequences(): array
+    {
+        return [];
+    }
+
+    public function getTables(): array
+    {
+        return [];
+    }
+}

--- a/tests/Unit/Mcp/Tools/DatabaseSchema/SchemaDriverFactoryTest.php
+++ b/tests/Unit/Mcp/Tools/DatabaseSchema/SchemaDriverFactoryTest.php
@@ -7,8 +7,11 @@ use Laravel\Boost\Mcp\Tools\DatabaseSchema\NullSchemaDriver;
 use Laravel\Boost\Mcp\Tools\DatabaseSchema\PostgreSQLSchemaDriver;
 use Laravel\Boost\Mcp\Tools\DatabaseSchema\SchemaDriverFactory;
 use Laravel\Boost\Mcp\Tools\DatabaseSchema\SQLiteSchemaDriver;
+use Tests\Fixtures\Mcp\Tools\DatabaseSchema\ExampleSchemaDriver;
 
 beforeEach(function (): void {
+    SchemaDriverFactory::flush();
+
     config()->set('database.connections.mysql_test', [
         'driver' => 'mysql',
         'database' => 'test_db',
@@ -34,6 +37,15 @@ beforeEach(function (): void {
         'database' => 'test_db',
         'prefix' => '',
     ]);
+    config()->set('database.connections.example_test', [
+        'driver' => 'example',
+        'database' => 'test_db',
+        'prefix' => '',
+    ]);
+});
+
+afterEach(function (): void {
+    SchemaDriverFactory::flush();
 });
 
 test('creates MySQLSchemaDriver for mysql connection', function (): void {
@@ -64,4 +76,20 @@ test('creates NullSchemaDriver for sqlsrv driver', function (): void {
     $driver = SchemaDriverFactory::make('sqlsrv_test');
 
     expect($driver)->toBeInstanceOf(NullSchemaDriver::class);
+});
+
+test('creates a registered driver for an example connection driver', function (): void {
+    SchemaDriverFactory::register('example', ExampleSchemaDriver::class);
+
+    $driver = SchemaDriverFactory::make('example_test');
+
+    expect($driver)->toBeInstanceOf(ExampleSchemaDriver::class);
+});
+
+test('creates a registered driver from an example closure resolver', function (): void {
+    SchemaDriverFactory::register('example', fn (?string $connection): ExampleSchemaDriver => new ExampleSchemaDriver($connection));
+
+    $driver = SchemaDriverFactory::make('example_test');
+
+    expect($driver)->toBeInstanceOf(ExampleSchemaDriver::class);
 });


### PR DESCRIPTION
### Summary
This makes the schema tooling extensible with custom SchemaDriver implementations.

### Why
- It adds an easy way to implement other third-party database drivers outside of this package, such as Oracle, MongoDB.
- It provides a way to override the built-in SchemaDriver implementations when needed.

### My use case
This would allow me to create simple tooling for Oracle that would live outside this package.

### Changes
- add SchemaDriverFactory::register() to allow custom driver resolvers by driver name
- support both closure-based resolvers and driver class names
- add SchemaDriverFactory::flush() so tests and callers can reset registered custom drivers
- update make() to prefer a registered custom driver before falling back to built-in MySQL/PostgreSQL/SQLite/null handling
- add fixture and unit tests covering custom driver registration via class string and closure

I appreciate any feedback, and thank you for reviewing.