### PR TITLE
Add Amazon Q Developer as a supported agent

### DIFF
--- a/src/BoostManager.php
+++ b/src/BoostManager.php
@@ -6,6 +6,7 @@ namespace Laravel\Boost;
 
 use InvalidArgumentException;
 use Laravel\Boost\Install\Agents\Agent;
+use Laravel\Boost\Install\Agents\AmazonQ;
 use Laravel\Boost\Install\Agents\Amp;
 use Laravel\Boost\Install\Agents\ClaudeCode;
 use Laravel\Boost\Install\Agents\Codex;
@@ -19,6 +20,7 @@ class BoostManager
 {
     /** @var array<string, class-string<Agent>> */
     private array $agents = [
+        'amazonq' => AmazonQ::class,
         'amp' => Amp::class,
         'junie' => Junie::class,
         'cursor' => Cursor::class,

--- a/src/Install/Agents/AmazonQ.php
+++ b/src/Install/Agents/AmazonQ.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install\Agents;
+
+use Laravel\Boost\Contracts\SupportsGuidelines;
+use Laravel\Boost\Contracts\SupportsSkills;
+use Laravel\Boost\Install\Enums\Platform;
+
+class AmazonQ extends Agent implements SupportsGuidelines, SupportsSkills
+{
+    public function name(): string
+    {
+        return 'amazonq';
+    }
+
+    public function displayName(): string
+    {
+        return 'Amazon Q Developer';
+    }
+
+    public function systemDetectionConfig(Platform $platform): array
+    {
+        return match ($platform) {
+            Platform::Darwin => [
+                'paths' => ['/Applications/Visual Studio Code.app'],
+            ],
+            Platform::Linux => [
+                'command' => 'command -v code',
+            ],
+            Platform::Windows => [
+                'paths' => [
+                    '%ProgramFiles%\\Microsoft VS Code',
+                    '%LOCALAPPDATA%\\Programs\\Microsoft VS Code',
+                ],
+            ],
+        };
+    }
+
+    public function projectDetectionConfig(): array
+    {
+        return [
+            'paths' => ['.amazonq'],
+        ];
+    }
+
+    public function guidelinesPath(): string
+    {
+        return config('boost.agents.amazonq.guidelines_path', '.amazonq/rules/guidelines.md');
+    }
+
+    public function skillsPath(): string
+    {
+        return config('boost.agents.amazonq.skills_path', '.amazonq/rules/skills');
+    }
+}

--- a/tests/Unit/BoostManagerTest.php
+++ b/tests/Unit/BoostManagerTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Laravel\Boost\BoostManager;
+use Laravel\Boost\Install\Agents\AmazonQ;
 use Laravel\Boost\Install\Agents\Amp;
 use Laravel\Boost\Install\Agents\ClaudeCode;
 use Laravel\Boost\Install\Agents\Codex;
@@ -18,6 +19,7 @@ it('returns default agents', function (): void {
     $registered = $manager->getAgents();
 
     expect($registered)->toMatchArray([
+        'amazonq' => AmazonQ::class,
         'amp' => Amp::class,
         'junie' => Junie::class,
         'cursor' => Cursor::class,

--- a/tests/Unit/Install/Agents/AmazonQTest.php
+++ b/tests/Unit/Install/Agents/AmazonQTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Install\Agents;
+
+use Laravel\Boost\Install\Agents\AmazonQ;
+use Laravel\Boost\Install\Detection\DetectionStrategyFactory;
+use Mockery;
+
+beforeEach(function (): void {
+    $this->strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
+});
+
+test('name returns amazonq', function (): void {
+    $agent = new AmazonQ($this->strategyFactory);
+
+    expect($agent->name())->toBe('amazonq');
+});
+
+test('displayName returns Amazon Q Developer', function (): void {
+    $agent = new AmazonQ($this->strategyFactory);
+
+    expect($agent->displayName())->toBe('Amazon Q Developer');
+});
+
+test('guidelinesPath returns default path', function (): void {
+    $agent = new AmazonQ($this->strategyFactory);
+
+    expect($agent->guidelinesPath())->toBe('.amazonq/rules/guidelines.md');
+});
+
+test('skillsPath returns default path', function (): void {
+    $agent = new AmazonQ($this->strategyFactory);
+
+    expect($agent->skillsPath())->toBe('.amazonq/rules/skills');
+});
+
+test('projectDetectionConfig detects .amazonq directory', function (): void {
+    $agent = new AmazonQ($this->strategyFactory);
+
+    expect($agent->projectDetectionConfig())->toBe([
+        'paths' => ['.amazonq'],
+    ]);
+});

--- a/tests/Unit/Install/AgentsDetectorTest.php
+++ b/tests/Unit/Install/AgentsDetectorTest.php
@@ -6,6 +6,7 @@ use Illuminate\Container\Container;
 use Illuminate\Support\Collection;
 use Laravel\Boost\BoostManager;
 use Laravel\Boost\Install\Agents\Agent;
+use Laravel\Boost\Install\Agents\AmazonQ;
 use Laravel\Boost\Install\Agents\Amp;
 use Laravel\Boost\Install\Agents\ClaudeCode;
 use Laravel\Boost\Install\Agents\Codex;
@@ -31,9 +32,9 @@ it('returns collection of all registered agents', function (): void {
     $agents = $this->detector->getAgents();
 
     expect($agents)->toBeInstanceOf(Collection::class)
-        ->and($agents->count())->toBe(8)
+        ->and($agents->count())->toBe(9)
         ->and($agents->keys()->toArray())->toBe([
-            'amp', 'junie', 'cursor', 'claude_code', 'codex', 'copilot', 'opencode', 'gemini',
+            'amazonq', 'amp', 'junie', 'cursor', 'claude_code', 'codex', 'copilot', 'opencode', 'gemini',
         ]);
 
     $agents->each(function ($agent): void {
@@ -54,6 +55,7 @@ it('returns an array of detected agents names for system discovery', function ()
     $mockOther->shouldReceive('detectOnSystem')->with(Mockery::type(Platform::class))->andReturn(false);
     $mockOther->shouldReceive('name')->andReturn('other');
 
+    $this->container->bind(AmazonQ::class, fn () => $mockOther);
     $this->container->bind(Amp::class, fn () => $mockOther);
     $this->container->bind(Junie::class, fn () => $mockJunie);
     $this->container->bind(Cursor::class, fn () => $mockCursor);
@@ -74,6 +76,7 @@ it('returns an empty array when no agents are detected for system discovery', fu
     $mockAgent->shouldReceive('detectOnSystem')->with(Mockery::type(Platform::class))->andReturn(false);
     $mockAgent->shouldReceive('name')->andReturn('mock');
 
+    $this->container->bind(AmazonQ::class, fn () => $mockAgent);
     $this->container->bind(Amp::class, fn () => $mockAgent);
     $this->container->bind(Junie::class, fn () => $mockAgent);
     $this->container->bind(Cursor::class, fn () => $mockAgent);
@@ -104,6 +107,7 @@ it('returns an array of detected agent names for project discovery', function ()
     $mockOther->shouldReceive('detectInProject')->with($basePath)->andReturn(false);
     $mockOther->shouldReceive('name')->andReturn('other');
 
+    $this->container->bind(AmazonQ::class, fn () => $mockOther);
     $this->container->bind(Amp::class, fn () => $mockOther);
     $this->container->bind(Junie::class, fn () => $mockJunie);
     $this->container->bind(Cursor::class, fn () => $mockOther);
@@ -126,6 +130,7 @@ it('returns an empty array when no agents are detected for project discovery', f
     $mockAgent->shouldReceive('detectInProject')->with($basePath)->andReturn(false);
     $mockAgent->shouldReceive('name')->andReturn('mock');
 
+    $this->container->bind(AmazonQ::class, fn () => $mockAgent);
     $this->container->bind(Amp::class, fn () => $mockAgent);
     $this->container->bind(Junie::class, fn () => $mockAgent);
     $this->container->bind(Cursor::class, fn () => $mockAgent);


### PR DESCRIPTION
Closes #705

## Summary

Adds Amazon Q Developer as a supported agent in Laravel Boost.

- New `AmazonQ` agent class implementing `SupportsGuidelines` and `SupportsSkills`
- Guidelines path: `.amazonq/rules/guidelines.md`
- Skills path: `.amazonq/rules/skills`
- Project detection via `.amazonq` directory
- System detection via VS Code (same as Copilot)
- No MCP support — Amazon Q MCP is user-level, not project-level

Amazon Q Developer automatically reads all `*.md` files under `.amazonq/rules/` as context in every chat and inline completion, requiring no extra configuration from the user.