### PR TITLE
Filter roster to direct requirements only

### DIFF
--- a/.ai/foundation.blade.php
+++ b/.ai/foundation.blade.php
@@ -9,7 +9,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
 - php - {{ PHP_MAJOR_VERSION }}.{{ PHP_MINOR_VERSION }}
-@foreach (app(\Laravel\Roster\Roster::class)->packages()->unique(fn ($package) => $package->rawName()) as $package)
+@foreach ($assist->getGuidelinePackages()->unique(fn ($package) => $package->rawName()) as $package)
 - {{ $package->rawName() }} ({{ $package->name() }}) - v{{ $package->majorVersion() }}
 @endforeach
 

--- a/src/Install/Concerns/DiscoverPackagePaths.php
+++ b/src/Install/Concerns/DiscoverPackagePaths.php
@@ -22,6 +22,8 @@ trait DiscoverPackagePaths
     protected array $mustBeDirect = [
         Packages::MCP,
         Packages::LIVEWIRE,
+        Packages::PINT,
+        Packages::PROMPTS,
     ];
 
     /**

--- a/src/Install/GuidelineAssist.php
+++ b/src/Install/GuidelineAssist.php
@@ -7,13 +7,18 @@ namespace Laravel\Boost\Install;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Laravel\Boost\Install\Assists\Inertia;
+use Laravel\Boost\Install\Concerns\DiscoverPackagePaths;
 use Laravel\Roster\Enums\NodePackageManager;
 use Laravel\Roster\Enums\Packages;
+use Laravel\Roster\Package;
+use Laravel\Roster\PackageCollection;
 use Laravel\Roster\Roster;
 use Symfony\Component\Finder\Finder;
 
 class GuidelineAssist
 {
+    use DiscoverPackagePaths;
+
     /** @var array<string, string> */
     protected array $enumPaths = [];
 
@@ -21,6 +26,17 @@ class GuidelineAssist
     {
         $this->skills ??= collect();
         $this->enumPaths = $this->discover();
+    }
+
+    protected function getRoster(): Roster
+    {
+        return $this->roster;
+    }
+
+    public function getGuidelinePackages(): PackageCollection
+    {
+        return $this->getRoster()->packages()
+            ->reject(fn (Package $package): bool => $this->shouldExcludePackage($package));
     }
 
     /**


### PR DESCRIPTION
Boost uses Laravel Roster to determine which packages are installed in the current environment, and uses the results to add guidelines, offer MCP tools, and search documentation. However, it includes indirect packages in the results. I don't have Pint installed in my environment, but Pint keeps showing up in my guidelines because other Laravel packages require it. This PR filters out indirect packages when checking the current Laravel environment.