### PR TITLE
Pin laravel/mcp below 0.7.1 to avoid breaking namespace renames

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/contracts": "^11.45.3|^12.41.1|^13.0",
         "illuminate/routing": "^11.45.3|^12.41.1|^13.0",
         "illuminate/support": "^11.45.3|^12.41.1|^13.0",
-        "laravel/mcp": "^0.5.1|^0.6.0|^0.7.0",
+        "laravel/mcp": "^0.5.1|^0.6.0|~0.7.0,<0.7.1",
         "laravel/prompts": "^0.3.10",
         "laravel/roster": "^0.5.0"
     },


### PR DESCRIPTION
Currently `composer.json` allows `laravel/mcp ^0.7.0`, which silently picks up v0.7.1 on `composer update`. That release renamed two namespaces:

- `Laravel\Mcp\Server\Transport\JsonRpcRequest` → `Laravel\Mcp\Transport\JsonRpcRequest`
- `Laravel\Mcp\Server\Transport\JsonRpcResponse` → `Laravel\Mcp\Transport\JsonRpcResponse`
- `Laravel\Mcp\Server\Exceptions\JsonRpcException` → `Laravel\Mcp\Exceptions\JsonRpcException`

`src/Server/Exceptions/` is removed entirely in v0.7.1; `src/Server/Transport/` keeps only the transport implementations.

Boost's `CallToolWithExecutor` still imports from the old paths, so anyone updating Boost 2.4.x hits a fatal at class load before the MCP server can boot:

```
Fatal error: Could not check compatibility between
  Laravel\Boost\Mcp\Methods\CallToolWithExecutor::handle(Laravel\Mcp\Server\Transport\JsonRpcRequest ...)
  and Laravel\Mcp\Server\Contracts\Method::handle(Laravel\Mcp\Transport\JsonRpcRequest ...),
because class Laravel\Mcp\Server\Transport\JsonRpcRequest is not available
```

Narrowing the constraint to `~0.7.0,<0.7.1` pins existing installs to v0.7.0 until a follow-up PR adopts v0.7.1+ with the actual code refactor.