### PR TITLE
Remove app helper style recommendation

### DIFF
--- a/.ai/laravel/skill/laravel-best-practices/rules/style.md
+++ b/.ai/laravel/skill/laravel-best-practices/rules/style.md
@@ -29,7 +29,6 @@
 | `$request->input('name')` | `$request->name` |
 | `return Redirect::back()` | `return back()` |
 | `Carbon::now()` | `now()` |
-| `App::make('Class')` | `app('Class')` |
 | `->where('column', '=', 1)` | `->where('column', 1)` |
 | `->orderBy('created_at', 'desc')` | `->latest()` |
 | `->orderBy('created_at', 'asc')` | `->oldest()` |


### PR DESCRIPTION
## Summary
- remove the App::make(Class) to app(Class) shorthand recommendation from the Laravel best practices style guide

## Rationale
Constructor injection is recommended elsewhere in the same skill guidance, so this shorthand row can nudge agents toward service-locator usage inside classes.

## Verification
- git diff --check