### PR TITLE
Remove redundant guidance to read .env directly

### DIFF
--- a/.ai/boost/core.blade.php
+++ b/.ai/boost/core.blade.php
@@ -26,7 +26,6 @@
 - Run Artisan commands directly via the command line (e.g., `{{ $assist->artisanCommand('route:list') }}`). Use `{{ $assist->artisanCommand('list') }}` to discover available commands and `{{ $assist->artisanCommand('[command] --help') }}` to check parameters.
 - Inspect routes with `{{ $assist->artisanCommand('route:list') }}`. Filter with: `--method=GET`, `--name=users`, `--path=api`, `--except-vendor`, `--only-vendor`.
 - Read configuration values using dot notation: `{{ $assist->artisanCommand('config:show app.name') }}`, `{{ $assist->artisanCommand('config:show database.default') }}`. Or read config files directly from the `config/` directory.
-- To check environment variables, read the `.env` file directly.
 
 ## Tinker
 - Execute PHP in app context for debugging and testing code. Do not create models without user approval, prefer tests with factories instead. Prefer existing Artisan commands over custom tinker code.


### PR DESCRIPTION
Thanks to the recent core-guideline cleanup work in #722 and #787 — the file reads cleanly. I'd like to propose removing one more redundant line: the instruction to read `.env` directly to check environment variables.

The line immediately above already documents `config:show` and direct reads of `config/*.php`, which cover the same use case. After tracing this through, the `.env` line looks redundant for legitimate lookups while pointing the model at a file Anthropic's [secure-deployment guide](https://code.claude.com/docs/en/agent-sdk/secure-deployment) and [settings reference](https://code.claude.com/docs/en/settings) treat as a sensitive denylist target alongside `~/.aws/credentials` and `*.pem`.

I saw the prior discussion in #728 and agree with the response there: guideline text can't enforce access restrictions, that belongs in the agent's permission layer. This PR isn't trying to revisit that. It's a removal in the same spirit as  #787, where a section was deleted once an adjacent mechanism made it redundant.

Behavior for users workflow is unchanged: agents can still read `.env` files.