### PR TITLE
The path to the Junie guidelines file has been corrected

### DIFF
--- a/src/Install/Agents/Junie.php
+++ b/src/Install/Agents/Junie.php
@@ -73,7 +73,7 @@ class Junie extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSk
 
     public function guidelinesPath(): string
     {
-        return config('boost.agents.junie.guidelines_path', 'AGENTS.md');
+        return config('boost.agents.junie.guidelines_path', '.junie/AGENTS.md');
     }
 
     public function skillsPath(): string


### PR DESCRIPTION
Junie can't read the `AGENTS.md` file from the project root, so the rules defined there are ignored.

Junie expects the file `.junie/AGENTS.md`.

Since the path key is located deep in the configuration (`boost.agents.junie.guidelines_path`), you can't simply specify the path - Laravel will overwrite other configurations due to the way the `array_merge` function works.

Junie also doesn't allow you to set global project settings, so you'll have to manually change the file path in 100+ projects.

Instead, I suggest changing the default path in Laravel Boost.

Junie version 261.1218.175

<img width="1178" height="734" alt="image" src="https://github.com/user-attachments/assets/8cdaf21b-2028-4a2d-921c-9e91945c4a63" />

