### PR TITLE
fix: typo and doc/comment improvements in ApplicationInfo and Boost

### DIFF
--- a/src/Mcp/Boost.php
+++ b/src/Mcp/Boost.php
@@ -38,7 +38,7 @@ class Boost extends Server
     /**
      * The MCP server's instructions for the LLM.
      */
-    protected string $instructions = 'Laravel ecosystem MCP server offering database schema access, error logs, semantic documentation search and more. Boost helps with code generation.';
+    protected string $instructions = 'Laravel ecosystem MCP server offering database schema access, error logs, semantic documentation search, and more. Boost helps with code generation.';
 
     /**
      * The default pagination length for resources that support pagination.

--- a/src/Mcp/Resources/ApplicationInfo.php
+++ b/src/Mcp/Resources/ApplicationInfo.php
@@ -39,7 +39,7 @@ class ApplicationInfo extends Resource
         $response = $this->toolExecutor->execute(ApplicationInfoTool::class);
 
         if ($response->isError()) {
-            return $response; // Return the error response directly
+            return $response;
         }
 
         $data = json_decode((string) $response->content(), true);

--- a/src/Mcp/Resources/ApplicationInfo.php
+++ b/src/Mcp/Resources/ApplicationInfo.php
@@ -19,7 +19,7 @@ class ApplicationInfo extends Resource
     /**
      * The resource's description.
      */
-    protected string $description = 'Comprehensive application information including PHP version, Laravel version, database engine, all installed packages with their versions in the application.';
+    protected string $description = 'Comprehensive application information including PHP version, Laravel version, database engine, and all installed packages with their versions in the application.';
 
     /**
      * The resource's URI.


### PR DESCRIPTION
This PR adds some minor typo/comment related updates:
- added missing conjunction in the `$description` property of `ApplicationInfo.php` for consistency and readability.
- added missing comma before "and" (oxford comma) in the `$instructions` property of `Boost.php`.
- removed unnecessary comment from `handler` method in `ApplicationInfo.php` (cause the code is itself descriptive enough)