### PR TITLE
Added better instructions for generating tests.

### DIFF
--- a/.ai/pest/3/skill/pest-testing/SKILL.blade.php
+++ b/.ai/pest/3/skill/pest-testing/SKILL.blade.php
@@ -20,6 +20,12 @@ Use `search-docs` for detailed Pest 3 patterns and documentation.
 
 All tests must be written using Pest. Use `{{ $assist->artisanCommand('make:test --pest {name}') }}`.
 
+The `{name}` argument should include only the path and test name, but should not include the test suite.
+- Incorrect: `{{ $assist->artisanCommand('make:test --pest Feature/SomeFeatureTest') }}` will generate `tests/Feature/Feature/SomeFeatureTest.php`
+- Correct: `{{ $assist->artisanCommand('make:test --pest SomeControllerTest') }}` will generate `tests/Feature/SomeControllerTest.php`
+- Incorrect: `{{ $assist->artisanCommand('make:test --pest --unit Unit/SomeServiceTest') }}` will generate `tests/Unit/Unit/SomeServiceTest.php`
+- Correct: `{{ $assist->artisanCommand('make:test --pest --unit SomeServiceTest') }}` will generate `tests/Unit/SomeServiceTest.php`
+
 ### Test Organization
 
 - Tests live in the `tests/Feature` and `tests/Unit` directories.
@@ -106,3 +112,4 @@ Pest 3 provides improved type coverage analysis. Run with `--type-coverage` flag
 - Using `assertStatus(200)` instead of `assertSuccessful()`
 - Forgetting datasets for repetitive validation tests
 - Deleting tests without approval
+- Prefixing `Feature/` or `Unit/` in `{name}` when using `make:test`

--- a/.ai/pest/4/skill/pest-testing/SKILL.blade.php
+++ b/.ai/pest/4/skill/pest-testing/SKILL.blade.php
@@ -20,6 +20,12 @@ Use `search-docs` for detailed Pest 4 patterns and documentation.
 
 All tests must be written using Pest. Use `{{ $assist->artisanCommand('make:test --pest {name}') }}`.
 
+The `{name}` argument should include only the path and test name, but should not include the test suite.
+- Incorrect: `{{ $assist->artisanCommand('make:test --pest Feature/SomeFeatureTest') }}` will generate `tests/Feature/Feature/SomeFeatureTest.php`
+- Correct: `{{ $assist->artisanCommand('make:test --pest SomeControllerTest') }}` will generate `tests/Feature/SomeControllerTest.php`
+- Incorrect: `{{ $assist->artisanCommand('make:test --pest --unit Unit/SomeServiceTest') }}` will generate `tests/Unit/Unit/SomeServiceTest.php`
+- Correct: `{{ $assist->artisanCommand('make:test --pest --unit SomeServiceTest') }}` will generate `tests/Unit/SomeServiceTest.php`
+
 ### Test Organization
 
 - Unit/Feature tests: `tests/Feature` and `tests/Unit` directories.
@@ -153,3 +159,4 @@ arch('controllers')
 - Forgetting datasets for repetitive validation tests
 - Deleting tests without approval
 - Forgetting `assertNoJavaScriptErrors()` in browser tests
+- Prefixing `Feature/` or `Unit/` in `{name}` when using `make:test`

--- a/.ai/pest/core.blade.php
+++ b/.ai/pest/core.blade.php
@@ -4,5 +4,6 @@
 ## Pest
 
 - This project uses Pest for testing. Create tests: `{{ $assist->artisanCommand('make:test --pest {name}') }}`.
+- The `{name}` argument should not include the test suite directory. Use `{{ $assist->artisanCommand('make:test --pest SomeFeatureTest') }}` instead of `{{ $assist->artisanCommand('make:test --pest Feature/SomeFeatureTest') }}`.
 - Run tests: `{{ $assist->artisanCommand('test --compact') }}` or filter: `{{ $assist->artisanCommand('test --compact --filter=testName') }}`.
 - Do NOT delete tests without approval.


### PR DESCRIPTION
I ran into issues with agents continually adding `Feature/` or `Unit/` to the test name while generating tests, realising their mistake, then having to delete the test and run the `make:test` command again.

This change should better instruct the agents on how to correctly generate tests without including the test suite in the test name.