### PR TITLE
Fix model/controller/enum discovery when classes are not pre-loaded

### DIFF
--- a/src/Install/GuidelineAssist.php
+++ b/src/Install/GuidelineAssist.php
@@ -96,7 +96,7 @@ class GuidelineAssist
                         continue;
                     }
 
-                    if (class_exists($className, false)) {
+                    if (class_exists($className, true)) {
                         self::$classes[$className] = $path;
                     }
                 } catch (Throwable) {

--- a/tests/Feature/Install/GuidelineAssistDiscoverTest.php
+++ b/tests/Feature/Install/GuidelineAssistDiscoverTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use Composer\Autoload\ClassLoader;
+use Laravel\Boost\Install\GuidelineAssist;
+use Laravel\Boost\Install\GuidelineConfig;
+use Laravel\Roster\Enums\NodePackageManager;
+use Laravel\Roster\Roster;
+
+beforeEach(function (): void {
+    $this->fixtureNamespace = 'BoostFixture'.bin2hex(random_bytes(6));
+    $this->fixtureDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'boost-guideline-assist-'.bin2hex(random_bytes(6));
+    $this->fixtureClass = $this->fixtureNamespace.'\\Models\\Gadget';
+
+    mkdir($this->fixtureDir.'/Models', 0777, true);
+    file_put_contents(
+        $this->fixtureDir.'/Models/Gadget.php',
+        "<?php\n\ndeclare(strict_types=1);\n\nnamespace {$this->fixtureNamespace}\\Models;\n\nuse Illuminate\\Database\\Eloquent\\Model;\n\nclass Gadget extends Model\n{\n}\n"
+    );
+
+    $loader = null;
+
+    foreach (spl_autoload_functions() as $fn) {
+        if (is_array($fn) && $fn[0] instanceof ClassLoader) {
+            $loader = $fn[0];
+
+            break;
+        }
+    }
+
+    $loader->addPsr4($this->fixtureNamespace.'\\', $this->fixtureDir);
+
+    $classesProperty = new ReflectionProperty(GuidelineAssist::class, 'classes');
+    $classesProperty->setValue(null, []);
+
+    $namespaceProperty = new ReflectionProperty($this->app, 'namespace');
+    $namespaceProperty->setValue($this->app, $this->fixtureNamespace.'\\');
+
+    $this->app->useAppPath($this->fixtureDir);
+
+    $this->roster = Mockery::mock(Roster::class);
+    $this->roster->shouldReceive('nodePackageManager')->andReturn(NodePackageManager::NPM)->byDefault();
+    $this->roster->shouldReceive('usesVersion')->andReturn(false)->byDefault();
+});
+
+afterEach(function (): void {
+    $classesProperty = new ReflectionProperty(GuidelineAssist::class, 'classes');
+    $classesProperty->setValue(null, []);
+
+    if (is_dir($this->fixtureDir)) {
+        @unlink($this->fixtureDir.'/Models/Gadget.php');
+        @rmdir($this->fixtureDir.'/Models');
+        @rmdir($this->fixtureDir);
+    }
+});
+
+test('discover() finds models that have not been pre-loaded', function (): void {
+    expect(class_exists($this->fixtureClass, false))->toBeFalse();
+
+    $assist = new GuidelineAssist($this->roster, new GuidelineConfig);
+
+    expect($assist->models())->toHaveKey($this->fixtureClass);
+});


### PR DESCRIPTION
When Boost runs as a long-running MCP server, `application-info` returns a nearly empty list of models, controllers, and enums for most apps.
On a real Laravel 12 project with 19 models in `app/Models/`, only 1 was discovered — the one Laravel happened to touch during boot.

  ## What's going on

  `GuidelineAssist::discover()` walks `app_path()` with Symfony Finder and checks each file with `class_exists($className, false)`. The second argument disables autoloading, so PHP only "sees" classes that some earlier code path has already loaded.

  During a normal HTTP request that's usually fine — enough code runs to warm up a reasonable set of classes. But when Boost runs as a persistent MCP server, the only classes Laravel loads on boot are the handful reached by the service provider graph. Everything else in `app/Models/` stays dormant on disk and is invisible to `class_exists(..., false)`.

  ## The fix

  One character: flip the flag to `true` so the autoloader can actually resolve the class.

  This is safe because `discover()` already gates each file with `fileHasClassLike()` a few lines above. That helper confirms the file defines a class, interface, trait, or enum before `class_exists` is ever called, so we're only asking the autoloader to resolve files we've already
  verified.

  ## Test

  Added a regression test that writes a throwaway model into a temp directory, registers a runtime PSR-4 mapping with Composer's class loader, points `app_path()` at the temp dir, and asserts `GuidelineAssist::models()` discovers it. The test first confirms the fixture is **not**  already in `get_declared_classes()`, so it genuinely exercises the autoload path.

  I used a runtime temp fixture rather than a static one under `tests/Fixtures/` because `tests/ArchTest.php` runs
  `arch('tests')->expect('Tests')`, which eagerly loads every class under the `Tests\` namespace and would defeat the "not pre-loaded"
  precondition.

  Against the unpatched code the new test fails. With the fix, the full suite is green (737 passed). Pint, Rector, and PHPStan clean.