### PR TITLE
ci: add HOL skill-publish validate workflow

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,0 +1,17 @@
+name: HOL Skill Validate
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+jobs:
+  validate-skill:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Validate skill package
+        uses: hashgraph-online/skill-publish@8f3c91d7d4cde7b104549e5f0cccdbb4cd7ee58d # v1
+        with:
+          mode: validate
+          skill-dir: .


### PR DESCRIPTION
## Add HOL skill-publish validate workflow

**laravel/boost** — Laravel-focused MCP server for AI development

**3384** stars

This PR adds a GitHub Actions workflow that runs the skill-publish action in validate mode.

### What it does

- Validates skill.json and SKILL.md against registry schema
- Checks trust signals (repo integrity, manifest integrity, domain proof)
- Scans for malicious scripts with safety score
- Shows on-chain cost estimate before publishing

### After merge

The workflow runs on push to main/master and pull requests. Results show schema validity, trust signals, and safety score.

To publish to the registry later, you will need an RB_API_KEY and credits.