### PR TITLE
Add optional Streamable HTTP MCP transport (disabled by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,57 @@ Laravel Boost accelerates AI-assisted development by providing the essential con
 
 Documentation for Laravel Boost can be found on the [Laravel website](https://laravel.com/docs/boost).
 
+## Optional Streamable HTTP MCP Transport
+
+By default, Laravel Boost exposes its MCP server over **stdio** via the `php artisan boost:mcp` command. This is the recommended transport for most local setups and remains unchanged.
+
+Some MCP clients do not keep stdio servers alive reliably and may appear to "disconnect" Boost after periods of inactivity. For those clients, Boost can also expose the same MCP server over HTTP (Streamable HTTP) using `laravel/mcp`'s web transport.
+
+The HTTP transport is **disabled by default**.
+
+### Enabling
+
+Publish the Boost config (if you have not already) and set the env vars:
+
+```env
+BOOST_MCP_WEB_ENABLED=true
+BOOST_MCP_WEB_PATH=/_boost/mcp
+```
+
+Then serve the application normally with your usual local web stack (Herd, Valet, Sail, `nginx`/`php-fpm`, or `php artisan serve`). The MCP client should be pointed at the application URL plus the configured path, for example:
+
+```
+http://my-app.test/_boost/mcp
+```
+
+### Configuration
+
+The full config block (in `config/boost.php`) looks like:
+
+```php
+'mcp' => [
+    'web' => [
+        'enabled'    => env('BOOST_MCP_WEB_ENABLED', false),
+        'path'       => env('BOOST_MCP_WEB_PATH', '/_boost/mcp'),
+        'middleware' => [],
+    ],
+],
+```
+
+You may attach project-appropriate middleware to the HTTP MCP route, for example:
+
+```php
+'middleware' => ['auth:sanctum'],
+```
+
+The stdio transport is unaffected by this setting and continues to work as before.
+
+### Security
+
+> **Warning** Laravel Boost exposes development tooling that can inspect your application, database, logs, routes, configuration, and other sensitive local development information. Do **not** expose the HTTP MCP endpoint on a public network without authentication and network-level protections.
+
+The HTTP transport is intended for trusted local development environments. If you must expose it beyond your local machine, protect it with appropriate middleware (such as `auth:sanctum`) and network-level controls. Do not enable it in production.
+
 ## Contributing
 
 Thank you for considering contributing to Boost! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).

--- a/config/boost.php
+++ b/config/boost.php
@@ -49,4 +49,44 @@ return [
         'current_directory' => env('BOOST_CURRENT_DIRECTORY_EXECUTABLE_PATH'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Boost MCP Transports
+    |--------------------------------------------------------------------------
+    |
+    | Boost registers a stdio (local) MCP server by default, exposed through
+    | the `php artisan boost:mcp` command. Some MCP clients do not keep
+    | stdio servers alive reliably, so Boost may also expose its MCP server
+    | over HTTP (Streamable HTTP) using laravel/mcp's web transport.
+    |
+    | The HTTP transport is disabled by default. Enabling it exposes Boost's
+    | development tooling (database access, log access, route inspection,
+    | tinker, etc.) over an HTTP endpoint, so it should only be enabled in
+    | trusted local development environments and ideally protected with
+    | application middleware (for example `auth:sanctum`) when reachable
+    | over a network.
+    |
+    */
+
+    'mcp' => [
+
+        'web' => [
+
+            'enabled' => env('BOOST_MCP_WEB_ENABLED', false),
+
+            'path' => env('BOOST_MCP_WEB_PATH', '/_boost/mcp'),
+
+            /*
+            | Middleware applied to the HTTP MCP route. Leave empty to inherit
+            | only the middleware that laravel/mcp applies internally. Add
+            | application-appropriate middleware (e.g. `auth:sanctum`) when
+            | exposing the endpoint outside of a trusted local environment.
+            */
+
+            'middleware' => [],
+
+        ],
+
+    ],
+
 ];

--- a/src/BoostServiceProvider.php
+++ b/src/BoostServiceProvider.php
@@ -53,6 +53,8 @@ class BoostServiceProvider extends ServiceProvider
 
         Mcp::local('laravel-boost', Boost::class);
 
+        $this->registerWebMcp();
+
         $this->registerPublishing();
         $this->registerCommands();
         $this->registerRoutes();
@@ -70,6 +72,27 @@ class BoostServiceProvider extends ServiceProvider
             $this->publishes([
                 __DIR__.'/../config/boost.php' => config_path('boost.php'),
             ], 'boost-config');
+        }
+    }
+
+    protected function registerWebMcp(): void
+    {
+        if (! config('boost.mcp.web.enabled', false)) {
+            return;
+        }
+
+        $path = config('boost.mcp.web.path', '/_boost/mcp');
+
+        if (! is_string($path) || $path === '') {
+            return;
+        }
+
+        $route = Mcp::web($path, Boost::class);
+
+        $middleware = config('boost.mcp.web.middleware', []);
+
+        if (is_array($middleware) && $middleware !== []) {
+            $route->middleware($middleware);
         }
     }
 

--- a/src/Mcp/ToolExecutor.php
+++ b/src/Mcp/ToolExecutor.php
@@ -7,10 +7,13 @@ namespace Laravel\Boost\Mcp;
 use Dotenv\Dotenv;
 use Illuminate\Support\Env;
 use Laravel\Boost\Support\CommandNormalizer;
+use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Process;
+use Throwable;
 
 class ToolExecutor
 {
@@ -20,7 +23,43 @@ class ToolExecutor
             return Response::error("Tool not registered or not allowed: {$toolClass}");
         }
 
+        // When Boost is being served over HTTP (PHP-FPM, CGI, php artisan serve),
+        // PHP_BINARY does not point at a CLI php that can run artisan, and each
+        // HTTP request is already its own isolated PHP process. Execute the
+        // tool inline rather than spawning a subprocess.
+        if (! $this->shouldRunInSubprocess()) {
+            return $this->executeInline($toolClass, $arguments);
+        }
+
         return $this->executeInSubprocess($toolClass, $arguments);
+    }
+
+    protected function shouldRunInSubprocess(): bool
+    {
+        return PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg';
+    }
+
+    protected function executeInline(string $toolClass, array $arguments): Response
+    {
+        /** @var Tool $tool */
+        $tool = app($toolClass);
+
+        $request = new Request($arguments);
+
+        ob_start();
+
+        try {
+            /** @var Response $response */
+            $response = $tool->handle($request); // @phpstan-ignore-line
+        } catch (Throwable $throwable) {
+            ob_end_clean();
+
+            return Response::error("Tool execution failed (E_THROWABLE): {$throwable->getMessage()}");
+        }
+
+        ob_end_clean();
+
+        return $response;
     }
 
     protected function executeInSubprocess(string $toolClass, array $arguments): Response

--- a/tests/Feature/Mcp/ToolExecutorInlineTest.php
+++ b/tests/Feature/Mcp/ToolExecutorInlineTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Mcp\ToolExecutor;
+use Laravel\Boost\Mcp\ToolRegistry;
+use Laravel\Boost\Mcp\Tools\DatabaseConnections;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Mockery\MockInterface;
+
+test('inline executor path resolves a registered tool without spawning a subprocess', function (): void {
+    /** @var ToolExecutor&MockInterface $executor */
+    $executor = Mockery::mock(ToolExecutor::class)->makePartial()
+        ->shouldAllowMockingProtectedMethods();
+
+    // Force the HTTP/non-CLI branch.
+    $executor->shouldReceive('shouldRunInSubprocess')->andReturnFalse();
+
+    // Subprocess builder must NOT be invoked under the HTTP path.
+    $executor->shouldNotReceive('buildCommand');
+    $executor->shouldNotReceive('executeInSubprocess');
+
+    $response = $executor->execute(DatabaseConnections::class, []);
+
+    expect($response)->toBeInstanceOf(Response::class)
+        ->and($response->isError())->toBeFalse();
+
+    $text = (string) $response->content();
+    expect($text)->toContain('connections');
+});
+
+test('inline executor still rejects unregistered tools', function (): void {
+    /** @var ToolExecutor&MockInterface $executor */
+    $executor = Mockery::mock(ToolExecutor::class)->makePartial()
+        ->shouldAllowMockingProtectedMethods();
+
+    $executor->shouldReceive('shouldRunInSubprocess')->andReturnFalse();
+
+    $response = $executor->execute('NonExistentToolClass');
+
+    expect($response)->toBeInstanceOf(Response::class)
+        ->and($response->isError())->toBeTrue();
+});
+
+test('inline executor wraps thrown exceptions as error responses', function (): void {
+    $throwingTool = new class extends Tool
+    {
+        public function handle(Request $request): Response
+        {
+            throw new RuntimeException('boom inline');
+        }
+    };
+
+    $toolClass = $throwingTool::class;
+
+    // Bypass registry by binding the class as allowed.
+    ToolRegistry::clearCache();
+    app()->instance($toolClass, $throwingTool);
+
+    /** @var ToolExecutor&MockInterface $executor */
+    $executor = Mockery::mock(ToolExecutor::class)->makePartial()
+        ->shouldAllowMockingProtectedMethods();
+
+    $executor->shouldReceive('shouldRunInSubprocess')->andReturnFalse();
+
+    // Bypass the registry guard by calling the inline path directly via reflection.
+    $reflection = new ReflectionClass(ToolExecutor::class);
+    $method = $reflection->getMethod('executeInline');
+
+    $response = $method->invoke($executor, $toolClass, []);
+
+    expect($response->isError())->toBeTrue()
+        ->and((string) $response->content())->toContain('boom inline');
+});
+
+test('shouldRunInSubprocess returns true under CLI SAPI', function (): void {
+    $executor = new ToolExecutor;
+
+    $reflection = new ReflectionClass($executor);
+    $method = $reflection->getMethod('shouldRunInSubprocess');
+
+    // The Pest runner is itself CLI, so the real check should reflect that.
+    expect($method->invoke($executor))->toBe(PHP_SAPI === 'cli' || PHP_SAPI === 'phpdbg');
+});

--- a/tests/Feature/Mcp/WebMcpTest.php
+++ b/tests/Feature/Mcp/WebMcpTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route as Router;
+use Laravel\Boost\BoostServiceProvider;
+use Laravel\Boost\Mcp\Boost;
+use Laravel\Mcp\Facades\Mcp;
+
+function bootBoost(): void
+{
+    app()->detectEnvironment(fn (): string => 'local');
+
+    $provider = new BoostServiceProvider(app());
+    $provider->register();
+    $provider->boot(app('router'));
+}
+
+function findRouteByUri(string $uri): ?Route
+{
+    foreach (Router::getRoutes()->getRoutes() as $route) {
+        if ($route->uri() === ltrim($uri, '/')) {
+            return $route;
+        }
+    }
+
+    return null;
+}
+
+beforeEach(function (): void {
+    $this->refreshApplication();
+    Config::set('logging.channels.browser');
+    Config::set('boost.enabled', true);
+});
+
+describe('web MCP registration', function (): void {
+    it('does not register the web MCP route by default', function (): void {
+        bootBoost();
+
+        expect(Mcp::getWebServer('_boost/mcp'))->toBeNull()
+            ->and(findRouteByUri('_boost/mcp'))->toBeNull();
+    });
+
+    it('does not register the web MCP route when explicitly disabled', function (): void {
+        Config::set('boost.mcp.web.enabled', false);
+        Config::set('boost.mcp.web.path', '/_boost/mcp');
+
+        bootBoost();
+
+        expect(Mcp::getWebServer('_boost/mcp'))->toBeNull();
+    });
+
+    it('registers the web MCP route when enabled', function (): void {
+        Config::set('boost.mcp.web.enabled', true);
+        Config::set('boost.mcp.web.path', '/_boost/mcp');
+
+        bootBoost();
+
+        $route = Mcp::getWebServer('_boost/mcp');
+
+        expect($route)->not->toBeNull()
+            ->and($route)->toBeInstanceOf(Route::class)
+            ->and(in_array('POST', $route->methods(), true))->toBeTrue();
+    });
+
+    it('respects a custom configured path', function (): void {
+        Config::set('boost.mcp.web.enabled', true);
+        Config::set('boost.mcp.web.path', '/custom/mcp-endpoint');
+
+        bootBoost();
+
+        expect(Mcp::getWebServer('custom/mcp-endpoint'))->not->toBeNull()
+            ->and(Mcp::getWebServer('_boost/mcp'))->toBeNull();
+    });
+
+    it('applies configured middleware to the route', function (): void {
+        Config::set('boost.mcp.web.enabled', true);
+        Config::set('boost.mcp.web.path', '/_boost/mcp');
+        Config::set('boost.mcp.web.middleware', ['auth:sanctum', 'throttle:mcp']);
+
+        bootBoost();
+
+        $route = Mcp::getWebServer('_boost/mcp');
+
+        expect($route)->not->toBeNull()
+            ->and($route->middleware())->toContain('auth:sanctum')
+            ->and($route->middleware())->toContain('throttle:mcp');
+    });
+
+    it('does not register the web route when boost itself is disabled', function (): void {
+        Config::set('boost.enabled', false);
+        Config::set('boost.mcp.web.enabled', true);
+        Config::set('boost.mcp.web.path', '/_boost/mcp');
+
+        bootBoost();
+
+        expect(Mcp::getWebServer('_boost/mcp'))->toBeNull();
+    });
+
+    it('keeps the local stdio MCP server registered alongside the web route', function (): void {
+        Config::set('boost.mcp.web.enabled', true);
+        Config::set('boost.mcp.web.path', '/_boost/mcp');
+
+        bootBoost();
+
+        expect(Mcp::getLocalServer('laravel-boost'))->not->toBeNull()
+            ->and(Mcp::getWebServer('_boost/mcp'))->not->toBeNull();
+    });
+
+    it('keeps the local stdio MCP server registered when web is disabled (default)', function (): void {
+        bootBoost();
+
+        expect(Mcp::getLocalServer('laravel-boost'))->not->toBeNull();
+    });
+
+    it('uses the Boost server class for the web route', function (): void {
+        Config::set('boost.mcp.web.enabled', true);
+        Config::set('boost.mcp.web.path', '/_boost/mcp');
+
+        bootBoost();
+
+        // Sanity check: the laravel/mcp registrar stored the route, and the
+        // Boost server class is the one Boost wires up.
+        expect(Boost::class)->toBeString()
+            ->and(Mcp::getWebServer('_boost/mcp'))->not->toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary

Adds an optional **Streamable HTTP** transport for Boost's MCP server, alongside the existing stdio transport. Stdio remains the default and recommended transport — nothing changes for current users.

The HTTP transport is **disabled by default** and must be opted into via config/env.

## Motivation

Some MCP clients do not keep stdio child processes alive reliably. After periods of inactivity they kill or lose the `boost:mcp` process and Boost appears disconnected until the client is restarted.

For those clients (and for setups where it is more convenient to point an MCP client at a long-running web server like Herd, Valet, Sail, nginx + PHP-FPM, or `php artisan serve`), Boost can now expose the same MCP server over HTTP using `laravel/mcp`'s built-in `Mcp::web(...)` transport.

## What changed

### Transport registration

- **`config/boost.php`** — New `mcp.web` block:
  ```php
  'mcp' => [
      'web' => [
          'enabled'    => env('BOOST_MCP_WEB_ENABLED', false),
          'path'       => env('BOOST_MCP_WEB_PATH', '/_boost/mcp'),
          'middleware' => [],
      ],
  ],
  ```
- **`src/BoostServiceProvider.php`** — `boot()` still calls `Mcp::local('laravel-boost', Boost::class)` exactly as before. A new `registerWebMcp()` method conditionally registers the HTTP route via `Mcp::web($path, Boost::class)` only when `boost.mcp.web.enabled` is `true`, applying configured middleware when non-empty.

### Tool execution under HTTP

- **`src/Mcp/ToolExecutor.php`** — When Boost is served over a non-CLI SAPI (PHP-FPM, CGI, `php artisan serve`), `ToolExecutor` now resolves and runs the tool **inline** instead of spawning `PHP_BINARY artisan boost:execute-tool ...`. Under HTTP, `PHP_BINARY` does not point at a CLI php that can register the `boost:` artisan namespace, so the previous subprocess approach failed with `There are no commands defined in the "boost" namespace.` and CGI headers polluting stdout.
  - New `shouldRunInSubprocess()` returns `true` only for `cli` / `phpdbg` SAPI.
  - New `executeInline($toolClass, $arguments)` resolves the tool from the container, invokes `$tool->handle($request)` directly, wraps `Throwable` as `Response::error(...)`, and `ob_*`-buffers stray stdout.
  - Subprocess execution path (used by stdio) is unchanged. Each HTTP request already runs in its own PHP-FPM worker, so subprocess-level isolation is not needed there.

### Tests

- **`tests/Feature/Mcp/WebMcpTest.php`** — covers:
  - default-disabled (no route registered)
  - explicit-disabled
  - enabled registers the route
  - custom path is respected
  - middleware is applied
  - boost-disabled short-circuits HTTP registration
  - stdio + HTTP coexist when HTTP is enabled
  - stdio remains registered when HTTP is disabled
- **`tests/Feature/Mcp/ToolExecutorInlineTest.php`** — covers:
  - non-CLI path resolves a real tool without invoking `buildCommand` / `executeInSubprocess`
  - non-CLI path still rejects unregistered tools
  - inline path wraps thrown exceptions as error responses
  - `shouldRunInSubprocess()` matches the current SAPI

### Docs

- **`README.md`** — new "Optional Streamable HTTP MCP Transport" section with enablement steps, configuration shape, sample MCP client URL, middleware example, and an explicit security warning.

## Usage

Stdio (unchanged, default):
```
php artisan boost:mcp
```

HTTP (opt-in):
```env
BOOST_MCP_WEB_ENABLED=true
BOOST_MCP_WEB_PATH=/_boost/mcp
```
Serve the app normally and point the MCP client at e.g. `http://my-app.test/_boost/mcp`.

Optional middleware:
```php
'middleware' => ['auth:sanctum'],
```

## Security

Boost exposes development tooling that can inspect the application, database, logs, routes, configuration, and other sensitive local-dev information. The HTTP endpoint is therefore **disabled by default** and the README clearly warns it should only be enabled in trusted local environments unless protected with authentication and network-level controls. No auth middleware is prescribed by default since the appropriate choice depends on the host application.

## Backward compatibility

- No change to default behavior.
- `Mcp::local('laravel-boost', Boost::class)` registration is untouched.
- `boost:mcp`, `mcp:start laravel-boost`, and `boost:execute-tool` all behave identically under CLI/stdio.
- HTTP route is only registered when explicitly opted in via config.
- All previously existing `ToolExecutor` tests (subprocess execution, isolation, autoload reload, timeout clamping, `buildCommand` behavior) still pass.

## Tests

- `pest tests/Feature/Mcp/ToolExecutorInlineTest.php tests/Feature/Mcp/ToolExecutorTest.php tests/Feature/Mcp/WebMcpTest.php tests/Feature/BoostServiceProviderTest.php` → **32 passed (66 assertions)**.
- Targeted: `WebMcpTest` 9/9, `ToolExecutorInlineTest` 4/4, `BoostServiceProviderTest` 9/9, `ToolExecutorTest` 10/10.
- Full suite (`pest`): 747 passed. The 5 unrelated failures on Windows (CRLF line-ending diff and `symlink(): Permission denied`) reproduce on `main` without these changes.

## Lint / Static analysis

- `phpstan analyse src` → no errors.
- `pint --format agent` applied to changed files.