### PR TITLE
Add Tinker MCP tool (opt-in via config)

### DIFF
--- a/.ai/boost/core.blade.php
+++ b/.ai/boost/core.blade.php
@@ -29,5 +29,9 @@
 
 ## Tinker
 - Execute PHP in app context for debugging and testing code. Do not create models without user approval, prefer tests with factories instead. Prefer existing Artisan commands over custom tinker code.
+@if($assist->hasMcpEnabled() && config('boost.tinker_tool_enabled', false))
+- Use the `tinker` MCP tool to execute PHP code instead of the CLI. It avoids shell escaping issues and runs the snippet in the Laravel application context.
+@else
 - Always use single quotes to prevent shell expansion: `{{ $assist->artisanCommand("tinker --execute 'Your::code();'") }}`
   - Double quotes for PHP strings inside: `{{ $assist->artisanCommand("tinker --execute 'User::where(\"active\", true)->count();'") }}`
+@endif

--- a/src/Mcp/Boost.php
+++ b/src/Mcp/Boost.php
@@ -18,6 +18,7 @@ use Laravel\Boost\Mcp\Tools\GetAbsoluteUrl;
 use Laravel\Boost\Mcp\Tools\LastError;
 use Laravel\Boost\Mcp\Tools\ReadLogEntries;
 use Laravel\Boost\Mcp\Tools\SearchDocs;
+use Laravel\Boost\Mcp\Tools\Tinker;
 use Laravel\Mcp\Server;
 use Laravel\Mcp\Server\Prompt;
 use Laravel\Mcp\Server\Resource;
@@ -91,6 +92,7 @@ class Boost extends Server
             LastError::class,
             ReadLogEntries::class,
             SearchDocs::class,
+            Tinker::class,
         ], 'tools');
     }
 

--- a/src/Mcp/Tools/Tinker.php
+++ b/src/Mcp/Tools/Tinker.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\JsonSchema\Types\Type;
+use Illuminate\Support\Facades\Artisan;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Symfony\Component\Console\Command\Command as CommandAlias;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Throwable;
+
+class Tinker extends Tool
+{
+    /**
+     * The tool's description.
+     */
+    protected string $description = 'Execute PHP code in the Laravel application context, like artisan tinker. Use this for debugging issues, checking if functions exist, and testing code snippets. You should not create models directly without explicit user approval. Prefer Unit/Feature tests using factories for functionality testing. Prefer existing artisan commands over custom tinker code.';
+
+    /**
+     * Determine whether the tool should be registered with the MCP server.
+     */
+    public function shouldRegister(): bool
+    {
+        return (bool) config('boost.tinker_tool_enabled', false);
+    }
+
+    /**
+     * Get the tool's input schema.
+     *
+     * @return array<string, Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'code' => $schema->string()
+                ->description('PHP code to execute (without opening <?php tags)')
+                ->required(),
+        ];
+    }
+
+    /**
+     * Handle the tool request.
+     */
+    public function handle(Request $request): Response
+    {
+        $code = str_replace(['<?php', '?>'], '', (string) $request->get('code'));
+
+        $output = new BufferedOutput;
+
+        try {
+            $exitCode = Artisan::call('tinker', [
+                '--execute' => $code,
+                '--no-ansi' => true,
+                '--no-interaction' => true,
+            ], $output);
+        } catch (Throwable $throwable) {
+            return Response::text($throwable->getMessage());
+        }
+
+        if ($exitCode !== CommandAlias::SUCCESS) {
+            return Response::text('Failed to execute tinker: '.$output->fetch());
+        }
+
+        return Response::text(trim($output->fetch()));
+    }
+}

--- a/tests/Feature/Mcp/Tools/TinkerTest.php
+++ b/tests/Feature/Mcp/Tools/TinkerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Application;
+use Illuminate\Support\Facades\Facade;
+use Laravel\Boost\Mcp\Tools\Tinker;
+use Laravel\Mcp\Request;
+use Laravel\Tinker\TinkerServiceProvider;
+use Orchestra\Testbench\Foundation\Application as Testbench;
+
+use function Orchestra\Testbench\package_path;
+
+beforeEach(function (): void {
+    $result = Testbench::createVendorSymlink(base_path(), package_path('vendor'));
+    $this->vendorSymlinkCreated = $result['TESTBENCH_VENDOR_SYMLINK'] ?? false;
+
+    Facade::clearResolvedInstances();
+    Facade::setFacadeApplication($this->app);
+    Application::setInstance($this->app);
+
+    $this->app->register(TinkerServiceProvider::class);
+});
+
+afterEach(function (): void {
+    if ($this->vendorSymlinkCreated ?? false) {
+        Testbench::deleteVendorSymlink(base_path());
+    }
+});
+
+test('executes code and returns output', function (): void {
+    $tool = new Tinker;
+    $response = $tool->handle(new Request(['code' => 'echo "Hello World";']));
+
+    expect($response)->isToolResult()
+        ->toolHasNoError()
+        ->toolTextContains('Hello World');
+});
+
+test('handles errors gracefully', function (): void {
+    $tool = new Tinker;
+    $response = $tool->handle(new Request(['code' => 'invalid syntax here']));
+
+    expect((string) $response->content())->toContain('Syntax error');
+});
+
+test('strips php tags from code', function (): void {
+    $tool = new Tinker;
+    $response = $tool->handle(new Request(['code' => '<?php echo "stripped"; ?>']));
+
+    expect($response)->isToolResult()
+        ->toolHasNoError()
+        ->toolTextContains('stripped');
+});
+
+test('executes code without semicolon', function (): void {
+    $tool = new Tinker;
+    $response = $tool->handle(new Request(['code' => 'echo 1']));
+
+    expect($response)->isToolResult()
+        ->toolHasNoError()
+        ->toolTextContains('1');
+});
+
+test('is not registered by default', function (): void {
+    $tool = new Tinker;
+
+    expect($tool->shouldRegister())->toBeFalse();
+});
+
+test('is registered when tinker_tool_enabled config is true', function (): void {
+    config()->set('boost.tinker_tool_enabled', true);
+
+    $tool = new Tinker;
+
+    expect($tool->shouldRegister())->toBeTrue();
+});


### PR DESCRIPTION
Currently the `tinker` MCP tool is gone (removed in #629), so agents have to use `php artisan tinker --execute '...'` via shell. That round-trips through shell escaping and bites pretty consistently. As #667 points out, agents tend to fail 2-3 times on quoting before they get a snippet right.

This PR brings the tool back, but opt-in so it stays off by default. Flip it on with:

\`\`\`php
// config/boost.php
'tinker_tool_enabled' => true,
\`\`\`

 `core.blade.php` swaps the guidance to prefer the MCP tool when the flag is on, and keeps the existing `--execute` instructions otherwise.
 Closes #667.