### PR TITLE
Add optional Laravel Boost AI artifact ignores during `boost:install`

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -88,6 +88,7 @@ class InstallCommand extends Command
         $this->discoverEnvironment();
         $this->collectInstallationPreferences();
         $this->performInstallation();
+        $this->updateGitignore();
         $this->outro();
 
         return self::SUCCESS;
@@ -138,6 +139,103 @@ class InstallCommand extends Command
         }
 
         $this->storeConfig();
+    }
+
+    protected function updateGitignore(): void
+    {
+        if (! $this->input->isInteractive()) {
+            $this->info('Skipped .gitignore updates.');
+
+            return;
+        }
+
+        if (! $this->confirm('Would you like to add recommended AI artifacts to .gitignore?')) {
+            $this->info('Skipped .gitignore updates.');
+
+            return;
+        }
+
+        $path = base_path('.gitignore');
+        $content = file_exists($path) ? file_get_contents($path) : '';
+        $updatedContent = $this->mergeBoostGitignoreRules($content ?: '');
+
+        if ($updatedContent === $content) {
+            $this->info('Laravel Boost ignore rules are already present in .gitignore.');
+
+            return;
+        }
+
+        file_put_contents($path, $updatedContent);
+
+        $this->info('Added Laravel Boost ignore rules to .gitignore.');
+    }
+
+    protected function mergeBoostGitignoreRules(string $content): string
+    {
+        $lineEnding = $this->detectLineEnding($content);
+        $lines = $this->gitignoreLines($content);
+        $normalizedLines = collect($lines)->map(fn (string $line): string => trim($line));
+        $entries = collect([
+            '.ai/generated',
+            '.ai/cache',
+            '.claude/',
+            '.cursor/rules/generated',
+        ]);
+
+        $missingEntries = $entries
+            ->reject(fn (string $entry): bool => $normalizedLines->contains($entry))
+            ->values();
+
+        if ($missingEntries->isEmpty()) {
+            return $content;
+        }
+
+        if ($normalizedLines->contains('# Laravel Boost')) {
+            $sectionStart = $normalizedLines->search('# Laravel Boost');
+            $sectionEnd = $sectionStart + 1;
+
+            while (isset($lines[$sectionEnd]) && $entries->contains(trim($lines[$sectionEnd]))) {
+                $sectionEnd++;
+            }
+
+            array_splice($lines, $sectionEnd, 0, $missingEntries->all());
+        } else {
+            $lines = [
+                ...$lines,
+                ...($lines === [] ? [] : ['']),
+                '# Laravel Boost',
+                ...$missingEntries->all(),
+            ];
+        }
+
+        return implode($lineEnding, $lines).$lineEnding;
+    }
+
+    protected function detectLineEnding(string $content): string
+    {
+        if (str_contains($content, "\r\n")) {
+            return "\r\n";
+        }
+
+        if (str_contains($content, "\r")) {
+            return "\r";
+        }
+
+        return "\n";
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function gitignoreLines(string $content): array
+    {
+        $trimmedContent = rtrim($content, "\r\n");
+
+        if ($trimmedContent === '') {
+            return [];
+        }
+
+        return preg_split('/\r\n|\n|\r/', $trimmedContent) ?: [];
     }
 
     protected function outro(): void

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -88,7 +88,7 @@ class InstallCommand extends Command
         $this->discoverEnvironment();
         $this->collectInstallationPreferences();
         $this->performInstallation();
-        $this->updateGitignore();
+        $this->displayGitignoreSuggestions();
         $this->outro();
 
         return self::SUCCESS;
@@ -141,101 +141,16 @@ class InstallCommand extends Command
         $this->storeConfig();
     }
 
-    protected function updateGitignore(): void
+    protected function displayGitignoreSuggestions(): void
     {
         if (! $this->input->isInteractive()) {
-            $this->info('Skipped .gitignore updates.');
-
             return;
         }
 
-        if (! $this->confirm('Would you like to add recommended AI artifacts to .gitignore?')) {
-            $this->info('Skipped .gitignore updates.');
-
-            return;
-        }
-
-        $path = base_path('.gitignore');
-        $content = file_exists($path) ? file_get_contents($path) : '';
-        $updatedContent = $this->mergeBoostGitignoreRules($content ?: '');
-
-        if ($updatedContent === $content) {
-            $this->info('Laravel Boost ignore rules are already present in .gitignore.');
-
-            return;
-        }
-
-        file_put_contents($path, $updatedContent);
-
-        $this->info('Added Laravel Boost ignore rules to .gitignore.');
-    }
-
-    protected function mergeBoostGitignoreRules(string $content): string
-    {
-        $lineEnding = $this->detectLineEnding($content);
-        $lines = $this->gitignoreLines($content);
-        $normalizedLines = collect($lines)->map(fn (string $line): string => trim($line));
-        $entries = collect([
-            '.ai/generated',
-            '.ai/cache',
-            '.claude/',
-            '.cursor/rules/generated',
-        ]);
-
-        $missingEntries = $entries
-            ->reject(fn (string $entry): bool => $normalizedLines->contains($entry))
-            ->values();
-
-        if ($missingEntries->isEmpty()) {
-            return $content;
-        }
-
-        if ($normalizedLines->contains('# Laravel Boost')) {
-            $sectionStart = $normalizedLines->search('# Laravel Boost');
-            $sectionEnd = $sectionStart + 1;
-
-            while (isset($lines[$sectionEnd]) && $entries->contains(trim($lines[$sectionEnd]))) {
-                $sectionEnd++;
-            }
-
-            array_splice($lines, $sectionEnd, 0, $missingEntries->all());
-        } else {
-            $lines = [
-                ...$lines,
-                ...($lines === [] ? [] : ['']),
-                '# Laravel Boost',
-                ...$missingEntries->all(),
-            ];
-        }
-
-        return implode($lineEnding, $lines).$lineEnding;
-    }
-
-    protected function detectLineEnding(string $content): string
-    {
-        if (str_contains($content, "\r\n")) {
-            return "\r\n";
-        }
-
-        if (str_contains($content, "\r")) {
-            return "\r";
-        }
-
-        return "\n";
-    }
-
-    /**
-     * @return list<string>
-     */
-    protected function gitignoreLines(string $content): array
-    {
-        $trimmedContent = rtrim($content, "\r\n");
-
-        if ($trimmedContent === '') {
-            return [];
-        }
-
-        return preg_split('/\r\n|\n|\r/', $trimmedContent) ?: [];
+        $this->newLine();
+        $this->info('Suggested .gitignore entry for Boost:');
+        $this->line('# Laravel Boost');
+        $this->line('boost.json');
     }
 
     protected function outro(): void

--- a/tests/Feature/Console/InstallCommandGitignoreTest.php
+++ b/tests/Feature/Console/InstallCommandGitignoreTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Laravel\Boost\Console\Enums\Theme;
+use Laravel\Boost\Console\InstallCommand;
+use Laravel\Boost\Install\AgentsDetector;
+use Laravel\Boost\Install\Cloud;
+use Laravel\Boost\Install\Nightwatch;
+use Laravel\Boost\Install\Sail;
+use Laravel\Boost\Support\Config;
+use Laravel\Prompts\Terminal;
+
+beforeEach(function (): void {
+    $this->originalBasePath = app()->basePath();
+    $this->sandboxBasePath = sys_get_temp_dir().'/boost-install-command-'.Str::uuid();
+
+    File::ensureDirectoryExists($this->sandboxBasePath);
+
+    app()->setBasePath($this->sandboxBasePath);
+
+    $this->app->instance(InstallCommand::class, new class(app(AgentsDetector::class), app(Cloud::class), app(Config::class), app(Nightwatch::class), app(Sail::class), app(Terminal::class)) extends InstallCommand
+    {
+        protected function displayBoostHeader(string $featureName, string $projectName, ?Theme $theme = null): void {}
+
+        protected function discoverEnvironment(): void {}
+
+        protected function collectInstallationPreferences(): void {}
+
+        protected function performInstallation(): void {}
+
+        protected function outro(): void {}
+    });
+});
+
+afterEach(function (): void {
+    app()->setBasePath($this->originalBasePath);
+    File::deleteDirectory($this->sandboxBasePath);
+});
+
+it('appends laravel boost ignore rules to an existing gitignore', function (): void {
+    File::put(base_path('.gitignore'), "vendor/\nnode_modules/");
+
+    $this->artisan('boost:install')
+        ->expectsConfirmation('Would you like to add recommended AI artifacts to .gitignore?', 'yes')
+        ->expectsOutputToContain('Added Laravel Boost ignore rules to .gitignore.')
+        ->assertSuccessful();
+
+    expect(File::get(base_path('.gitignore')))->toBe(implode("\n", [
+        'vendor/',
+        'node_modules/',
+        '',
+        '# Laravel Boost',
+        '.ai/generated',
+        '.ai/cache',
+        '.claude/',
+        '.cursor/rules/generated',
+        '',
+    ]));
+});
+
+it('creates a gitignore file when one does not exist', function (): void {
+    $this->artisan('boost:install')
+        ->expectsConfirmation('Would you like to add recommended AI artifacts to .gitignore?', 'yes')
+        ->expectsOutputToContain('Added Laravel Boost ignore rules to .gitignore.')
+        ->assertSuccessful();
+
+    expect(File::get(base_path('.gitignore')))->toBe(implode("\n", [
+        '# Laravel Boost',
+        '.ai/generated',
+        '.ai/cache',
+        '.claude/',
+        '.cursor/rules/generated',
+        '',
+    ]));
+});
+
+it('avoids duplicating existing entries and only merges missing rules into the boost section', function (): void {
+    File::put(base_path('.gitignore'), implode("\n", [
+        'vendor/',
+        '# Laravel Boost',
+        '.ai/generated',
+        '.claude/',
+        '',
+        '.cursor/rules/generated',
+        '',
+    ]));
+
+    $this->artisan('boost:install')
+        ->expectsConfirmation('Would you like to add recommended AI artifacts to .gitignore?', 'yes')
+        ->expectsOutputToContain('Added Laravel Boost ignore rules to .gitignore.')
+        ->assertSuccessful();
+
+    expect(File::get(base_path('.gitignore')))->toBe(implode("\n", [
+        'vendor/',
+        '# Laravel Boost',
+        '.ai/generated',
+        '.claude/',
+        '.ai/cache',
+        '',
+        '.cursor/rules/generated',
+        '',
+    ]));
+});

--- a/tests/Feature/Console/InstallCommandGitignoreTest.php
+++ b/tests/Feature/Console/InstallCommandGitignoreTest.php
@@ -2,8 +2,6 @@
 
 declare(strict_types=1);
 
-use Illuminate\Support\Facades\File;
-use Illuminate\Support\Str;
 use Laravel\Boost\Console\Enums\Theme;
 use Laravel\Boost\Console\InstallCommand;
 use Laravel\Boost\Install\AgentsDetector;
@@ -14,13 +12,6 @@ use Laravel\Boost\Support\Config;
 use Laravel\Prompts\Terminal;
 
 beforeEach(function (): void {
-    $this->originalBasePath = app()->basePath();
-    $this->sandboxBasePath = sys_get_temp_dir().'/boost-install-command-'.Str::uuid();
-
-    File::ensureDirectoryExists($this->sandboxBasePath);
-
-    app()->setBasePath($this->sandboxBasePath);
-
     $this->app->instance(InstallCommand::class, new class(app(AgentsDetector::class), app(Cloud::class), app(Config::class), app(Nightwatch::class), app(Sail::class), app(Terminal::class)) extends InstallCommand
     {
         protected function displayBoostHeader(string $featureName, string $projectName, ?Theme $theme = null): void {}
@@ -35,72 +26,17 @@ beforeEach(function (): void {
     });
 });
 
-afterEach(function (): void {
-    app()->setBasePath($this->originalBasePath);
-    File::deleteDirectory($this->sandboxBasePath);
+it('shows suggested gitignore entries in interactive installs', function (): void {
+    $this->artisan('boost:install')
+        ->expectsOutputToContain('Suggested .gitignore entry for Boost:')
+        ->expectsOutputToContain('# Laravel Boost')
+        ->expectsOutputToContain('boost.json')
+        ->assertSuccessful();
 });
 
-it('appends laravel boost ignore rules to an existing gitignore', function (): void {
-    File::put(base_path('.gitignore'), "vendor/\nnode_modules/");
-
-    $this->artisan('boost:install')
-        ->expectsConfirmation('Would you like to add recommended AI artifacts to .gitignore?', 'yes')
-        ->expectsOutputToContain('Added Laravel Boost ignore rules to .gitignore.')
+it('does not show suggested gitignore entries in non-interactive installs', function (): void {
+    $this->artisan('boost:install', ['--no-interaction' => true])
+        ->doesntExpectOutputToContain('Suggested .gitignore entry for Boost:')
+        ->doesntExpectOutputToContain('boost.json')
         ->assertSuccessful();
-
-    expect(File::get(base_path('.gitignore')))->toBe(implode("\n", [
-        'vendor/',
-        'node_modules/',
-        '',
-        '# Laravel Boost',
-        '.ai/generated',
-        '.ai/cache',
-        '.claude/',
-        '.cursor/rules/generated',
-        '',
-    ]));
-});
-
-it('creates a gitignore file when one does not exist', function (): void {
-    $this->artisan('boost:install')
-        ->expectsConfirmation('Would you like to add recommended AI artifacts to .gitignore?', 'yes')
-        ->expectsOutputToContain('Added Laravel Boost ignore rules to .gitignore.')
-        ->assertSuccessful();
-
-    expect(File::get(base_path('.gitignore')))->toBe(implode("\n", [
-        '# Laravel Boost',
-        '.ai/generated',
-        '.ai/cache',
-        '.claude/',
-        '.cursor/rules/generated',
-        '',
-    ]));
-});
-
-it('avoids duplicating existing entries and only merges missing rules into the boost section', function (): void {
-    File::put(base_path('.gitignore'), implode("\n", [
-        'vendor/',
-        '# Laravel Boost',
-        '.ai/generated',
-        '.claude/',
-        '',
-        '.cursor/rules/generated',
-        '',
-    ]));
-
-    $this->artisan('boost:install')
-        ->expectsConfirmation('Would you like to add recommended AI artifacts to .gitignore?', 'yes')
-        ->expectsOutputToContain('Added Laravel Boost ignore rules to .gitignore.')
-        ->assertSuccessful();
-
-    expect(File::get(base_path('.gitignore')))->toBe(implode("\n", [
-        'vendor/',
-        '# Laravel Boost',
-        '.ai/generated',
-        '.claude/',
-        '.ai/cache',
-        '',
-        '.cursor/rules/generated',
-        '',
-    ]));
 });


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
## Summary

Adds a small DX improvement to `php artisan boost:install` by offering to append recommended AI artifact entries to `.gitignore`.

If confirmed, Boost adds this grouped section:

```gitignore
# Laravel Boost
.ai/generated
.ai/cache
.claude/
.cursor/rules/generated
```

The update is safe and idempotent:

- creates `.gitignore` if it does not exist
- preserves existing file contents and ordering
- appends only missing entries
- avoids duplicate section headers
- skips the prompt in non-interactive mode

## Implementation

- keeps the logic inline in `InstallCommand.php`
- follows the command’s existing confirmation, output, and file-handling patterns
- does not introduce new services, config, or abstractions

## Tests

Added focused coverage for:

- appending entries to an existing `.gitignore`
- creating `.gitignore` when missing
- avoiding duplicates when the Boost section already exists

## Note

This PR is intended to provide a convenient starting point for AI-related `.gitignore` entries during `boost:install`, not to define a perfect universal ignore list.

I’m not fully sure the current list for .gitignore is ideal for every workflow or at all.