### PR TITLE
Add tinker tool option to config

### DIFF
--- a/config/boost.php
+++ b/config/boost.php
@@ -36,7 +36,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | The following option may be used to enable or disable the tinker tool MCP
-    | feature within Laravel Boost. The tinker tool can helps when there is
+    | feature within Laravel Boost. The tinker tool can help when there is a
     | need to execute PHP to debug code or query Eloquent models directly.
     |
     */

--- a/config/boost.php
+++ b/config/boost.php
@@ -32,6 +32,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Boost Tinker Tool (MCP)
+    |--------------------------------------------------------------------------
+    |
+    | The following option may be used to enable or disable the tinker tool MCP
+    | feature within Laravel Boost. The tinker tool can helps when there is
+    | need to execute PHP to debug code or query Eloquent models directly.
+    |
+    */
+
+    'tinker_tool_enabled' => env('BOOST_TINKER_TOOL_ENABLED', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Boost Executables Paths
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
This is to add the configurable option brought back in https://github.com/laravel/boost/pull/807 to the config array that is currently published when users run the `vendor:publish` command, i.e.

```sh
user@home /project % php artisan vendor:publish --tag boost-config

   INFO  Publishing [boost-config] assets.  

  Copying file [vendor/laravel/boost/config/boost.php] to [config/boost.php] ........................................................ DONE
```

## Considerations
- Default to false, maintaining opt-in
- Give brief explainer of benefits

I thought it was good that this feature was brought back in as I've experienced many of the issue discussed in the linked PRs comments and linked issue, but I can appreciate the decision that lead to it's removal in the first place. It being configurable but defaulting to disabled is a perfectly acceptable middle ground, and having it included in the publishable config options gives it a little more visibility.