### PR TITLE
feat(agents): add Kiro IDE agent support

### DIFF
--- a/src/BoostManager.php
+++ b/src/BoostManager.php
@@ -13,6 +13,7 @@ use Laravel\Boost\Install\Agents\Copilot;
 use Laravel\Boost\Install\Agents\Cursor;
 use Laravel\Boost\Install\Agents\Gemini;
 use Laravel\Boost\Install\Agents\Junie;
+use Laravel\Boost\Install\Agents\Kiro;
 use Laravel\Boost\Install\Agents\OpenCode;
 
 class BoostManager
@@ -25,6 +26,7 @@ class BoostManager
         'claude_code' => ClaudeCode::class,
         'codex' => Codex::class,
         'copilot' => Copilot::class,
+        'kiro' => Kiro::class,
         'opencode' => OpenCode::class,
         'gemini' => Gemini::class,
     ];

--- a/src/Install/Agents/Kiro.php
+++ b/src/Install/Agents/Kiro.php
@@ -50,9 +50,11 @@ class Kiro extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSki
         ];
     }
 
-    public function frontmatter(): bool
+    public function httpMcpServerConfig(string $url): array
     {
-        return true;
+        return [
+            'url' => $url,
+        ];
     }
 
     public function mcpConfigPath(): string
@@ -62,7 +64,7 @@ class Kiro extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSki
 
     public function guidelinesPath(): string
     {
-        return config('boost.agents.kiro.guidelines_path', '.kiro/steering/boost.md');
+        return config('boost.agents.kiro.guidelines_path', 'AGENTS.md');
     }
 
     public function skillsPath(): string

--- a/src/Install/Agents/Kiro.php
+++ b/src/Install/Agents/Kiro.php
@@ -50,6 +50,11 @@ class Kiro extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSki
         ];
     }
 
+    public function frontmatter(): bool
+    {
+        return true;
+    }
+
     public function mcpConfigPath(): string
     {
         return config('boost.agents.kiro.mcp_config_path', '.kiro/settings/mcp.json');

--- a/src/Install/Agents/Kiro.php
+++ b/src/Install/Agents/Kiro.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install\Agents;
+
+use Laravel\Boost\Contracts\SupportsGuidelines;
+use Laravel\Boost\Contracts\SupportsMcp;
+use Laravel\Boost\Contracts\SupportsSkills;
+use Laravel\Boost\Install\Enums\Platform;
+
+class Kiro extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSkills
+{
+    public function name(): string
+    {
+        return 'kiro';
+    }
+
+    public function displayName(): string
+    {
+        return 'Kiro';
+    }
+
+    public function systemDetectionConfig(Platform $platform): array
+    {
+        return match ($platform) {
+            Platform::Darwin => [
+                'paths' => ['/Applications/Kiro.app'],
+            ],
+            Platform::Linux => [
+                'paths' => [
+                    '/opt/kiro',
+                    '/usr/local/bin/kiro',
+                    '~/.local/bin/kiro',
+                ],
+            ],
+            Platform::Windows => [
+                'paths' => [
+                    '%ProgramFiles%\\Kiro',
+                    '%LOCALAPPDATA%\\Programs\\Kiro',
+                ],
+            ],
+        };
+    }
+
+    public function projectDetectionConfig(): array
+    {
+        return [
+            'paths' => ['.kiro'],
+        ];
+    }
+
+    public function mcpConfigPath(): string
+    {
+        return config('boost.agents.kiro.mcp_config_path', '.kiro/settings/mcp.json');
+    }
+
+    public function guidelinesPath(): string
+    {
+        return config('boost.agents.kiro.guidelines_path', '.kiro/steering/boost.md');
+    }
+
+    public function skillsPath(): string
+    {
+        return config('boost.agents.kiro.skills_path', '.kiro/skills');
+    }
+}

--- a/tests/Unit/Install/Agents/KiroTest.php
+++ b/tests/Unit/Install/Agents/KiroTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Install\Agents;
+
+use Laravel\Boost\Install\Agents\Kiro;
+use Laravel\Boost\Install\Detection\DetectionStrategyFactory;
+use Mockery;
+
+beforeEach(function (): void {
+    $this->strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
+});
+
+test('guidelinesPath returns .kiro/steering/boost.md by default', function (): void {
+    $agent = new Kiro($this->strategyFactory);
+
+    expect($agent->guidelinesPath())->toBe('.kiro/steering/boost.md');
+});
+
+test('skillsPath returns .kiro/skills by default', function (): void {
+    $agent = new Kiro($this->strategyFactory);
+
+    expect($agent->skillsPath())->toBe('.kiro/skills');
+});
+
+test('mcpConfigPath returns .kiro/settings/mcp.json by default', function (): void {
+    $agent = new Kiro($this->strategyFactory);
+
+    expect($agent->mcpConfigPath())->toBe('.kiro/settings/mcp.json');
+});
+
+test('projectDetectionConfig detects via .kiro directory', function (): void {
+    $agent = new Kiro($this->strategyFactory);
+
+    expect($agent->projectDetectionConfig())->toBe([
+        'paths' => ['.kiro'],
+    ]);
+});

--- a/tests/Unit/Install/Agents/KiroTest.php
+++ b/tests/Unit/Install/Agents/KiroTest.php
@@ -12,10 +12,10 @@ beforeEach(function (): void {
     $this->strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
 });
 
-test('guidelinesPath returns .kiro/steering/boost.md by default', function (): void {
+test('guidelinesPath returns AGENTS.md by default', function (): void {
     $agent = new Kiro($this->strategyFactory);
 
-    expect($agent->guidelinesPath())->toBe('.kiro/steering/boost.md');
+    expect($agent->guidelinesPath())->toBe('AGENTS.md');
 });
 
 test('skillsPath returns .kiro/skills by default', function (): void {
@@ -38,8 +38,10 @@ test('projectDetectionConfig detects via .kiro directory', function (): void {
     ]);
 });
 
-test('frontmatter returns true so steering file is always applied', function (): void {
+test('httpMcpServerConfig returns url without type field', function (): void {
     $agent = new Kiro($this->strategyFactory);
 
-    expect($agent->frontmatter())->toBeTrue();
+    expect($agent->httpMcpServerConfig('https://example.com/mcp'))->toBe([
+        'url' => 'https://example.com/mcp',
+    ]);
 });

--- a/tests/Unit/Install/Agents/KiroTest.php
+++ b/tests/Unit/Install/Agents/KiroTest.php
@@ -37,3 +37,9 @@ test('projectDetectionConfig detects via .kiro directory', function (): void {
         'paths' => ['.kiro'],
     ]);
 });
+
+test('frontmatter returns true so steering file is always applied', function (): void {
+    $agent = new Kiro($this->strategyFactory);
+
+    expect($agent->frontmatter())->toBeTrue();
+});

--- a/tests/Unit/Install/AgentsDetectorTest.php
+++ b/tests/Unit/Install/AgentsDetectorTest.php
@@ -13,6 +13,7 @@ use Laravel\Boost\Install\Agents\Copilot;
 use Laravel\Boost\Install\Agents\Cursor;
 use Laravel\Boost\Install\Agents\Gemini;
 use Laravel\Boost\Install\Agents\Junie;
+use Laravel\Boost\Install\Agents\Kiro;
 use Laravel\Boost\Install\Agents\OpenCode;
 use Laravel\Boost\Install\AgentsDetector;
 use Laravel\Boost\Install\Enums\Platform;
@@ -31,9 +32,9 @@ it('returns collection of all registered agents', function (): void {
     $agents = $this->detector->getAgents();
 
     expect($agents)->toBeInstanceOf(Collection::class)
-        ->and($agents->count())->toBe(8)
+        ->and($agents->count())->toBe(9)
         ->and($agents->keys()->toArray())->toBe([
-            'amp', 'junie', 'cursor', 'claude_code', 'codex', 'copilot', 'opencode', 'gemini',
+            'amp', 'junie', 'cursor', 'claude_code', 'codex', 'copilot', 'kiro', 'opencode', 'gemini',
         ]);
 
     $agents->each(function ($agent): void {
@@ -60,6 +61,7 @@ it('returns an array of detected agents names for system discovery', function ()
     $this->container->bind(ClaudeCode::class, fn () => $mockOther);
     $this->container->bind(Codex::class, fn () => $mockOther);
     $this->container->bind(Copilot::class, fn () => $mockOther);
+    $this->container->bind(Kiro::class, fn () => $mockOther);
     $this->container->bind(OpenCode::class, fn () => $mockOther);
     $this->container->bind(Gemini::class, fn () => $mockOther);
 
@@ -80,6 +82,7 @@ it('returns an empty array when no agents are detected for system discovery', fu
     $this->container->bind(ClaudeCode::class, fn () => $mockAgent);
     $this->container->bind(Codex::class, fn () => $mockAgent);
     $this->container->bind(Copilot::class, fn () => $mockAgent);
+    $this->container->bind(Kiro::class, fn () => $mockAgent);
     $this->container->bind(OpenCode::class, fn () => $mockAgent);
     $this->container->bind(Gemini::class, fn () => $mockAgent);
 
@@ -110,6 +113,7 @@ it('returns an array of detected agent names for project discovery', function ()
     $this->container->bind(ClaudeCode::class, fn () => $mockClaudeCode);
     $this->container->bind(Codex::class, fn () => $mockOther);
     $this->container->bind(Copilot::class, fn () => $mockOther);
+    $this->container->bind(Kiro::class, fn () => $mockOther);
     $this->container->bind(OpenCode::class, fn () => $mockOther);
     $this->container->bind(Gemini::class, fn () => $mockOther);
 
@@ -132,6 +136,7 @@ it('returns an empty array when no agents are detected for project discovery', f
     $this->container->bind(ClaudeCode::class, fn () => $mockAgent);
     $this->container->bind(Codex::class, fn () => $mockAgent);
     $this->container->bind(Copilot::class, fn () => $mockAgent);
+    $this->container->bind(Kiro::class, fn () => $mockAgent);
     $this->container->bind(OpenCode::class, fn () => $mockAgent);
     $this->container->bind(Gemini::class, fn () => $mockAgent);
 


### PR DESCRIPTION
# Add Kiro IDE support

[Kiro](https://kiro.dev/) is Amazon's AI-powered IDE and is gaining traction in the dev community. This PR adds it as a supported agent alongside Cursor, Claude Code, Copilot, etc.

## Changes

- `src/Install/Agents/Kiro.php` — new agent supporting guidelines (`.kiro/steering/boost.md`), skills (`.kiro/skills/`), and MCP (`.kiro/settings/mcp.json`). Detects via `/Applications/Kiro.app` on macOS and `.kiro/` at the project root.
- `src/BoostManager.php` — registers `kiro` in the default agents map.
- `tests/Unit/Install/AgentsDetectorTest.php` — updated to account for the new agent.
