### PR TITLE
fix: call test binary directly in determineTestEnforcement()

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -159,8 +159,17 @@ class InstallCommand extends Command
             return false;
         }
 
-        $process = new Process([PHP_BINARY, 'artisan', 'test', '--list-tests'], base_path());
+        $binary = file_exists(base_path('vendor/bin/pest'))
+            ? base_path('vendor/bin/pest')
+            : base_path('vendor/bin/phpunit');
+
+        $process = new Process([PHP_BINARY, $binary, '--list-tests'], base_path());
+        $process->setTimeout(30);
         $process->run();
+
+        if (! $process->isSuccessful()) {
+            return false;
+        }
 
         return Str::of($process->getOutput())
             ->trim()

--- a/tests/Unit/Console/InstallCommandDetermineTestEnforcementTest.php
+++ b/tests/Unit/Console/InstallCommandDetermineTestEnforcementTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Console\InstallCommand;
+
+function callDetermineTestEnforcement(): bool
+{
+    $command = Mockery::mock(InstallCommand::class)
+        ->makePartial()
+        ->shouldAllowMockingProtectedMethods();
+
+    $reflect = new ReflectionClass(InstallCommand::class);
+
+    return $reflect->getMethod('determineTestEnforcement')->invoke($command);
+}
+
+test('returns config value when boost.enforce_tests is explicitly set to true', function (): void {
+    config(['boost.enforce_tests' => true]);
+
+    expect(callDetermineTestEnforcement())->toBeTrue();
+});
+
+test('returns config value when boost.enforce_tests is explicitly set to false', function (): void {
+    config(['boost.enforce_tests' => false]);
+
+    expect(callDetermineTestEnforcement())->toBeFalse();
+});
+
+test('returns false when phpunit binary is not installed', function (): void {
+    config(['boost.enforce_tests' => null]);
+
+    // The vendor/bin/phpunit check will use the actual base_path which
+    // in the test environment points to the workbench - where phpunit
+    // binary does not exist at vendor/bin/phpunit
+    expect(callDetermineTestEnforcement())->toBeFalse();
+});


### PR DESCRIPTION
Fixes #512

## Problem

`determineTestEnforcement()` runs `php artisan test --list-tests` via Symfony Process, which hangs indefinitely on projects with large test suites (16,000+ tests). The issue is specific to routing through `artisan` — calling the test binary directly works fine.

## Solution

- **Call the test binary directly** — detect whether Pest or PHPUnit is installed and invoke the binary (`vendor/bin/pest` or `vendor/bin/phpunit`) instead of going through `php artisan test`
- **Add a 30-second explicit timeout** as a safety net (Process default is 60s, but explicit is clearer)
- **Gracefully return `false`** if the process fails or times out, instead of proceeding with empty output