### PR TITLE
Fix TypeError in RendersBladeGuidelines when Blade::render returns an HtmlString

### DIFF
--- a/src/Concerns/RendersBladeGuidelines.php
+++ b/src/Concerns/RendersBladeGuidelines.php
@@ -37,7 +37,7 @@ trait RendersBladeGuidelines
             ...$data,
         ]);
 
-        $rendered = html_entity_decode($rendered, ENT_QUOTES | ENT_HTML5);
+        $rendered = html_entity_decode((string) $rendered, ENT_QUOTES | ENT_HTML5);
 
         return str_replace(array_values($placeholders), array_keys($placeholders), $rendered);
     }


### PR DESCRIPTION
In recent Laravel versions, `Blade::render()` returns an `Illuminate\Support\HtmlString` instead of a raw string. When this occurs within the `RendersBladeGuidelines` trait, the `html_entity_decode()` function throws a `TypeError`.

This PR adds a `(string)` cast to the rendered content to ensure it is converted to a raw string before being processed by `html_entity_decode`.
