### PR TITLE
Strip HTML comments before parsing skill frontmatter

### DIFF
--- a/src/Install/SkillComposer.php
+++ b/src/Install/SkillComposer.php
@@ -231,7 +231,9 @@ class SkillComposer
      */
     protected function parseSkillFrontmatter(string $content): array
     {
-        if (! preg_match('/^---\s*\n(.*?)\n---\s*\n/s', $content, $matches)) {
+        $content = preg_replace('/^(\s*<!--.*?-->\s*)+/s', '', $content);
+
+        if (! preg_match('/^\s*---\s*\n(.*?)\n---\s*\n/s', $content, $matches)) {
             return [];
         }
 

--- a/tests/Feature/Install/SkillComposerTest.php
+++ b/tests/Feature/Install/SkillComposerTest.php
@@ -358,3 +358,30 @@ test('blade skills with code before frontmatter are parsed correctly', function 
         @rmdir($skillDir);
     }
 });
+
+test('frontmatter parsing ignores HTML comments injected by third-party packages', function (): void {
+    $packages = new PackageCollection([
+        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+    ]);
+
+    $this->roster->shouldReceive('packages')->andReturn($packages);
+
+    $composer = new SkillComposer($this->roster);
+    $method = new ReflectionMethod($composer, 'parseSkillFrontmatter');
+
+    $content = <<<'HTML'
+        <!-- Start blade view: 'storage/framework/views/bf9245cd.blade.php' -->
+        ---
+        name: pest-testing
+        description: "Write and run tests with Pest"
+        ---
+
+        # Content
+        HTML;
+
+    $result = $method->invoke($composer, $content);
+
+    expect($result)
+        ->toHaveKey('name', 'pest-testing')
+        ->toHaveKey('description', 'Write and run tests with Pest');
+});


### PR DESCRIPTION
When `spatie/laravel-blade-comments` is installed, it injects HTML comments into Blade rendering output. This causes skill frontmatter parsing to silently fail for all `.blade.php` skills because the regex expects `---` at the start of the string.

Fixes #710

### Approach

- Strip HTML comments from rendered content before parsing frontmatter
- Allow leading whitespace before the frontmatter delimiter