### PR TITLE
Remove model discovery and use token-based class parsing

### DIFF
--- a/.ai/php/core.blade.php
+++ b/.ai/php/core.blade.php
@@ -3,9 +3,6 @@
 @php
 /** @var \Laravel\Boost\Install\GuidelineAssist $assist */
 @endphp
-@if($assist->shouldEnforceStrictTypes())
-- Always declare `declare(strict_types=1);` at the top of every `.php` file.
-@endif
 - Always use curly braces for control structures, even for single-line bodies.
 - Use PHP 8 constructor property promotion: `public function __construct(public GitHub $github) { }`. Do not leave empty zero-parameter `__construct()` methods unless the constructor is private.
 - Use explicit return type declarations and type hints for all method parameters: `function isAccessible(User $user, ?string $path = null): bool`

--- a/src/Install/GuidelineAssist.php
+++ b/src/Install/GuidelineAssist.php
@@ -52,10 +52,10 @@ class GuidelineAssist
             ->name('/[A-Z].*\.php$/');
 
         foreach ($finder as $file) {
-            $path = $appPath.DIRECTORY_SEPARATOR.$file->getRelativePathname();
+            $path = $file->getRealPath();
             $code = file_get_contents($path);
 
-            if ($code === false) {
+            if ($code === false || stripos($code, 'enum') === false) {
                 continue;
             }
 

--- a/src/Install/GuidelineAssist.php
+++ b/src/Install/GuidelineAssist.php
@@ -4,52 +4,23 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Install;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Laravel\Boost\Install\Assists\Inertia;
 use Laravel\Roster\Enums\NodePackageManager;
 use Laravel\Roster\Enums\Packages;
 use Laravel\Roster\Roster;
-use ReflectionClass;
 use Symfony\Component\Finder\Finder;
-use Throwable;
 
 class GuidelineAssist
 {
     /** @var array<string, string> */
-    protected array $modelPaths = [];
-
-    /** @var array<string, string> */
-    protected array $controllerPaths = [];
-
-    /** @var array<string, string> */
     protected array $enumPaths = [];
-
-    protected static array $classes = [];
 
     public function __construct(public Roster $roster, public GuidelineConfig $config, public ?Collection $skills = null)
     {
         $this->skills ??= collect();
-        $this->modelPaths = $this->discover(fn ($reflection): bool => ($reflection->isSubclassOf(Model::class) && ! $reflection->isAbstract()));
-        $this->controllerPaths = $this->discover(fn (ReflectionClass $reflection): bool => (stripos($reflection->getName(), 'controller') !== false || stripos($reflection->getNamespaceName(), 'controller') !== false));
-        $this->enumPaths = $this->discover(fn ($reflection) => $reflection->isEnum());
-    }
-
-    /**
-     * @return array<string, string> - className, absolutePath
-     */
-    public function models(): array
-    {
-        return $this->modelPaths;
-    }
-
-    /**
-     * @return array<string, string> - className, absolutePath
-     */
-    public function controllers(): array
-    {
-        return $this->controllerPaths;
+        $this->enumPaths = $this->discover();
     }
 
     /**
@@ -61,108 +32,50 @@ class GuidelineAssist
     }
 
     /**
-     * Discover all Eloquent models in the application.
+     * Discover all enum files in the application directory.
      *
      * @return array<string, string>
      */
-    protected function discover(callable $cb): array
+    protected function discover(): array
     {
-        $classes = [];
         $appPath = app_path();
 
         if (! is_dir($appPath)) {
-            return ['app-path-isnt-a-directory' => $appPath];
+            return [];
         }
 
-        if (self::$classes === []) {
-            $finder = Finder::create()
-                ->in($appPath)
-                ->files()
-                ->name('/[A-Z].*\.php$/');
+        $enums = [];
 
-            foreach ($finder as $file) {
-                $relativePath = $file->getRelativePathname();
-                $namespace = app()->getNamespace();
-                $className = $namespace.str_replace(
-                    ['/', '.php'],
-                    ['\\', ''],
-                    $relativePath
-                );
+        $finder = Finder::create()
+            ->in($appPath)
+            ->files()
+            ->name('/[A-Z].*\.php$/');
 
-                try {
-                    $path = $appPath.DIRECTORY_SEPARATOR.$relativePath;
+        foreach ($finder as $file) {
+            $path = $appPath.DIRECTORY_SEPARATOR.$file->getRelativePathname();
+            $code = file_get_contents($path);
 
-                    if (! $this->fileHasClassLike($path)) {
-                        continue;
-                    }
+            if ($code === false) {
+                continue;
+            }
 
-                    if (class_exists($className, false)) {
-                        self::$classes[$className] = $path;
-                    }
-                } catch (Throwable) {
-                    // Ignore exceptions and errors from class loading/reflection
+            $tokens = token_get_all($code);
+
+            foreach ($tokens as $token) {
+                if (is_array($token) && $token[0] === T_ENUM) {
+                    $className = app()->getNamespace().str_replace(
+                        ['/', '.php'],
+                        ['\\', ''],
+                        $file->getRelativePathname()
+                    );
+                    $enums[$className] = $path;
+
+                    break;
                 }
             }
         }
 
-        foreach (self::$classes as $className => $path) {
-            if ($cb(new ReflectionClass($className))) {
-                $classes[$className] = $path;
-            }
-        }
-
-        return $classes;
-    }
-
-    public function fileHasClassLike(string $path): bool
-    {
-        static $cache = [];
-
-        if (isset($cache[$path])) {
-            return $cache[$path];
-        }
-
-        $code = file_get_contents($path);
-
-        if ($code === false) {
-            return $cache[$path] = false;
-        }
-
-        $containsClassKeyword = stripos($code, 'class') !== false
-            || stripos($code, 'interface') !== false
-            || stripos($code, 'trait') !== false
-            || stripos($code, 'enum') !== false;
-
-        if (! $containsClassKeyword) {
-            return $cache[$path] = false;
-        }
-
-        $tokens = token_get_all($code);
-
-        foreach ($tokens as $token) {
-            if (is_array($token) && in_array($token[0], [T_CLASS, T_INTERFACE, T_TRAIT, T_ENUM], true)) {
-                return $cache[$path] = true;
-            }
-        }
-
-        return $cache[$path] = false;
-    }
-
-    public function shouldEnforceStrictTypes(): bool
-    {
-        if ($this->modelPaths === []) {
-            return false;
-        }
-
-        $path = current($this->modelPaths);
-
-        if (! is_file($path)) {
-            return false;
-        }
-
-        $code = file_get_contents($path);
-
-        return $code !== false && str_contains($code, 'strict_types=1');
+        return $enums;
     }
 
     public function enumContents(): string

--- a/src/Install/GuidelineAssist.php
+++ b/src/Install/GuidelineAssist.php
@@ -54,9 +54,11 @@ class GuidelineAssist
         foreach ($finder as $file) {
             $path = $file->getRealPath();
             $code = file_get_contents($path);
+
             if ($code === false) {
                 continue;
             }
+
             if (stripos($code, 'enum') === false) {
                 continue;
             }

--- a/src/Install/GuidelineAssist.php
+++ b/src/Install/GuidelineAssist.php
@@ -54,8 +54,10 @@ class GuidelineAssist
         foreach ($finder as $file) {
             $path = $file->getRealPath();
             $code = file_get_contents($path);
-
-            if ($code === false || stripos($code, 'enum') === false) {
+            if ($code === false) {
+                continue;
+            }
+            if (stripos($code, 'enum') === false) {
                 continue;
             }
 

--- a/src/Mcp/Resources/ApplicationInfo.php
+++ b/src/Mcp/Resources/ApplicationInfo.php
@@ -19,7 +19,7 @@ class ApplicationInfo extends Resource
     /**
      * The resource's description.
      */
-    protected string $description = 'Comprehensive application information including PHP version, Laravel version, database engine, all installed packages with their versions, and all Eloquent models in the application.';
+    protected string $description = 'Comprehensive application information including PHP version, Laravel version, database engine, all installed packages with their versions in the application.';
 
     /**
      * The resource's URI.

--- a/src/Mcp/Tools/ApplicationInfo.php
+++ b/src/Mcp/Tools/ApplicationInfo.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Mcp\Tools;
 
-use Laravel\Boost\Install\GuidelineAssist;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;
@@ -15,7 +14,7 @@ use Laravel\Roster\Roster;
 #[IsReadOnly]
 class ApplicationInfo extends Tool
 {
-    public function __construct(protected Roster $roster, protected GuidelineAssist $guidelineAssist)
+    public function __construct(protected Roster $roster)
     {
         //
     }
@@ -23,7 +22,7 @@ class ApplicationInfo extends Tool
     /**
      * The tool's description.
      */
-    protected string $description = 'Get comprehensive application information including PHP version, Laravel version, database engine, all installed packages with their versions, and all Eloquent models in the application. You should use this tool on each new chat, and use the package & version data to write version specific code for the packages that exist.';
+    protected string $description = 'Get comprehensive application information including PHP version, Laravel version, database engine, and all installed packages with their versions. You should use this tool on each new chat, and use the package & version data to write version specific code for the packages that exist.';
 
     /**
      * Handle the tool request.
@@ -35,7 +34,6 @@ class ApplicationInfo extends Tool
             'laravel_version' => app()->version(),
             'database_engine' => config('database.default'),
             'packages' => $this->roster->packages()->map(fn (Package $package): array => ['roster_name' => $package->name(), 'version' => $package->version(), 'package_name' => $package->rawName()]),
-            'models' => array_keys($this->guidelineAssist->models()),
         ]);
     }
 }

--- a/tests/Feature/Mcp/Tools/ApplicationInfoTest.php
+++ b/tests/Feature/Mcp/Tools/ApplicationInfoTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Laravel\Boost\Install\GuidelineAssist;
 use Laravel\Boost\Mcp\Tools\ApplicationInfo;
 use Laravel\Mcp\Request;
 use Laravel\Roster\Enums\Packages;
@@ -19,13 +18,7 @@ test('it returns application info with packages', function (): void {
     $roster = Mockery::mock(Roster::class);
     $roster->shouldReceive('packages')->andReturn($packages);
 
-    $guidelineAssist = Mockery::mock(GuidelineAssist::class);
-    $guidelineAssist->shouldReceive('models')->andReturn([
-        'App\\Models\\User' => '/app/Models/User.php',
-        'App\\Models\\Post' => '/app/Models/Post.php',
-    ]);
-
-    $tool = new ApplicationInfo($roster, $guidelineAssist);
+    $tool = new ApplicationInfo($roster);
     $response = $tool->handle(new Request([]));
 
     expect($response)->isToolResult()
@@ -46,10 +39,6 @@ test('it returns application info with packages', function (): void {
                     'version' => '2.0.0',
                 ],
             ],
-            'models' => [
-                'App\\Models\\User',
-                'App\\Models\\Post',
-            ],
         ]);
 });
 
@@ -57,10 +46,7 @@ test('it returns application info with no packages', function (): void {
     $roster = Mockery::mock(Roster::class);
     $roster->shouldReceive('packages')->andReturn(new PackageCollection([]));
 
-    $guidelineAssist = Mockery::mock(GuidelineAssist::class);
-    $guidelineAssist->shouldReceive('models')->andReturn([]);
-
-    $tool = new ApplicationInfo($roster, $guidelineAssist);
+    $tool = new ApplicationInfo($roster);
     $response = $tool->handle(new Request([]));
 
     expect($response)->isToolResult()
@@ -70,7 +56,6 @@ test('it returns application info with no packages', function (): void {
             'laravel_version' => app()->version(),
             'database_engine' => config('database.default'),
             'packages' => [],
-            'models' => [],
         ]);
 });
 
@@ -83,15 +68,11 @@ it('returns updated package versions when roster binding changes in container', 
     $roster->shouldReceive('packages')->andReturn($initialPackages);
     $this->app->instance(Roster::class, $roster);
 
-    $guidelineAssist = Mockery::mock(GuidelineAssist::class);
-    $guidelineAssist->shouldReceive('models')->andReturn([]);
-    $this->app->instance(GuidelineAssist::class, $guidelineAssist);
-
     $tool = app(ApplicationInfo::class);
     $response = $tool->handle(new Request([]));
 
     expect($response)->toolJsonContent(function (array $data): void {
-        expect($data)->toHaveKeys(['packages', 'php_version', 'laravel_version', 'database_engine', 'models'])
+        expect($data)->toHaveKeys(['packages', 'php_version', 'laravel_version', 'database_engine'])
             ->and($data['packages'])->toHaveCount(1)
             ->sequence(
                 fn ($package) => $package->toMatchArray(['version' => '11.0.0', 'roster_name' => 'LARAVEL']),
@@ -111,34 +92,11 @@ it('returns updated package versions when roster binding changes in container', 
     $response = $tool->handle(new Request([]));
 
     expect($response)->toolJsonContent(function (array $data): void {
-        expect($data)->toHaveKeys(['packages', 'php_version', 'laravel_version', 'database_engine', 'models'])
+        expect($data)->toHaveKeys(['packages', 'php_version', 'laravel_version', 'database_engine'])
             ->and($data['packages'])->toHaveCount(2)
             ->sequence(
                 fn ($package) => $package->toMatchArray(['version' => '12.0.0', 'roster_name' => 'LARAVEL']),
                 fn ($package) => $package->toMatchArray(['package_name' => 'pestphp/pest', 'version' => '3.0.0']),
             );
-    });
-});
-
-it('extracts model class names from guideline assist paths and returns them as array', function (): void {
-    $roster = Mockery::mock(Roster::class);
-    $roster->shouldReceive('packages')->andReturn(new PackageCollection([]));
-    $this->app->instance(Roster::class, $roster);
-
-    $guidelineAssist = Mockery::mock(GuidelineAssist::class);
-    $guidelineAssist->shouldReceive('models')->andReturn([
-        'App\\Models\\User' => '/app/Models/User.php',
-        'App\\Models\\Order' => '/app/Models/Order.php',
-    ]);
-    $this->app->instance(GuidelineAssist::class, $guidelineAssist);
-
-    $tool = app(ApplicationInfo::class);
-    $response = $tool->handle(new Request([]));
-
-    expect($response)->toolJsonContent(function (array $data): void {
-        expect($data)->toHaveKey('models')
-            ->and($data['models'])->toHaveCount(2)
-            ->each->toBeString()
-            ->and($data['models'])->toBe(['App\\Models\\User', 'App\\Models\\Order']);
     });
 });

--- a/tests/Unit/Install/GuidelineAssistTest.php
+++ b/tests/Unit/Install/GuidelineAssistTest.php
@@ -144,16 +144,6 @@ test('hasSkills property can be set to true', function (): void {
     expect($config->hasSkills)->toBeTrue();
 });
 
-test('shouldEnforceStrictTypes returns false when app directory does not exist', function (): void {
-    $sentinel = ['app-path-isnt-a-directory' => sys_get_temp_dir()];
-
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
-    $assist->shouldAllowMockingProtectedMethods();
-    $assist->shouldReceive('discover')->andReturn($sentinel);
-
-    expect($assist->shouldEnforceStrictTypes())->toBeFalse();
-});
-
 test('enumContents returns empty string when app directory does not exist', function (): void {
     $sentinel = ['app-path-isnt-a-directory' => sys_get_temp_dir()];
 


### PR DESCRIPTION
The model list returned by the `ApplicationInfo` MCP tool was broken (#716) — `class_exists($className, false)` only found already-loaded classes, so most models were missing. Enabling autoloading caused crashes (Pest errors, trait redeclarations, fatal errors — see #149, #100). Rather than fixing an endless stream of edge cases, this removes model discovery entirely. Modern AI agents can find models by searching the codebase directly.

Fixes #716


> [!WARNING]
> The `ApplicationInfo` MCP tool no longer returns a `models` key. The `models()` and `shouldEnforceStrictTypes()` methods have been removed from `GuidelineAssist`.