### PR TITLE
Omit cwd from Codex MCP config to fix Sail and worktree issues

### DIFF
--- a/config/boost.php
+++ b/config/boost.php
@@ -46,7 +46,7 @@ return [
         'composer' => env('BOOST_COMPOSER_EXECUTABLE_PATH'),
         'npm' => env('BOOST_NPM_EXECUTABLE_PATH'),
         'vendor_bin' => env('BOOST_VENDOR_BIN_EXECUTABLE_PATH'),
-        'current_directory' => env('BOOST_CURRENT_DIRECTORY_EXECUTABLE_PATH', base_path()),
+        'current_directory' => env('BOOST_CURRENT_DIRECTORY_EXECUTABLE_PATH'),
     ],
 
 ];

--- a/src/Install/Agents/Codex.php
+++ b/src/Install/Agents/Codex.php
@@ -77,7 +77,7 @@ class Codex extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSk
         return collect([
             'command' => $command,
             'args' => $args,
-            'cwd' => config('boost.executable_paths.current_directory', base_path()),
+            'cwd' => config('boost.executable_paths.current_directory'),
             'env' => $env,
         ])->filter(fn ($value): bool => ! in_array($value, [[], null, ''], true))
             ->toArray();

--- a/tests/Unit/Install/Agents/CodexTest.php
+++ b/tests/Unit/Install/Agents/CodexTest.php
@@ -47,14 +47,14 @@ test('returns correct MCP config key', function (): void {
     expect($codex->mcpConfigKey())->toBe('mcp_servers');
 });
 
-test('builds MCP server config with cwd field', function (): void {
+test('builds MCP server config without cwd by default', function (): void {
     $codex = new Codex($this->strategyFactory);
 
     $config = $codex->mcpServerConfig('php', ['artisan', 'boost:mcp']);
 
     expect($config)->toHaveKey('command', 'php')
         ->toHaveKey('args', ['artisan', 'boost:mcp'])
-        ->toHaveKey('cwd', base_path());
+        ->not->toHaveKey('cwd');
 });
 
 test('builds MCP server config with config "boost.executable_paths.current_directory" override', function (): void {
@@ -76,7 +76,7 @@ test('builds MCP server config with env when provided', function (): void {
 
     expect($config)->toHaveKey('command', 'php')
         ->toHaveKey('args', ['artisan'])
-        ->toHaveKey('cwd')
+        ->not->toHaveKey('cwd')
         ->toHaveKey('env', ['APP_ENV' => 'local']);
 });
 
@@ -86,7 +86,7 @@ test('filters empty values from server config', function (): void {
     $config = $codex->mcpServerConfig('php', [], []);
 
     expect($config)->toHaveKey('command', 'php')
-        ->toHaveKey('cwd')
+        ->not->toHaveKey('cwd')
         ->not->toHaveKey('args')
         ->not->toHaveKey('env');
 });
@@ -170,5 +170,5 @@ test('installMcp creates TOML config file', function (): void {
         ->and($capturedContent)->toContain('[mcp_servers.laravel_boost]')
         ->and($capturedContent)->toContain('command = "php"')
         ->and($capturedContent)->toContain('args = ["artisan", "boost:mcp"]')
-        ->and($capturedContent)->toContain('cwd = ');
+        ->and($capturedContent)->not->toContain('cwd = ');
 });


### PR DESCRIPTION
Currently `boost:install` writes `cwd = base_path()` into `.codex/config.toml`. This breaks two real scenarios reported in #786:

- **Sail.** When install runs inside the container, `base_path()` resolves to the Docker-internal path (e.g. `/var/www/html`), but Codex CLI runs on the host. MCP fails with `No such file or directory`.
- **Worktrees.** `.codex/config.toml` is meant to be a committed project config, but the absolute `cwd` differs per worktree, so every Codex worktree dirties git.

The base `Agent::mcpServerConfig()` doesn't include `cwd`, which is why Claude Code's `.mcp.json` was never affected. Codex resolves an omitted `cwd` to the directory containing `config.toml` (the project root), which is exactly what we want.

This PR drops the `base_path()` fallback from both the config default and the Codex agent, so `cwd` is only written when a user explicitly sets `BOOST_CURRENT_DIRECTORY_EXECUTABLE_PATH`. The escape hatch stays; the silent footgun goes.

Fixes #786.