### PR TITLE
Preserve empty objects in MCP JSON config files

### DIFF
--- a/src/Install/Mcp/FileWriter.php
+++ b/src/Install/Mcp/FileWriter.php
@@ -415,11 +415,7 @@ class FileWriter
     protected function addServersToConfig(array|object &$config): void
     {
         if (is_array($config)) {
-            foreach ($this->serversToAdd as $key => $serverConfig) {
-                $config[$this->configKey][$key] = $serverConfig;
-            }
-
-            return;
+            $config = (object) $config;
         }
 
         if (! isset($config->{$this->configKey}) || ! is_object($config->{$this->configKey})) {
@@ -431,7 +427,7 @@ class FileWriter
         }
     }
 
-    protected function writeJsonConfig(array|object $config): bool
+    protected function writeJsonConfig(object $config): bool
     {
         $json = json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 

--- a/src/Install/Mcp/FileWriter.php
+++ b/src/Install/Mcp/FileWriter.php
@@ -6,6 +6,7 @@ namespace Laravel\Boost\Install\Mcp;
 
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
+use stdClass;
 
 class FileWriter
 {
@@ -77,7 +78,7 @@ class FileWriter
 
     protected function updatePlainJsonFile(string $content): bool
     {
-        $config = json_decode($content, true);
+        $config = json_decode($content);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             return false;
@@ -411,14 +412,26 @@ class FileWriter
         return $this->writeJsonConfig($config);
     }
 
-    protected function addServersToConfig(array &$config): void
+    protected function addServersToConfig(array|object &$config): void
     {
+        if (is_array($config)) {
+            foreach ($this->serversToAdd as $key => $serverConfig) {
+                $config[$this->configKey][$key] = $serverConfig;
+            }
+
+            return;
+        }
+
+        if (! isset($config->{$this->configKey}) || ! is_object($config->{$this->configKey})) {
+            $config->{$this->configKey} = new stdClass;
+        }
+
         foreach ($this->serversToAdd as $key => $serverConfig) {
-            $config[$this->configKey][$key] = $serverConfig;
+            $config->{$this->configKey}->{$key} = $serverConfig;
         }
     }
 
-    protected function writeJsonConfig(array $config): bool
+    protected function writeJsonConfig(array|object $config): bool
     {
         $json = json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 

--- a/tests/Unit/Install/Mcp/FileWriterTest.php
+++ b/tests/Unit/Install/Mcp/FileWriterTest.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Str;
 use Laravel\Boost\Install\Mcp\FileWriter;
 use Mockery;
 use ReflectionClass;
+use stdClass;
 
 test('constructor sets file path', function (): void {
     $writer = new FileWriter('/path/to/mcp.json');
@@ -125,6 +126,46 @@ test('adds to existing mcpServers in plain JSON', function (): void {
         ->toHaveKey('mcpServers.boost'); // New server added
 
     expect($decoded['mcpServers']['boost']['command'])->toBe('php');
+});
+
+test('preserves empty objects in existing plain JSON files', function (): void {
+    $writtenContent = '';
+    $content = <<<'JSON'
+    {
+        "$schema": "https://opencode.ai/config.json",
+        "mcp": {
+            "existing": {
+                "type": "remote",
+                "enabled": true,
+                "url": "https://example.com/mcp",
+                "oauth": {}
+            }
+        }
+    }
+    JSON;
+
+    mockFileOperations(
+        fileExists: true,
+        content: $content,
+        capturedContent: $writtenContent
+    );
+
+    File::shouldReceive('size')->andReturn(200);
+
+    $result = (new FileWriter('/path/to/opencode.json'))
+        ->configKey('mcp')
+        ->addServerConfig('laravel-boost', [
+            'type' => 'local',
+            'enabled' => true,
+            'command' => ['php', 'artisan', 'boost:mcp'],
+        ])
+        ->save();
+
+    $decoded = json_decode((string) $writtenContent);
+
+    expect($result)->toBeTrue();
+    expect($decoded->mcp->existing->oauth)->toBeInstanceOf(stdClass::class);
+    expect($decoded->mcp->{'laravel-boost'}->command)->toBe(['php', 'artisan', 'boost:mcp']);
 });
 
 test('preserves complex JSON5 features that VS Code supports', function (): void {


### PR DESCRIPTION
## Summary

This fixes plain JSON MCP config updates so existing empty objects are preserved when Boost adds a server entry.

Previously, updating an existing `opencode.json` that contained an empty object such as `"oauth": {}` would rewrite it as `"oauth": []`. OpenCode validates its config schema on startup, so this prevented OpenCode from loading the config after Boost installed its MCP server entry.

The change keeps decoded plain JSON objects as objects while still supporting the existing array-based path used for new config creation.

## Benefit to End Users

Users with an existing OpenCode MCP config can install Boost without making their OpenCode configuration invalid. Empty object fields such as `oauth` remain valid objects, allowing OpenCode to continue loading normally.

## Backwards Compatibility

This should not break existing behavior because `json_encode` supports both arrays and decoded objects. New file creation still uses the existing array-based config path, and existing plain JSON files now retain their original object/array shapes more accurately.