### PR TITLE
Fix leftover quotes in MCP development skill description

### DIFF
--- a/.ai/mcp/skill/mcp-development/SKILL.blade.php
+++ b/.ai/mcp/skill/mcp-development/SKILL.blade.php
@@ -23,7 +23,7 @@ search-docs(['mcp tools', 'mcp resources', 'mcp validation'])
 
 ### Artisan Commands
 
-Create MCP Primitives"
+Create MCP Primitives
 ```bash
 {{ $assist->artisanCommand('make:mcp-tool ToolName') }}
 {{ $assist->artisanCommand('make:mcp-resource ResourceName') }}


### PR DESCRIPTION
Just removes leftover quotes in the MCP development skill.