### PR TITLE
feat: add skills lock management and commands for updating/removing skills

### DIFF
--- a/src/BoostServiceProvider.php
+++ b/src/BoostServiceProvider.php
@@ -80,8 +80,10 @@ class BoostServiceProvider extends ServiceProvider
                 Console\StartCommand::class,
                 Console\InstallCommand::class,
                 Console\UpdateCommand::class,
+                Console\UpdateSkillsCommand::class,
                 Console\ExecuteToolCommand::class,
                 Console\AddSkillCommand::class,
+                Console\RemoveSkillCommand::class,
             ]);
         }
     }

--- a/src/Console/AddSkillCommand.php
+++ b/src/Console/AddSkillCommand.php
@@ -14,8 +14,10 @@ use Laravel\Boost\Concerns\DisplayHelper;
 use Laravel\Boost\Skills\Remote\AuditResult;
 use Laravel\Boost\Skills\Remote\GitHubRepository;
 use Laravel\Boost\Skills\Remote\GitHubSkillProvider;
+use Laravel\Boost\Skills\Remote\InstalledSkill;
 use Laravel\Boost\Skills\Remote\RemoteSkill;
 use Laravel\Boost\Skills\Remote\SkillAuditor;
+use Laravel\Boost\Support\SkillsLock;
 use Laravel\Prompts\Terminal;
 use RuntimeException;
 
@@ -181,6 +183,7 @@ class AddSkillCommand extends Command
 
             grid($results['installedNames']);
 
+            $this->writeSkillsLock($skillsToInstall);
             $this->runBoostUpdate();
             $this->showOutro();
         }
@@ -400,6 +403,24 @@ class AddSkillCommand extends Command
     protected function runBoostUpdate(): void
     {
         $this->callSilently(UpdateCommand::class);
+    }
+
+    protected function writeSkillsLock(Collection $skills): void
+    {
+        $lock = new SkillsLock;
+
+        foreach ($skills as $skill) {
+            $hash = $this->fetcher->getSkillHash($skill);
+
+            if ($hash !== null) {
+                $lock->addSkill(new InstalledSkill(
+                    name: $skill->name,
+                    source: $skill->repo,
+                    sourceType: 'github',
+                    hash: $hash,
+                ));
+            }
+        }
     }
 
     protected function showOutro(): void

--- a/src/Console/RemoveSkillCommand.php
+++ b/src/Console/RemoveSkillCommand.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Console;
+
+use const DIRECTORY_SEPARATOR;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Laravel\Boost\Concerns\DisplayHelper;
+use Laravel\Boost\Skills\Remote\InstalledSkill;
+use Laravel\Boost\Support\SkillsLock;
+use Laravel\Prompts\Terminal;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\grid;
+use function Laravel\Prompts\multiselect;
+
+class RemoveSkillCommand extends Command
+{
+    use DisplayHelper;
+
+    protected $signature = 'boost:remove-skill';
+
+    protected $description = 'Remove installed skills';
+
+    protected string $defaultSkillsPath = '.ai/skills';
+
+    public function __construct(private readonly Terminal $terminal)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $this->displayHeader();
+
+        $lock = new SkillsLock;
+
+        if (! $lock->isValid()) {
+            $this->error('No skills lock file found.');
+
+            return self::FAILURE;
+        }
+
+        $installedSkills = $lock->getSkills();
+
+        if ($installedSkills === []) {
+            $this->warn('No skills found in lock file.');
+
+            return self::SUCCESS;
+        }
+
+        $selectedSkills = $this->selectSkills($installedSkills);
+
+        if ($selectedSkills === []) {
+            $this->info('No skills selected.');
+
+            return self::SUCCESS;
+        }
+
+        if (stream_isatty(STDIN) && ! confirm(label: 'Remove '.count($selectedSkills).' skill(s)?')) {
+            return self::SUCCESS;
+        }
+
+        $removedSkills = $this->removeSkills($lock, $selectedSkills);
+
+        $this->info('Skills removed:');
+        grid($removedSkills);
+
+        $this->info('Skill removal completed.');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param  array<string, InstalledSkill>  $installedSkills
+     * @return array<int, string>
+     */
+    protected function selectSkills(array $installedSkills): array
+    {
+        $options = [];
+
+        foreach ($installedSkills as $name => $skill) {
+            $options[$name] = sprintf('%s (%s)', $name, $skill->source);
+        }
+
+        /** @var array<int, string> $selected */
+        $selected = multiselect(
+            label: 'Select skills to remove',
+            options: $options,
+            scroll: 10,
+            required: false,
+            hint: 'Leave empty to cancel',
+        );
+
+        return $selected;
+    }
+
+    /**
+     * @param  array<int, string>  $selectedSkills
+     * @return array<int, string>
+     */
+    protected function removeSkills(SkillsLock $lock, array $selectedSkills): array
+    {
+        $removedSkills = [];
+
+        foreach ($selectedSkills as $skillName) {
+            $lock->removeSkill($skillName);
+
+            $path = base_path($this->defaultSkillsPath.DIRECTORY_SEPARATOR.$skillName);
+
+            if (is_dir($path)) {
+                File::deleteDirectory($path);
+            }
+
+            $removedSkills[] = $skillName;
+        }
+
+        sort($removedSkills);
+
+        return $removedSkills;
+    }
+
+    protected function displayHeader(): void
+    {
+        $this->terminal->initDimensions();
+        $this->displayBoostHeader('Skill Remove', config('app.name'));
+    }
+}

--- a/src/Console/UpdateCommand.php
+++ b/src/Console/UpdateCommand.php
@@ -18,7 +18,8 @@ class UpdateCommand extends Command
     /** @var string */
     protected $signature = 'boost:update
         {--discover : Discover and prompt for newly available guidelines and skills}
-        {--ignore-skills : Skip updating the skills directory}';
+        {--ignore-skills : Skip updating the skills directory}
+        {--update-skills : Update installed skills to latest versions}';
 
     public function handle(Config $config): int
     {
@@ -26,6 +27,10 @@ class UpdateCommand extends Command
             $this->error('Please set up Boost with [php artisan boost:install] first.');
 
             return self::FAILURE;
+        }
+
+        if ($this->option('update-skills')) {
+            return $this->updateInstalledSkills();
         }
 
         if ($this->option('discover')) {
@@ -50,12 +55,16 @@ class UpdateCommand extends Command
         return self::SUCCESS;
     }
 
+    protected function updateInstalledSkills(): int
+    {
+        return $this->call(UpdateSkillsCommand::class);
+    }
+
     protected function discoverNewContent(Config $config): void
     {
         $newPackages = $this->resolveNewPackages($config);
 
         if ($newPackages->isNotEmpty()) {
-            /** @var array<int, string> $selectedPackages */
             $selectedPackages = multiselect(
                 label: 'New packages with guidelines/skills discovered! Which would you like to add?',
                 options: $newPackages

--- a/src/Console/UpdateSkillsCommand.php
+++ b/src/Console/UpdateSkillsCommand.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Console;
+
+use const DIRECTORY_SEPARATOR;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\File;
+use Laravel\Boost\Concerns\DisplayHelper;
+use Laravel\Boost\Skills\Remote\GitHubRepository;
+use Laravel\Boost\Skills\Remote\GitHubSkillProvider;
+use Laravel\Boost\Skills\Remote\InstalledSkill;
+use Laravel\Boost\Skills\Remote\RemoteSkill;
+use Laravel\Boost\Support\SkillsLock;
+use Laravel\Prompts\Terminal;
+use RuntimeException;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\grid;
+use function Laravel\Prompts\spin;
+
+class UpdateSkillsCommand extends Command
+{
+    use DisplayHelper;
+
+    protected $signature = 'boost:update-skills
+        {--force : Update skills without confirmation}
+        {--sync : Force sync all skills from GitHub (overwrites local changes)}';
+
+    protected $description = 'Update installed skills to their latest versions from GitHub';
+
+    protected string $defaultSkillsPath = '.ai/skills';
+
+    public function __construct(private readonly Terminal $terminal)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $this->displayHeader();
+
+        $lock = new SkillsLock;
+
+        if (! $lock->isValid()) {
+            $this->error('No skills lock file found. Please install skills first using boost:add-skill.');
+
+            return self::FAILURE;
+        }
+
+        $installedSkills = $lock->getSkills();
+
+        if ($installedSkills === []) {
+            $this->warn('No skills found in lock file.');
+
+            return self::SUCCESS;
+        }
+
+        return $this->updateSkills($installedSkills);
+    }
+
+    /**
+     * @param  array<string, InstalledSkill>  $installedSkills
+     */
+    protected function updateSkills(array $installedSkills): int
+    {
+        $isSync = $this->isSyncMode();
+        $skillsToUpdate = $this->findOutdatedSkills($installedSkills);
+        $skillCount = $skillsToUpdate->count();
+
+        if ($skillsToUpdate->isEmpty()) {
+            $this->info($isSync ? 'All skills are already in sync.' : 'All skills are up to date.');
+
+            return self::SUCCESS;
+        }
+
+        if ($isSync) {
+            $this->info("Found {$skillCount} skill(s) to sync from GitHub (--sync):");
+        } else {
+            $this->info("Found {$skillCount} skill(s) to update:");
+        }
+
+        grid($skillsToUpdate->keys()->values()->toArray());
+
+        if (! $this->option('force') && stream_isatty(STDIN)) {
+            $label = $isSync
+                ? "Sync {$skillCount} skill(s) from GitHub?"
+                : "Update {$skillCount} skill(s)?";
+
+            if (! confirm(label: $label)) {
+                return self::SUCCESS;
+            }
+        }
+
+        $results = $this->downloadUpdatedSkills($skillsToUpdate);
+
+        $this->displayUpdateResults($results);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param  array<string, InstalledSkill>  $installedSkills
+     * @return Collection<string, array{installed: InstalledSkill, remote: RemoteSkill}>
+     */
+    protected function findOutdatedSkills(array $installedSkills): Collection
+    {
+        $message = $this->isSyncMode()
+            ? 'Checking skills to sync...'
+            : 'Checking for updates...';
+
+        return spin(
+            callback: function () use ($installedSkills): Collection {
+                $result = collect($installedSkills)
+                    ->filter(fn (InstalledSkill $skill): bool => $skill->sourceType === 'github')
+                    ->map(fn (InstalledSkill $skill): ?array => $this->checkSkillUpdate($skill))
+                    ->filter(fn (?array $item): bool => $item !== null);
+
+                return $result->keyBy(fn (array $data): string => $data['installed']->name);
+            },
+            message: $message
+        );
+    }
+
+    /**
+     * @return array{installed: InstalledSkill, remote: RemoteSkill}|null
+     */
+    protected function checkSkillUpdate(InstalledSkill $installed): ?array
+    {
+        try {
+            $fetcher = $this->fetcherForInstalledSkill($installed);
+            $availableSkills = $fetcher->discoverSkills();
+
+            $remoteSkill = $availableSkills->get($installed->name);
+
+            if ($remoteSkill === null) {
+                return null;
+            }
+
+            $remoteHash = $fetcher->getSkillHash($remoteSkill);
+
+            if ($remoteHash !== null && $remoteHash === $installed->hash) {
+                if (! $this->isSyncMode()) {
+                    return null;
+                }
+
+                if (! $fetcher->hasLocalChanges($remoteSkill, $this->skillTargetPath($remoteSkill))) {
+                    return null;
+                }
+            }
+
+            return ['installed' => $installed, 'remote' => $remoteSkill];
+        } catch (RuntimeException) {
+            return null;
+        }
+    }
+
+    /**
+     * @param  Collection<string, array{installed: InstalledSkill, remote: RemoteSkill}>  $skillsToUpdate
+     * @return array{updated: array<int, string>, failed: array<string, string>}
+     */
+    protected function downloadUpdatedSkills(Collection $skillsToUpdate): array
+    {
+        $message = $this->isSyncMode()
+            ? 'Syncing skills...'
+            : 'Updating skills...';
+
+        return spin(
+            callback: fn (): array => $this->performUpdate($skillsToUpdate),
+            message: $message
+        );
+    }
+
+    /**
+     * @param  Collection<string, array{installed: InstalledSkill, remote: RemoteSkill}>  $skillsToUpdate
+     * @return array{updated: array<int, string>, failed: array<string, string>}
+     */
+    protected function performUpdate(Collection $skillsToUpdate): array
+    {
+        $action = $this->isSyncMode() ? 'Syncing' : 'Updating';
+        $results = ['updated' => [], 'failed' => []];
+        $lock = new SkillsLock;
+
+        foreach ($skillsToUpdate as $data) {
+            $installed = $data['installed'];
+            $remoteSkill = $data['remote'];
+
+            try {
+                $fetcher = $this->fetcherForInstalledSkill($installed);
+                $targetPath = $this->skillTargetPath($remoteSkill);
+
+                $this->line("  {$action} {$remoteSkill->name} from {$installed->source}...");
+
+                if (is_dir($targetPath)) {
+                    File::deleteDirectory($targetPath);
+                }
+
+                $downloadResult = $fetcher->downloadSkill($remoteSkill, $targetPath);
+
+                if ($downloadResult) {
+                    $results['updated'][] = $remoteSkill->name;
+
+                    $newHash = $fetcher->getSkillHash($remoteSkill);
+
+                    if ($newHash !== null) {
+                        $lock->addSkill(new InstalledSkill(
+                            name: $remoteSkill->name,
+                            source: $installed->source,
+                            sourceType: $installed->sourceType,
+                            hash: $newHash,
+                        ));
+                    }
+                } else {
+                    $results['failed'][$remoteSkill->name] = 'Download failed';
+                }
+            } catch (RuntimeException $e) {
+                $results['failed'][$remoteSkill->name] = $e->getMessage();
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * @param  array{updated: array<int, string>, failed: array<string, string>}  $results
+     */
+    protected function displayUpdateResults(array $results): void
+    {
+        $isSync = $this->isSyncMode();
+
+        if ($results['updated'] !== []) {
+            $this->info($isSync ? 'Skills synced:' : 'Skills updated:');
+
+            grid($results['updated']);
+        }
+
+        if ($results['failed'] !== []) {
+            $this->error($isSync ? 'Some skills failed to sync:' : 'Some skills failed to update:');
+
+            grid(array_keys($results['failed']));
+        }
+
+        $this->info($isSync ? 'Skills sync completed.' : 'Skills update completed.');
+    }
+
+    protected function isSyncMode(): bool
+    {
+        return (bool) $this->option('sync');
+    }
+
+    protected function fetcherForInstalledSkill(InstalledSkill $installed): GitHubSkillProvider
+    {
+        return new GitHubSkillProvider(GitHubRepository::fromInput($installed->source));
+    }
+
+    protected function skillTargetPath(RemoteSkill $skill): string
+    {
+        return base_path($this->defaultSkillsPath.DIRECTORY_SEPARATOR.$skill->name);
+    }
+
+    protected function displayHeader(): void
+    {
+        $this->terminal->initDimensions();
+        $this->displayBoostHeader('Skills Update', config('app.name'));
+    }
+}

--- a/src/Skills/Remote/GitHubSkillProvider.php
+++ b/src/Skills/Remote/GitHubSkillProvider.php
@@ -7,6 +7,7 @@ namespace Laravel\Boost\Skills\Remote;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Pool;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use RuntimeException;
@@ -273,5 +274,72 @@ class GitHubSkillProvider
     protected function getGitHubToken(): ?string
     {
         return config('boost.github.token') ?? config('services.github.token');
+    }
+
+    public function getSkillHash(RemoteSkill $skill): ?string
+    {
+        $tree = $this->fetchRepositoryTree();
+
+        if ($tree === null) {
+            return null;
+        }
+
+        $skillItem = collect($tree['tree'])
+            ->first(fn (array $item): bool => $item['path'] === $skill->path && $item['type'] === 'tree');
+
+        return is_array($skillItem) ? ($skillItem['sha'] ?? null) : null;
+    }
+
+    public function hasLocalChanges(RemoteSkill $skill, string $targetPath): bool
+    {
+        if (! is_dir($targetPath)) {
+            return true;
+        }
+
+        $tree = $this->fetchRepositoryTree();
+
+        if ($tree === null) {
+            return true;
+        }
+
+        $remoteFiles = $this->extractSkillFilesFromTree($tree['tree'], $skill->path)
+            ->filter(fn (array $item): bool => $item['type'] === 'blob')
+            ->mapWithKeys(fn (array $item): array => [
+                $this->getRelativePath((string) $item['path'], $skill->path) => (string) ($item['sha'] ?? ''),
+            ]);
+
+        $localFiles = collect(File::allFiles($targetPath))
+            ->mapWithKeys(function ($file) use ($targetPath): array {
+                $path = (string) $file->getPathname();
+                $hash = $this->computeGitBlobHash($path);
+
+                if ($hash === null) {
+                    return [];
+                }
+
+                $relativePath = str_replace(
+                    DIRECTORY_SEPARATOR,
+                    '/',
+                    ltrim(str_replace($targetPath.DIRECTORY_SEPARATOR, '', $path), DIRECTORY_SEPARATOR)
+                );
+
+                return [$relativePath => $hash];
+            });
+
+        return $remoteFiles->count() !== $localFiles->count()
+            || $remoteFiles->contains(
+                fn (string $remoteHash, string $relativePath): bool => $remoteHash === '' || $localFiles->get($relativePath) !== $remoteHash
+            );
+    }
+
+    protected function computeGitBlobHash(string $path): ?string
+    {
+        $contents = @file_get_contents($path);
+
+        if ($contents === false) {
+            return null;
+        }
+
+        return sha1('blob '.strlen($contents)."\0".$contents);
     }
 }

--- a/src/Skills/Remote/InstalledSkill.php
+++ b/src/Skills/Remote/InstalledSkill.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Skills\Remote;
+
+class InstalledSkill
+{
+    public function __construct(
+        public string $name,
+        public string $source,
+        public string $sourceType,
+        public string $hash
+    ) {
+        //
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(string $name, array $data): self
+    {
+        return new self(
+            name: $name,
+            source: $data['source'] ?? '',
+            sourceType: $data['sourceType'] ?? 'github',
+            hash: $data['computedHash'] ?? '',
+        );
+    }
+}

--- a/src/Support/SkillsLock.php
+++ b/src/Support/SkillsLock.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Support;
+
+use Laravel\Boost\Skills\Remote\InstalledSkill;
+
+class SkillsLock
+{
+    protected const FILE = 'boost-skills-lock.json';
+
+    protected const VERSION = 1;
+
+    /**
+     * @return array<string, InstalledSkill>
+     */
+    public function getSkills(): array
+    {
+        $lock = $this->all();
+
+        if (! isset($lock['repositories']) || ! is_array($lock['repositories'])) {
+            return [];
+        }
+
+        $skills = [];
+
+        foreach ($lock['repositories'] as $source => $repository) {
+            if (! is_string($source) || ! is_array($repository)) {
+                continue;
+            }
+
+            if (! isset($repository['sourceType']) || ! is_string($repository['sourceType'])) {
+                continue;
+            }
+
+            $sourceType = $repository['sourceType'];
+
+            $repositorySkills = $repository['skills'] ?? [];
+
+            if (! is_array($repositorySkills)) {
+                continue;
+            }
+
+            foreach ($repositorySkills as $name => $data) {
+                if (! is_string($name) || ! is_array($data)) {
+                    continue;
+                }
+
+                if (! isset($data['computedHash']) || ! is_string($data['computedHash'])) {
+                    continue;
+                }
+
+                $skills[$name] = InstalledSkill::fromArray($name, [
+                    'source' => $source,
+                    'sourceType' => $sourceType,
+                    'computedHash' => $data['computedHash'],
+                ]);
+            }
+        }
+
+        ksort($skills);
+
+        return $skills;
+    }
+
+    public function addSkill(InstalledSkill $skill): void
+    {
+        $lock = $this->all();
+
+        $lock['version'] = self::VERSION;
+
+        if (! isset($lock['repositories']) || ! is_array($lock['repositories'])) {
+            $lock['repositories'] = [];
+        }
+
+        if (! isset($lock['repositories'][$skill->source]) || ! is_array($lock['repositories'][$skill->source])) {
+            $lock['repositories'][$skill->source] = [
+                'sourceType' => $skill->sourceType,
+                'skills' => [],
+            ];
+        }
+
+        $lock['repositories'][$skill->source]['sourceType'] = $skill->sourceType;
+
+        $repositorySkills = $lock['repositories'][$skill->source]['skills'] ?? [];
+
+        if (! is_array($repositorySkills)) {
+            $repositorySkills = [];
+        }
+
+        $repositorySkills[$skill->name] = ['computedHash' => $skill->hash];
+        ksort($repositorySkills);
+
+        $lock['repositories'][$skill->source]['skills'] = $repositorySkills;
+
+        $repositories = $lock['repositories'];
+        ksort($repositories);
+        $lock['repositories'] = $repositories;
+
+        $this->write($lock);
+    }
+
+    public function removeSkill(string $name): void
+    {
+        $lock = $this->all();
+
+        if (! isset($lock['repositories']) || ! is_array($lock['repositories'])) {
+            return;
+        }
+
+        $repositories = $lock['repositories'];
+
+        foreach ($repositories as $source => $repository) {
+            if (! is_array($repository)) {
+                unset($repositories[$source]);
+
+                continue;
+            }
+
+            $repositorySkills = $repository['skills'] ?? [];
+
+            if (! is_array($repositorySkills)) {
+                $repositorySkills = [];
+            }
+
+            unset($repositorySkills[$name]);
+
+            if ($repositorySkills === []) {
+                unset($repositories[$source]);
+
+                continue;
+            }
+
+            ksort($repositorySkills);
+            $repository['skills'] = $repositorySkills;
+            $repositories[$source] = $repository;
+        }
+
+        $lock['version'] = self::VERSION;
+        ksort($repositories);
+        $lock['repositories'] = $repositories;
+
+        $this->write($lock);
+    }
+
+    public function isValid(): bool
+    {
+        $path = base_path(self::FILE);
+
+        if (! file_exists($path)) {
+            return false;
+        }
+
+        $content = file_get_contents($path);
+
+        if ($content === false) {
+            return false;
+        }
+
+        $lock = json_decode($content, true);
+
+        return json_last_error() === JSON_ERROR_NONE;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function all(): array
+    {
+        $path = base_path(self::FILE);
+
+        if (! file_exists($path)) {
+            return $this->emptyLock();
+        }
+
+        $content = file_get_contents($path);
+
+        if ($content === false) {
+            return $this->emptyLock();
+        }
+
+        $lock = json_decode($content, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE || ! is_array($lock)) {
+            return $this->emptyLock();
+        }
+
+        return $this->normalize($lock);
+    }
+
+    /**
+     * @param  array<string, mixed>  $lock
+     */
+    protected function write(array $lock): void
+    {
+        $path = base_path(self::FILE);
+
+        $json = json_encode($this->normalize($lock), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+
+        if ($json === false) {
+            $json = '{}';
+        }
+
+        file_put_contents(
+            $path,
+            $json.PHP_EOL
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $lock
+     * @return array{version: int, repositories: array<string, array{sourceType: string, skills: array<string, array{computedHash: string}>}>}
+     */
+    protected function normalize(array $lock): array
+    {
+        $repositories = $lock['repositories'] ?? null;
+
+        if (! is_array($repositories)) {
+            return $this->emptyLock();
+        }
+
+        return [
+            'version' => self::VERSION,
+            'repositories' => $this->normalizeRepositories($repositories),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $repositories
+     * @return array<string, array{sourceType: string, skills: array<string, array{computedHash: string}>}>
+     */
+    protected function normalizeRepositories(array $repositories): array
+    {
+        $normalized = [];
+
+        foreach ($repositories as $source => $repository) {
+            if (! is_array($repository)) {
+                continue;
+            }
+
+            if (! isset($repository['sourceType']) || ! is_string($repository['sourceType'])) {
+                continue;
+            }
+
+            $sourceType = $repository['sourceType'];
+
+            $repositorySkills = $repository['skills'] ?? [];
+
+            if (! is_array($repositorySkills)) {
+                continue;
+            }
+
+            $skills = [];
+
+            foreach ($repositorySkills as $name => $skill) {
+                if (! is_string($name)) {
+                    continue;
+                }
+
+                if (! is_array($skill) || ! isset($skill['computedHash']) || ! is_string($skill['computedHash'])) {
+                    continue;
+                }
+
+                $skills[$name] = ['computedHash' => $skill['computedHash']];
+            }
+
+            if ($skills === []) {
+                continue;
+            }
+
+            ksort($skills);
+
+            $normalized[$source] = [
+                'sourceType' => $sourceType,
+                'skills' => $skills,
+            ];
+        }
+
+        ksort($normalized);
+
+        return $normalized;
+    }
+
+    /**
+     * @return array{version: int, repositories: array<string, array{sourceType: string, skills: array<string, array{computedHash: string}>}>}
+     */
+    protected function emptyLock(): array
+    {
+        return [
+            'version' => self::VERSION,
+            'repositories' => [],
+        ];
+    }
+}

--- a/tests/Feature/Console/UpdateCommandTest.php
+++ b/tests/Feature/Console/UpdateCommandTest.php
@@ -75,6 +75,7 @@ it('calls install command with a guidelines flag when guidelines are enabled', f
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('update-skills')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
@@ -102,6 +103,7 @@ it('calls install command with skills flag when skills are configured', function
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('update-skills')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
@@ -129,6 +131,7 @@ it('calls install command with both flags when guidelines and skills are enabled
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('update-skills')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
@@ -156,6 +159,7 @@ it('does not pass mcp flag to install command even when mcp is configured', func
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('update-skills')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
@@ -183,6 +187,7 @@ it('preserves sail configuration when updating guidelines', function (): void {
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('update-skills')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
@@ -211,6 +216,7 @@ it('preserves non-sail configuration when updating guidelines', function (): voi
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('update-skills')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
@@ -239,6 +245,7 @@ it('preserves sail configuration when updating skills', function (): void {
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('update-skills')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
@@ -268,6 +275,7 @@ it('calls install command with skills flag when .ai/skills directory exists but 
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('update-skills')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
@@ -308,6 +316,7 @@ it('does not run discovery when --discover flag is not set', function (): void {
         ->shouldAllowMockingProtectedMethods();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('update-skills')->andReturn(false);
     $command->shouldNotReceive('discoverNewContent');
     $command->shouldReceive('callSilently')
         ->once()
@@ -338,6 +347,7 @@ it('does not change config when no new packages are found with --discover', func
         ->shouldAllowMockingProtectedMethods();
     $command->shouldReceive('option')->with('discover')->andReturn(true);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('update-skills')->andReturn(false);
     $command->shouldReceive('resolveNewPackages')->andReturn(collect());
     $command->shouldReceive('callSilently')->once()->andReturn(0);
     $command->setLaravel($this->app);
@@ -366,6 +376,7 @@ it('adds selected new packages to config when using --discover', function (): vo
         ->shouldAllowMockingProtectedMethods();
     $command->shouldReceive('option')->with('discover')->andReturn(true);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('update-skills')->andReturn(false);
     $command->shouldReceive('resolveNewPackages')
         ->andReturn(collect(['vendor/awesome-pkg' => $newPackage]));
     $command->shouldReceive('callSilently')->andReturn(0);
@@ -388,6 +399,7 @@ it('skips skills when --ignore-skills flag is set even if skills are configured'
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(true);
+    $command->shouldReceive('option')->with('update-skills')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
@@ -416,6 +428,7 @@ it('skips skills when --ignore-skills flag is set even if .ai/skills directory e
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(true);
+    $command->shouldReceive('option')->with('update-skills')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [

--- a/tests/Unit/Skills/Remote/GitHubSkillProviderTest.php
+++ b/tests/Unit/Skills/Remote/GitHubSkillProviderTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 use Laravel\Boost\Skills\Remote\GitHubRepository;
 use Laravel\Boost\Skills\Remote\GitHubSkillProvider;
@@ -27,6 +28,11 @@ function fakeTreeResponse(array $tree, string $branch = 'main'): array
             'truncated' => false,
         ]),
     ];
+}
+
+function fakeBlobHash(string $contents): string
+{
+    return sha1('blob '.strlen($contents)."\0".$contents);
 }
 
 it('discovers skills from repository directories', function (): void {
@@ -461,4 +467,65 @@ it('discovers skills in wildcard paths like .ai/*/skills', function (): void {
     expect($skills)->toHaveCount(1)
         ->and($skills->has('my-skill'))->toBeTrue()
         ->and($skills->get('my-skill')->path)->toBe('.ai/claude/skills/my-skill');
+});
+
+it('returns false for hasLocalChanges when local skill files match remote blobs', function (): void {
+    $targetDir = sys_get_temp_dir().'/boost-test-'.uniqid();
+    $skillContent = "# SKILL Content\n";
+    $exampleContent = "# Example Content\n";
+
+    File::ensureDirectoryExists($targetDir.'/examples');
+    file_put_contents($targetDir.'/SKILL.md', $skillContent);
+    file_put_contents($targetDir.'/examples/example.md', $exampleContent);
+
+    Http::fake([
+        ...fakeGitHubRepo(),
+        ...fakeTreeResponse([
+            ['path' => 'skill-one', 'type' => 'tree', 'sha' => 'tree-sha'],
+            ['path' => 'skill-one/SKILL.md', 'type' => 'blob', 'sha' => fakeBlobHash($skillContent), 'size' => strlen($skillContent)],
+            ['path' => 'skill-one/examples', 'type' => 'tree', 'sha' => 'examples-sha'],
+            ['path' => 'skill-one/examples/example.md', 'type' => 'blob', 'sha' => fakeBlobHash($exampleContent), 'size' => strlen($exampleContent)],
+        ]),
+    ]);
+
+    $skill = new RemoteSkill(
+        name: 'skill-one',
+        repo: 'owner/repo',
+        path: 'skill-one'
+    );
+
+    $fetcher = new GitHubSkillProvider(new GitHubRepository('owner', 'repo'));
+
+    expect($fetcher->hasLocalChanges($skill, $targetDir))->toBeFalse();
+
+    File::deleteDirectory($targetDir);
+});
+
+it('returns true for hasLocalChanges when local skill files differ from remote blobs', function (): void {
+    $targetDir = sys_get_temp_dir().'/boost-test-'.uniqid();
+    $remoteSkillContent = "# SKILL Content\n";
+    $localSkillContent = "# Modified SKILL Content\n";
+
+    File::ensureDirectoryExists($targetDir);
+    file_put_contents($targetDir.'/SKILL.md', $localSkillContent);
+
+    Http::fake([
+        ...fakeGitHubRepo(),
+        ...fakeTreeResponse([
+            ['path' => 'skill-one', 'type' => 'tree', 'sha' => 'tree-sha'],
+            ['path' => 'skill-one/SKILL.md', 'type' => 'blob', 'sha' => fakeBlobHash($remoteSkillContent), 'size' => strlen($remoteSkillContent)],
+        ]),
+    ]);
+
+    $skill = new RemoteSkill(
+        name: 'skill-one',
+        repo: 'owner/repo',
+        path: 'skill-one'
+    );
+
+    $fetcher = new GitHubSkillProvider(new GitHubRepository('owner', 'repo'));
+
+    expect($fetcher->hasLocalChanges($skill, $targetDir))->toBeTrue();
+
+    File::deleteDirectory($targetDir);
 });


### PR DESCRIPTION
Issue: #701

This PR introduces a skills lock and update system, inspired by Vercel's Skills CLI. When you install skills using boost:add-skill, the system now tracks each skill's source, version, and hash in a `boost-skills-lock.json` file in the root folder, enabling you to update installed skills when new versions are available on GitHub.

### Usage

Skills Lock File (boost-skills-lock.json) - Tracks installed skills with:
- Install skills: `php artisan boost:add-skill`
- Update installed skills: `php artisan boost:update-skills`
- Re-sync local drifted skill files: `php artisan boost:update-skills --sync`
- Trigger skills update through boost:update: `php artisan boost:update --update-skills`
- Remove skills interactively: `php artisan boost:remove-skill`

Note: you can also use `--force` 

boost-skills-lock.json file:
```
{
    "version": 1,
    "repositories": {
        "SagorIslamOfficial/agent-skills": {
            "sourceType": "github",
            "skills": {
                "composition-patterns": {
                    "computedHash": "bf90d0a4b83ea054653350f9c67f6de235d3a368"
                },
                "deploy-to-vercel": {
                    "computedHash": "aa82a6f7819a2a7691a39be2a968aab0d6e344e0"
                }
            }
        },
        "anthropics/skills": {
            "sourceType": "github",
            "skills": {
                "brand-guidelines": {
                    "computedHash": "7dc45f289fa37f9763a993008d9500e9a157fa4a"
                },
                "claude-api": {
                    "computedHash": "5a67769c8d12b9eb00c840ccc9e74a37d9d2a3c9"
                }
            }
        }
    }
}

```

Note: I tested all newly added features and found no breaking changes after the implementation.