### PR TITLE
Instruct agents to use APP_ENV=testing for Pest

### DIFF
--- a/.ai/pest/core.blade.php
+++ b/.ai/pest/core.blade.php
@@ -6,3 +6,4 @@
 - This project uses Pest for testing. Create tests: `{{ $assist->artisanCommand('make:test --pest {name}') }}`.
 - Run tests: `{{ $assist->artisanCommand('test --compact') }}` or filter: `{{ $assist->artisanCommand('test --compact --filter=testName') }}`.
 - Do NOT delete tests without approval.
+- Make sure to run tests using the APP_ENV=testing env variable.


### PR DESCRIPTION
I have been working with Gemini CLI recently, and I was going crazy because every time the agent ran tests they would fail... After some debugging, I found that for some reason Gemini CLI sets APP_ENV=local :/. I'm not sure why this happens, looking at their source code I haven't found any reference to this, but [someone else opened an issue](https://github.com/google-gemini/gemini-cli/issues/11564) so I'm not the only one facing that problem.

I'm not sure if my proposed solution is the best idea, but I have tried adding this sentence to my local .ai/guidelines folder and everything is working fine.

Even if you don't want to merge this, at least people should come across this solution if they are searching for answers :).