### PR TITLE
Escape Blade component tags in guideline rendering

### DIFF
--- a/src/Concerns/RendersBladeGuidelines.php
+++ b/src/Concerns/RendersBladeGuidelines.php
@@ -19,13 +19,16 @@ trait RendersBladeGuidelines
             return $content;
         }
 
-        // Temporarily replace backticks and PHP opening tags with placeholders before Blade processing
-        // This prevents Blade from trying to execute PHP code examples and supports inline code
+        // Temporarily replace backticks, PHP opening tags, component tags, and Volt directives
+        // with placeholders before Blade processing. This prevents Blade from trying to execute
+        // PHP code examples, compile component references, and supports inline code.
         $placeholders = [
             '`' => '___SINGLE_BACKTICK___',
             '<?php' => '___OPEN_PHP_TAG___',
             '@volt' => '___VOLT_DIRECTIVE___',
             '@endvolt' => '___ENDVOLT_DIRECTIVE___',
+            '</x-' => '___BLADE_COMPONENT_CLOSE___',
+            '<x-' => '___BLADE_COMPONENT_OPEN___',
         ];
 
         $content = str_replace(array_keys($placeholders), array_values($placeholders), $content);


### PR DESCRIPTION
The Inertia v3 upgrade prompt references `<x-inertia::head>` and `<x-inertia::app>` as literal markdown text, but Blade's ComponentTagCompiler tries to compile them as real components, throwing an `InvalidArgumentException` that corrupts the MCP stdio transport with non-JSON output.

### Approach

- Added `<x-` and `</x-` to the existing placeholder system that already handles backticks, PHP tags, and Volt directives, so component tag references in prompt templates are preserved as literal strings during Blade compilation.