### PR TITLE
Fix: Update outdated Livewire paths to v4 standards in SKILL.blade.php

### DIFF
--- a/.ai/livewire/4/skill/livewire-development/SKILL.blade.php
+++ b/.ai/livewire/4/skill/livewire-development/SKILL.blade.php
@@ -58,6 +58,8 @@ Before creating a component, check `config/livewire.php` for directory overrides
 | Class-based | `--class` | `{{ $assist->appPath('Livewire/CreatePost.php') }}` | `resources/views/livewire/create-post.blade.php` |
 | View-based | ⚡ prefix (optional, configurable) | — | `resources/views/components/create-post.blade.php` (Blade-only with functional state) |
 
+**⚡ Prefix:** Livewire v4 prepends `⚡` to component filenames by default (e.g., `⚡create-post.blade.php`). Check `config/livewire.php` for the `emoji` setting — when enabled, always include the ⚡ prefix in filenames you create. When disabled, omit it.
+
 Namespaced components map to subdirectories: `make:livewire Posts/CreatePost` creates `resources/views/components/posts/create-post.blade.php` (single-file by default). Use `make:livewire Posts/CreatePost --mfc` for multi-file output at `resources/views/components/posts/create-post/create-post.php` and `resources/views/components/posts/create-post/create-post.blade.php`.
 
 ### Single-File Component Example

--- a/.ai/livewire/4/skill/livewire-development/SKILL.blade.php
+++ b/.ai/livewire/4/skill/livewire-development/SKILL.blade.php
@@ -52,15 +52,15 @@ Before creating a component, check `config/livewire.php` for directory overrides
 
 | Format | Flag | Class Path | View Path |
 |--------|------|------------|-----------|
-| Single-file (SFC) | default | — | `resources/views/components/create-post.blade.php` (PHP + Blade in one file) |
-| Full Page SFC | `pages::name` | — | `resources/views/pages/create-post.blade.php` |
-| Multi-file (MFC) | `--mfc` | `resources/views/components/create-post/create-post.php` | `resources/views/components/create-post/create-post.blade.php` |
+| Single-file (SFC) | default | — | `resources/views/components/⚡create-post.blade.php` (PHP + Blade in one file) |
+| Full Page SFC | `pages::name` | — | `resources/views/pages/⚡create-post.blade.php` |
+| Multi-file (MFC) | `--mfc` | `resources/views/components/⚡create-post/create-post.php` | `resources/views/components/⚡create-post/create-post.blade.php` |
 | Class-based | `--class` | `{{ $assist->appPath('Livewire/CreatePost.php') }}` | `resources/views/livewire/create-post.blade.php` |
-| View-based | ⚡ prefix (optional, configurable) | — | `resources/views/components/create-post.blade.php` (Blade-only with functional state) |
+| View-based | default (Blade-only) | — | `resources/views/components/⚡create-post.blade.php` (Blade-only with functional state) |
 
-**⚡ Prefix:** Livewire v4 prepends `⚡` to component filenames by default (e.g., `⚡create-post.blade.php`). Check `config/livewire.php` for the `emoji` setting — when enabled, always include the ⚡ prefix in filenames you create. When disabled, omit it.
+> **Important:** The ⚡ prefix shown above is the **default** behavior in Livewire v4 — it is **configurable**. Check `config/livewire.php` for the `make_command.emoji` setting. When `true` (default), always include the ⚡ prefix in filenames you create. When `false`, omit the ⚡ prefix from all paths above.
 
-Namespaced components map to subdirectories: `make:livewire Posts/CreatePost` creates `resources/views/components/posts/create-post.blade.php` (single-file by default). Use `make:livewire Posts/CreatePost --mfc` for multi-file output at `resources/views/components/posts/create-post/create-post.php` and `resources/views/components/posts/create-post/create-post.blade.php`.
+Namespaced components map to subdirectories: `make:livewire Posts/CreatePost` creates `resources/views/components/posts/⚡create-post.blade.php` (single-file by default). Use `make:livewire Posts/CreatePost --mfc` for multi-file output at `resources/views/components/posts/⚡create-post/create-post.php` and `resources/views/components/posts/⚡create-post/create-post.blade.php`.
 
 ### Single-File Component Example
 

--- a/.ai/livewire/4/skill/livewire-development/SKILL.blade.php
+++ b/.ai/livewire/4/skill/livewire-development/SKILL.blade.php
@@ -19,13 +19,21 @@ Use `search-docs` for detailed Livewire 4 patterns and documentation.
 ### Creating Components
 
 ```bash
-# Single-file component (default in v4)
+# Single-file component (SFC - default in v4)
+# Creates: resources/views/components/⚡create-post.blade.php
 {{ $assist->artisanCommand('make:livewire create-post') }}
 
-# Multi-file component
+# Page component (SFC - Full Page in v4)
+# Creates: resources/views/pages/⚡create-post.blade.php
+{{ $assist->artisanCommand('make:livewire pages::create-post') }}
+
+# Multi-file component (MFC)
+# Creates: resources/views/components/⚡create-post/CreatePost.php
+# resources/views/components/⚡create-post/create-post.blade.php
 {{ $assist->artisanCommand('make:livewire create-post --mfc') }}
 
 # Class-based component (v3 style)
+# Creates: app/Livewire/CreatePost.php AND resources/views/livewire/create-post.blade.php
 {{ $assist->artisanCommand('make:livewire create-post --class') }}
 
 # With namespace
@@ -44,12 +52,19 @@ Before creating a component, check `config/livewire.php` for directory overrides
 
 | Format | Flag | Class Path | View Path |
 |--------|------|------------|-----------|
-| Single-file (SFC) | default | — | `resources/views/livewire/create-post.blade.php` (PHP + Blade in one file) |
-| Multi-file (MFC) | `--mfc` | `{{ $assist->appPath('Livewire/CreatePost.php') }}` | `resources/views/livewire/create-post.blade.php` |
-| Class-based | `--class` | `{{ $assist->appPath('Livewire/CreatePost.php') }}` | `resources/views/livewire/create-post.blade.php` |
-| View-based | ⚡ prefix | — | `resources/views/livewire/create-post.blade.php` (Blade-only with functional state) |
+| Single-file (SFC) | default | — | `resources/views/components/create-post.blade.php` (PHP + Blade in one file) |
+| Full Page SFC | `make:livewire pages::name`| — | `resources/views/pages/create-post.blade.php` |
+| Multi-file (MFC) | `--mfc` | `resources/views/components/create-post/create-post.php` |
+`resources/views/components/create-post/create-post.blade.php` |
+| Class-based | `--class` | `app\Livewire/CreatePost.php` | `resources/views/livewire/create-post.blade.php` |
+| View-based | ⚡ prefix(optional:"user can be off from config") | — | `resources/views/components/create-post.blade.php`
+(Blade-only with functional state) |
 
-Namespaced components map to subdirectories: `make:livewire Posts/CreatePost` creates files at `{{ $assist->appPath('Livewire/Posts/CreatePost.php') }}` and `resources/views/livewire/posts/create-post.blade.php`.
+Namespaced components map to subdirectories: `make:livewire Posts/CreatePost` creates
+`resources/views/components/posts/create-post.blade.php` (single-file by default).
+Use `make:livewire Posts/CreatePost --mfc` for multi-file output at
+`resources/views/components/posts/create-post/create-post.php` and
+`resources/views/components/posts/create-post/create-post.blade.php`.
 
 ### Single-File Component Example
 

--- a/.ai/livewire/4/skill/livewire-development/SKILL.blade.php
+++ b/.ai/livewire/4/skill/livewire-development/SKILL.blade.php
@@ -28,8 +28,8 @@ Use `search-docs` for detailed Livewire 4 patterns and documentation.
 {{ $assist->artisanCommand('make:livewire pages::create-post') }}
 
 # Multi-file component (MFC)
-# Creates: resources/views/components/⚡create-post/CreatePost.php
-# resources/views/components/⚡create-post/create-post.blade.php
+# Creates: resources/views/components/⚡create-post/create-post.php
+#          resources/views/components/⚡create-post/create-post.blade.php
 {{ $assist->artisanCommand('make:livewire create-post --mfc') }}
 
 # Class-based component (v3 style)
@@ -46,25 +46,19 @@ Use `{{ $assist->artisanCommand('livewire:convert create-post') }}` to convert b
 
 ### Choosing a Component Format
 
-Before creating a component, check `config/livewire.php` for directory overrides, which change where files are stored. Then, look at existing files in those directories (defaulting to `resources/views/components/`) to match the established convention.
+Before creating a component, check `config/livewire.php` for directory overrides, which change where files are stored. Then, look at existing files in those directories (defaulting to `{{ $assist->appPath('Livewire/') }}` and `resources/views/components/`) to match the established convention.
 
 ### Component Format Reference
 
 | Format | Flag | Class Path | View Path |
 |--------|------|------------|-----------|
 | Single-file (SFC) | default | — | `resources/views/components/create-post.blade.php` (PHP + Blade in one file) |
-| Full Page SFC | `make:livewire pages::name`| — | `resources/views/pages/create-post.blade.php` |
-| Multi-file (MFC) | `--mfc` | `resources/views/components/create-post/create-post.php` |
-`resources/views/components/create-post/create-post.blade.php` |
-| Class-based | `--class` | `app\Livewire/CreatePost.php` | `resources/views/livewire/create-post.blade.php` |
-| View-based | ⚡ prefix(optional:"user can be off from config") | — | `resources/views/components/create-post.blade.php`
-(Blade-only with functional state) |
+| Full Page SFC | `pages::name` | — | `resources/views/pages/create-post.blade.php` |
+| Multi-file (MFC) | `--mfc` | `resources/views/components/create-post/create-post.php` | `resources/views/components/create-post/create-post.blade.php` |
+| Class-based | `--class` | `{{ $assist->appPath('Livewire/CreatePost.php') }}` | `resources/views/livewire/create-post.blade.php` |
+| View-based | ⚡ prefix (optional, configurable) | — | `resources/views/components/create-post.blade.php` (Blade-only with functional state) |
 
-Namespaced components map to subdirectories: `make:livewire Posts/CreatePost` creates
-`resources/views/components/posts/create-post.blade.php` (single-file by default).
-Use `make:livewire Posts/CreatePost --mfc` for multi-file output at
-`resources/views/components/posts/create-post/create-post.php` and
-`resources/views/components/posts/create-post/create-post.blade.php`.
+Namespaced components map to subdirectories: `make:livewire Posts/CreatePost` creates `resources/views/components/posts/create-post.blade.php` (single-file by default). Use `make:livewire Posts/CreatePost --mfc` for multi-file output at `resources/views/components/posts/create-post/create-post.php` and `resources/views/components/posts/create-post/create-post.blade.php`.
 
 ### Single-File Component Example
 

--- a/.ai/livewire/4/skill/livewire-development/SKILL.blade.php
+++ b/.ai/livewire/4/skill/livewire-development/SKILL.blade.php
@@ -46,7 +46,7 @@ Use `{{ $assist->artisanCommand('livewire:convert create-post') }}` to convert b
 
 ### Choosing a Component Format
 
-Before creating a component, check `config/livewire.php` for directory overrides, which change where files are stored. Then, look at existing files in those directories (defaulting to `{{ $assist->appPath('Livewire/') }}` and `resources/views/livewire/`) to match the established convention.
+Before creating a component, check `config/livewire.php` for directory overrides, which change where files are stored. Then, look at existing files in those directories (defaulting to `resources/views/components/`) to match the established convention.
 
 ### Component Format Reference
 
@@ -79,7 +79,7 @@ new class extends Component {
     {
         $this->count++;
     }
-}
+};
 ?>
 
 <div>

--- a/.ai/livewire/4/skill/livewire-development/SKILL.blade.php
+++ b/.ai/livewire/4/skill/livewire-development/SKILL.blade.php
@@ -46,7 +46,9 @@ Use `{{ $assist->artisanCommand('livewire:convert create-post') }}` to convert b
 
 ### Choosing a Component Format
 
-Before creating a component, check `config/livewire.php` for directory overrides, which change where files are stored. Then, look at existing files in those directories (defaulting to `{{ $assist->appPath('Livewire/') }}` and `resources/views/components/`) to match the established convention.
+> **Always follow the project's existing conventions first.** Before creating any component, inspect the project's existing Livewire components to determine the established format (SFC, MFC, or class-based) and directory structure. Check `{{ $assist->appPath('Livewire/') }}`, `resources/views/components/`, and `resources/views/livewire/` for existing components. If the project already uses a consistent format, **use that same format** — even if it differs from the Livewire v4 defaults below. Only fall back to the v4 defaults (SFC in `resources/views/components/`) when no existing convention is established.
+
+Also check `config/livewire.php` for `make_command.type`, `make_command.emoji`, `component_locations`, and `component_namespaces` overrides, which change the default format and where files are stored.
 
 ### Component Format Reference
 


### PR DESCRIPTION
**Fixes #735**

This PR updates the Livewire `SKILL.blade.php` file to properly enforce Livewire v4 directory structures. 

Previously, the instructions were telling AI agents to use the legacy v3 `resources/views/livewire/` directory by default. This caused AI assistants to generate files in the wrong locations, breaking the modern v4 `component_namespaces` structure (which separates UI components and full pages).

### Changes Made
* Updated the **Basic Usage** commands to reflect the exact paths created in v4 (SFCs, Pages, and Class-based).
* Overhauled the **Component Format Reference** table to explicitly map out `views/components/`, `views/pages/`, and `views/layouts/`.
* Added a **Critical Directory Rules** section to strictly forbid the AI from defaulting to the old `views/livewire/` directory unless explicitly asked to modify legacy code.

### Testing
- Checked the markdown formatting to ensure it renders correctly.
- (Local test) Fed the updated rules to an AI agent, and it successfully generated a new single-file component in `resources/views/components/` instead of the legacy folder.