### PR TITLE
Handle Http::pool errors when downloading remote skills

### DIFF
--- a/src/Skills/Remote/GitHubSkillProvider.php
+++ b/src/Skills/Remote/GitHubSkillProvider.php
@@ -178,32 +178,34 @@ class GitHubSkillProvider
             $item['path'] => $this->buildRawFileUrl($item['path']),
         ]);
 
-        try {
-            $responses = Http::pool(fn (Pool $pool) => $fileUrls->map(
-                fn (string $url, string $path) => $pool->as($path)
-                    ->timeout(60)
-                    ->get($url)
-            )->all(), concurrency: 25);
-        } catch (Throwable) {
-            return false;
-        }
-
-        foreach ($files as $item) {
-            $response = $responses[$item['path']] ?? null;
-
-            if ($response instanceof Throwable || $response === null || $response->failed()) {
+        foreach ($fileUrls->chunk(25) as $chunk) {
+            try {
+                $responses = Http::pool(fn (Pool $pool) => $chunk->map(
+                    fn (string $url, string $path) => $pool->as($path)
+                        ->timeout(60)
+                        ->get($url)
+                )->all());
+            } catch (Throwable) {
                 return false;
             }
 
-            $relativePath = $this->getRelativePath($item['path'], $basePath);
-            $localPath = $targetPath.'/'.$relativePath;
+            foreach ($chunk->keys() as $path) {
+                $response = $responses[$path] ?? null;
 
-            if (! $this->ensureDirectoryExists(dirname($localPath))) {
-                return false;
-            }
+                if ($response instanceof Throwable || $response === null || $response->failed()) {
+                    return false;
+                }
 
-            if (file_put_contents($localPath, $response->body()) === false) {
-                return false;
+                $relativePath = $this->getRelativePath($path, $basePath);
+                $localPath = $targetPath.'/'.$relativePath;
+
+                if (! $this->ensureDirectoryExists(dirname($localPath))) {
+                    return false;
+                }
+
+                if (file_put_contents($localPath, $response->body()) === false) {
+                    return false;
+                }
             }
         }
 

--- a/src/Skills/Remote/GitHubSkillProvider.php
+++ b/src/Skills/Remote/GitHubSkillProvider.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Skills\Remote;
 
+use GuzzleHttp\Promise\EachPromise;
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Http\Client\Pool;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -178,34 +178,40 @@ class GitHubSkillProvider
             $item['path'] => $this->buildRawFileUrl($item['path']),
         ]);
 
-        foreach ($fileUrls->chunk(25) as $chunk) {
-            try {
-                $responses = Http::pool(fn (Pool $pool) => $chunk->map(
-                    fn (string $url, string $path) => $pool->as($path)
-                        ->timeout(60)
-                        ->get($url)
-                )->all());
-            } catch (Throwable) {
+        $responses = [];
+
+        $generator = (function () use ($fileUrls) {
+            foreach ($fileUrls as $path => $url) {
+                yield $path => $this->client(60)->async()->get($url);
+            }
+        })();
+
+        (new EachPromise($generator, [
+            'concurrency' => 25,
+            'fulfilled' => static function ($response, $path) use (&$responses): void {
+                $responses[$path] = $response;
+            },
+            'rejected' => static function ($reason, $path) use (&$responses): void {
+                $responses[$path] = $reason;
+            },
+        ]))->promise()->wait();
+
+        foreach ($files as $item) {
+            $response = $responses[$item['path']] ?? null;
+
+            if ($response instanceof Throwable || $response === null || $response->failed()) {
                 return false;
             }
 
-            foreach ($chunk->keys() as $path) {
-                $response = $responses[$path] ?? null;
+            $relativePath = $this->getRelativePath($item['path'], $basePath);
+            $localPath = $targetPath.'/'.$relativePath;
 
-                if ($response instanceof Throwable || $response === null || $response->failed()) {
-                    return false;
-                }
+            if (! $this->ensureDirectoryExists(dirname($localPath))) {
+                return false;
+            }
 
-                $relativePath = $this->getRelativePath($path, $basePath);
-                $localPath = $targetPath.'/'.$relativePath;
-
-                if (! $this->ensureDirectoryExists(dirname($localPath))) {
-                    return false;
-                }
-
-                if (file_put_contents($localPath, $response->body()) === false) {
-                    return false;
-                }
+            if (file_put_contents($localPath, $response->body()) === false) {
+                return false;
             }
         }
 

--- a/src/Skills/Remote/GitHubSkillProvider.php
+++ b/src/Skills/Remote/GitHubSkillProvider.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use RuntimeException;
+use Throwable;
 
 class GitHubSkillProvider
 {
@@ -177,17 +178,20 @@ class GitHubSkillProvider
             $item['path'] => $this->buildRawFileUrl($item['path']),
         ]);
 
-        $responses = Http::pool(fn (Pool $pool) => $fileUrls->map(
-            fn (string $url, string $path) => $pool->as($path)
-                ->withHeaders(['User-Agent' => 'Laravel-Boost'])
-                ->timeout(30)
-                ->get($url)
-        )->all());
+        try {
+            $responses = Http::pool(fn (Pool $pool) => $fileUrls->map(
+                fn (string $url, string $path) => $pool->as($path)
+                    ->timeout(60)
+                    ->get($url)
+            )->all(), concurrency: 25);
+        } catch (Throwable) {
+            return false;
+        }
 
         foreach ($files as $item) {
             $response = $responses[$item['path']] ?? null;
 
-            if ($response === null || $response->failed()) {
+            if ($response instanceof Throwable || $response === null || $response->failed()) {
                 return false;
             }
 


### PR DESCRIPTION
When downloading skills with many files, `boost:add` crashes because `Http::pool()` fires all requests concurrently, causing GitHub's CDN to refuse connections (cURL error 7). The `ConnectionException` gets stored in the responses array, and calling `->failed()` on it throws a fatal error. A second failure mode is a Guzzle-level `LogicException` when concurrent rejected promises corrupt the pool's state.

Fixes #777

### Approach

- Using the concurrency polyfill to support in laravel 11.