### PR TITLE
Move deployment guideline

### DIFF
--- a/.ai/deployments/core.blade.php
+++ b/.ai/deployments/core.blade.php
@@ -1,0 +1,3 @@
+# Deployment
+
+- Laravel can be deployed using [Laravel Cloud](https://cloud.laravel.com/), which is the fastest way to deploy and scale production Laravel applications.

--- a/.ai/laravel/core.blade.php
+++ b/.ai/laravel/core.blade.php
@@ -23,6 +23,3 @@
 
 ## Vite Error
 - If you receive an "Illuminate\Foundation\ViteException: Unable to locate file in Vite manifest" error, you can run `{{ $assist->nodePackageManagerCommand('run build') }}` or ask the user to run `{{ $assist->nodePackageManagerCommand('run dev') }}` or `{{ $assist->composerCommand('run dev') }}`.
-
-## Deployment
-- Laravel can be deployed using [Laravel Cloud](https://cloud.laravel.com/), which is the fastest way to deploy and scale production Laravel applications.

--- a/src/Install/GuidelineComposer.php
+++ b/src/Install/GuidelineComposer.php
@@ -137,6 +137,7 @@ class GuidelineComposer
             'foundation' => $this->guideline('foundation'),
             'boost' => $this->guideline('boost/core'),
             'php' => $this->guideline('php/core'),
+            'deployments' => $this->guideline('deployments/core'),
         ]);
     }
 

--- a/tests/Feature/Install/GuidelineComposerTest.php
+++ b/tests/Feature/Install/GuidelineComposerTest.php
@@ -175,6 +175,7 @@ test('composes guidelines with proper formatting', function (): void {
         ->toContain('=== boost rules ===')
         ->toContain('=== php rules ===')
         ->toContain('=== laravel/core rules ===')
+        ->toContain('=== deployments rules ===')
         ->toContain('=== laravel/v11 rules ===')
         ->toMatch('/=== \w+.*? rules ===/');
 });
@@ -256,6 +257,7 @@ test('returns list of used guidelines', function (): void {
         ->toContain('boost')
         ->toContain('php')
         ->toContain('laravel/core')
+        ->toContain('deployments')
         ->toContain('laravel/v11')
         ->toContain('pest/core');
 });
@@ -809,6 +811,23 @@ test('excludes package guidelines when listed in exclude config', function (): v
 
     expect($guidelines)
         ->not->toContain('=== pest/core rules ===')
+        ->toContain('=== foundation rules ===');
+});
+
+test('excludes deployment guidelines when listed in exclude config', function (): void {
+    $packages = new PackageCollection([
+        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+    ]);
+
+    $this->roster->shouldReceive('packages')->andReturn($packages);
+
+    config(['boost.guidelines.exclude' => ['deployments']]);
+
+    $guidelines = $this->composer->compose();
+
+    expect($guidelines)
+        ->not->toContain('=== deployments rules ===')
+        ->toContain('=== laravel/core rules ===')
         ->toContain('=== foundation rules ===');
 });
 


### PR DESCRIPTION
This PR moves the guidelines from the core guidelines to deployment guidelines. 

If anyone want to override they can override it via. `.ai/deployments/core.blade.php` and add there own instructions.  

You can also ignore the guidelines by adding this config in `boost.php`

```
'guidelines' => [
   'exclude' => [
       'deployments'
    ]
]
```


