### PR TITLE
Sync Flux UI free/pro component lists with fluxui.dev

### DIFF
--- a/.ai/fluxui-free/skill/fluxui-development/SKILL.blade.php
+++ b/.ai/fluxui-free/skill/fluxui-development/SKILL.blade.php
@@ -28,7 +28,7 @@ Use Flux UI components when available. Fall back to standard Blade components wh
 
 ## Available Components (Free Edition)
 
-Available: avatar, badge, brand, breadcrumbs, button, callout, checkbox, dropdown, field, heading, icon, input, modal, navbar, otp-input, profile, radio, select, separator, skeleton, switch, text, textarea, tooltip
+Available: avatar, badge, brand, breadcrumbs, button, callout, card, checkbox, dropdown, field, heading, icon, input, modal, navbar, otp-input, pagination, profile, progress, radio, select, separator, skeleton, switch, table, text, textarea, toast, tooltip
 
 ## Icons
 

--- a/.ai/fluxui-pro/skill/fluxui-development/SKILL.blade.php
+++ b/.ai/fluxui-pro/skill/fluxui-development/SKILL.blade.php
@@ -28,7 +28,7 @@ Use Flux UI components when available. Fall back to standard Blade components wh
 
 ## Available Components (Pro Edition)
 
-Available: accordion, autocomplete, avatar, badge, brand, breadcrumbs, button, calendar, callout, card, chart, checkbox, command, composer, context, date-picker, dropdown, editor, field, file-upload, heading, icon, input, kanban, modal, navbar, otp-input, pagination, pillbox, popover, profile, radio, select, separator, skeleton, slider, switch, table, tabs, text, textarea, time-picker, toast, tooltip
+Available: accordion, autocomplete, avatar, badge, brand, breadcrumbs, button, calendar, callout, card, chart, checkbox, color-picker, command, composer, context, date-picker, dropdown, editor, field, file-upload, heading, icon, input, kanban, modal, navbar, otp-input, pagination, pillbox, popover, profile, progress, radio, select, separator, skeleton, slider, switch, table, tabs, text, textarea, time-picker, timeline, toast, tooltip
 
 ## Icons
 


### PR DESCRIPTION
Currently the Flux UI skills list components that don't match what's actually available on fluxui.dev. The free skill is missing `table`, `card`, `pagination`, `progress`, and `toast` (all free per fluxui.dev), so agents tell users "table is Pro" and write custom Blade tables instead. The Pro skill was also missing `color-picker` and `timeline`.

Verified by scraping fluxui.dev/components and checking each component page for the "Pro component" marker.

Fixes #803