### PR TITLE
Remove skills listing from foundation guideline

### DIFF
--- a/.ai/foundation.blade.php
+++ b/.ai/foundation.blade.php
@@ -18,14 +18,9 @@ Application purpose: {!! config('boost.purpose') !!}
 
 @endif
 
-@if($assist->hasSkillsEnabled() && $assist->skills()->isNotEmpty())
+@if($assist->hasSkillsEnabled())
 ## Skills Activation
-
-This project has domain-specific skills available. You MUST activate the relevant skill whenever you work in that domain—don't wait until you're stuck.
-
-@foreach($assist->skills() as $skill)
-- `{{ $skill->name }}` — {{ $skill->description }}
-@endforeach
+This project has domain-specific skills available in `**/skills/**`. You MUST activate the relevant skill whenever you work in that domain—don't wait until you're stuck.
 @endif
 
 ## Conventions

--- a/src/Install/GuidelineAssist.php
+++ b/src/Install/GuidelineAssist.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Laravel\Boost\Install;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Laravel\Boost\Install\Assists\Inertia;
 use Laravel\Roster\Enums\NodePackageManager;
@@ -28,9 +27,8 @@ class GuidelineAssist
 
     protected static array $classes = [];
 
-    public function __construct(public Roster $roster, public GuidelineConfig $config, public ?Collection $skills = null)
+    public function __construct(public Roster $roster, public GuidelineConfig $config)
     {
-        $this->skills ??= collect();
         $this->modelPaths = $this->discover(fn ($reflection): bool => ($reflection->isSubclassOf(Model::class) && ! $reflection->isAbstract()));
         $this->controllerPaths = $this->discover(fn (ReflectionClass $reflection): bool => (stripos($reflection->getName(), 'controller') !== false || stripos($reflection->getNamespaceName(), 'controller') !== false));
         $this->enumPaths = $this->discover(fn ($reflection) => $reflection->isEnum());
@@ -278,14 +276,6 @@ class GuidelineAssist
     public function appPath(string $path = ''): string
     {
         return ltrim(Str::after(app_path($path), base_path()), DIRECTORY_SEPARATOR);
-    }
-
-    /**
-     * @return Collection<string, Skill>
-     */
-    public function skills(): Collection
-    {
-        return $this->skills;
     }
 
     public function hasSkillsEnabled(): bool

--- a/src/Install/GuidelineComposer.php
+++ b/src/Install/GuidelineComposer.php
@@ -27,8 +27,6 @@ class GuidelineComposer
 
     protected GuidelineConfig $config;
 
-    protected ?SkillComposer $skillComposer = null;
-
     public function __construct(protected Roster $roster, protected Herd $herd)
     {
         $this->config = new GuidelineConfig;
@@ -317,9 +315,7 @@ class GuidelineComposer
 
     protected function getGuidelineAssist(): GuidelineAssist
     {
-        $skillsComposer = $this->skillComposer ??= new SkillComposer($this->roster, $this->config);
-
-        return new GuidelineAssist($this->roster, $this->config, $skillsComposer->skills());
+        return new GuidelineAssist($this->roster, $this->config);
     }
 
     protected function prependPackageGuidelinePath(string $path): string

--- a/src/Install/SkillComposer.php
+++ b/src/Install/SkillComposer.php
@@ -255,6 +255,6 @@ class SkillComposer
 
     protected function getGuidelineAssist(): GuidelineAssist
     {
-        return new GuidelineAssist($this->roster, $this->config, $this->skills ?? collect());
+        return new GuidelineAssist($this->roster, $this->config);
     }
 }

--- a/tests/Feature/Install/GuidelineComposerTest.php
+++ b/tests/Feature/Install/GuidelineComposerTest.php
@@ -756,6 +756,25 @@ test('excludes Skills Activation section when skills are disabled', function ():
         ->not->toContain('This project has domain-specific skills available');
 });
 
+test('includes Skills Activation section when skills are enabled', function (): void {
+    $packages = new PackageCollection([
+        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+    ]);
+
+    $this->roster->shouldReceive('packages')->andReturn($packages);
+
+    $config = new GuidelineConfig;
+    $config->hasSkills = true;
+
+    $guidelines = $this->composer
+        ->config($config)
+        ->compose();
+
+    expect($guidelines)
+        ->toContain('## Skills Activation')
+        ->toContain('This project has domain-specific skills available');
+});
+
 test('excludes guidelines listed in config exclude list', function (): void {
     $packages = new PackageCollection([
         new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
@@ -898,26 +917,6 @@ test('excludes guidelines from used() list', function (): void {
     expect($used)
         ->not->toContain('pest/core')
         ->toContain('foundation');
-});
-
-test('includes Skills Activation section when skills are enabled and skills exist', function (): void {
-    $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::PEST, 'pestphp/pest', '3.0.0'),
-    ]);
-
-    $this->roster->shouldReceive('packages')->andReturn($packages);
-
-    $config = new GuidelineConfig;
-    $config->hasSkills = true;
-
-    $guidelines = $this->composer
-        ->config($config)
-        ->compose();
-
-    expect($guidelines)
-        ->toContain('## Skills Activation')
-        ->toContain('This project has domain-specific skills available');
 });
 
 test('excludes MCP Tools and Searching Documentation sections when hasMcp is false', function (): void {


### PR DESCRIPTION
The foundation guideline previously listed each available skill by name and description inline (This was added because skill triggering was not reliable we recently improve skill description so this section no longer needed). This removes that listing while keeping the Skills Activation section header and prompt, so the guideline stays lean without losing the instruction to activate skills.