### PR TITLE
Use configured PHP executable path in ToolExecutor subprocess

### DIFF
--- a/src/Install/Agents/Agent.php
+++ b/src/Install/Agents/Agent.php
@@ -11,6 +11,7 @@ use Laravel\Boost\Install\Enums\McpInstallationStrategy;
 use Laravel\Boost\Install\Enums\Platform;
 use Laravel\Boost\Install\Mcp\FileWriter;
 use Laravel\Boost\Install\Mcp\TomlFileWriter;
+use Laravel\Boost\Support\CommandNormalizer;
 
 abstract class Agent
 {
@@ -270,19 +271,7 @@ abstract class Agent
      */
     protected function normalizeCommand(string $command, array $args = []): array
     {
-        if (str_starts_with($command, '/') || preg_match('#^[a-zA-Z]:[/\\\\]#', $command)) {
-            return [
-                'command' => $command,
-                'args' => $args,
-            ];
-        }
-
-        $parts = str($command)->explode(' ');
-
-        return [
-            'command' => $parts->first(),
-            'args' => $parts->skip(1)->values()->merge($args)->all(),
-        ];
+        return CommandNormalizer::normalize($command, $args);
     }
 
     /**

--- a/src/Install/SkillComposer.php
+++ b/src/Install/SkillComposer.php
@@ -233,7 +233,7 @@ class SkillComposer
     {
         $content = preg_replace('/^(\s*<!--.*?-->\s*)+/s', '', $content);
 
-        if (! preg_match('/^\s*---\s*\n(.*?)\n---\s*\n/s', $content, $matches)) {
+        if (! preg_match('/^\s*---\s*\n(.*?)\n---\s*\n/s', (string) $content, $matches)) {
             return [];
         }
 

--- a/src/Mcp/ToolExecutor.php
+++ b/src/Mcp/ToolExecutor.php
@@ -6,6 +6,7 @@ namespace Laravel\Boost\Mcp;
 
 use Dotenv\Dotenv;
 use Illuminate\Support\Env;
+use Laravel\Boost\Support\CommandNormalizer;
 use Laravel\Mcp\Response;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
@@ -124,8 +125,12 @@ class ToolExecutor
      */
     protected function buildCommand(string $toolClass, array $arguments): array
     {
+        $phpBinary = config('boost.executable_paths.php') ?? PHP_BINARY;
+        $normalized = CommandNormalizer::normalize($phpBinary);
+
         return [
-            PHP_BINARY,
+            $normalized['command'],
+            ...$normalized['args'],
             base_path('artisan'),
             'boost:execute-tool',
             $toolClass,

--- a/src/Support/CommandNormalizer.php
+++ b/src/Support/CommandNormalizer.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Support;
+
+class CommandNormalizer
+{
+    /**
+     * Normalize a command string into a command and args array.
+     *
+     * Absolute paths (starting with / on Unix or a drive letter on Windows)
+     * are never split, as they may contain spaces (e.g. macOS "Application Support").
+     *
+     * @param  array<int, string>  $args
+     * @return array{command: string, args: array<int, string>}
+     */
+    public static function normalize(string $command, array $args = []): array
+    {
+        if (str_starts_with($command, '/') || preg_match('#^[a-zA-Z]:[/\\\\]#', $command)) {
+            return [
+                'command' => $command,
+                'args' => $args,
+            ];
+        }
+
+        $parts = str($command)->explode(' ');
+
+        return [
+            'command' => $parts->first(),
+            'args' => $parts->skip(1)->values()->merge($args)->all(),
+        ];
+    }
+}

--- a/src/Support/CommandNormalizer.php
+++ b/src/Support/CommandNormalizer.php
@@ -7,11 +7,6 @@ namespace Laravel\Boost\Support;
 class CommandNormalizer
 {
     /**
-     * Normalize a command string into a command and args array.
-     *
-     * Absolute paths (starting with / on Unix or a drive letter on Windows)
-     * are never split, as they may contain spaces (e.g. macOS "Application Support").
-     *
      * @param  array<int, string>  $args
      * @return array{command: string, args: array<int, string>}
      */

--- a/tests/Feature/Mcp/ToolExecutorTest.php
+++ b/tests/Feature/Mcp/ToolExecutorTest.php
@@ -174,6 +174,46 @@ test('output buffering discards stray stdout during tool execution', function ()
     }
 });
 
+test('buildCommand preserves absolute paths with spaces', function (): void {
+    config(['boost.executable_paths.php' => '/Applications/Some App/bin/php']);
+
+    $executor = new ToolExecutor;
+
+    $reflection = new ReflectionClass($executor);
+    $method = $reflection->getMethod('buildCommand');
+
+    $command = $method->invoke($executor, 'SomeTool', []);
+
+    expect($command[0])->toBe('/Applications/Some App/bin/php');
+});
+
+test('buildCommand splits multi-token wrapper commands', function (): void {
+    config(['boost.executable_paths.php' => 'herd php']);
+
+    $executor = new ToolExecutor;
+
+    $reflection = new ReflectionClass($executor);
+    $method = $reflection->getMethod('buildCommand');
+
+    $command = $method->invoke($executor, 'SomeTool', []);
+
+    expect($command[0])->toBe('herd')
+        ->and($command[1])->toBe('php');
+});
+
+test('buildCommand uses PHP_BINARY when no config is set', function (): void {
+    config(['boost.executable_paths.php' => null]);
+
+    $executor = new ToolExecutor;
+
+    $reflection = new ReflectionClass($executor);
+    $method = $reflection->getMethod('buildCommand');
+
+    $command = $method->invoke($executor, 'SomeTool', []);
+
+    expect($command[0])->toBe(PHP_BINARY);
+});
+
 test('clamps timeout values correctly', function (): void {
     $executor = new ToolExecutor;
 


### PR DESCRIPTION
When running Boost's MCP server via HTTP transport (`Mcp::web()`) behind PHP-FPM, `ToolExecutor` uses `PHP_BINARY` to spawn subprocesses — which resolves to `php-fpm` instead of `php`, breaking all tool calls. The `boost.executable_paths.php` config already exists and is respected elsewhere, but `ToolExecutor` wasn't using it.

Fixes #723

### Approach

- Extracted the command normalization logic (absolute path detection, multi-token command splitting) into a shared `CommandNormalizer` helper so it can be reused
- Updated `ToolExecutor::buildCommand()` to read the configured PHP path with `PHP_BINARY` as fallback
- Added tests for absolute paths with spaces, multi-token wrappers like `herd php`, and the default fallback