### PR TITLE
Adopt laravel/mcp 0.7.1 namespace renames

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/contracts": "^11.45.3|^12.41.1|^13.0",
         "illuminate/routing": "^11.45.3|^12.41.1|^13.0",
         "illuminate/support": "^11.45.3|^12.41.1|^13.0",
-        "laravel/mcp": "^0.5.1|^0.6.0|~0.7.0,<0.7.1",
+        "laravel/mcp": "^0.7.1",
         "laravel/prompts": "^0.3.10",
         "laravel/roster": "^0.5.0"
     },

--- a/src/Mcp/Methods/CallToolWithExecutor.php
+++ b/src/Mcp/Methods/CallToolWithExecutor.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace Laravel\Boost\Mcp\Methods;
 
 use Laravel\Boost\Mcp\ToolExecutor;
+use Laravel\Mcp\Exceptions\JsonRpcException;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Contracts\Errable;
 use Laravel\Mcp\Server\Contracts\Method;
-use Laravel\Mcp\Server\Exceptions\JsonRpcException;
 use Laravel\Mcp\Server\Methods\Concerns\InteractsWithResponses;
 use Laravel\Mcp\Server\ServerContext;
-use Laravel\Mcp\Server\Transport\JsonRpcRequest;
-use Laravel\Mcp\Server\Transport\JsonRpcResponse;
+use Laravel\Mcp\Transport\JsonRpcRequest;
+use Laravel\Mcp\Transport\JsonRpcResponse;
 use Throwable;
 
 class CallToolWithExecutor implements Errable, Method
@@ -27,7 +27,7 @@ class CallToolWithExecutor implements Errable, Method
     /**
      * Handle the JSON-RPC tool/call request with process isolation.
      */
-    public function handle(JsonRpcRequest $request, ServerContext $context): JsonRpcResponse
+    public function handle(JsonRpcRequest $request, ServerContext $context): iterable|JsonRpcResponse
     {
         if (is_null($request->get('name'))) {
             throw new JsonRpcException(

--- a/tests/Feature/Mcp/Methods/CallToolWithExecutorTest.php
+++ b/tests/Feature/Mcp/Methods/CallToolWithExecutorTest.php
@@ -3,18 +3,18 @@
 use Laravel\Boost\Mcp\Methods\CallToolWithExecutor;
 use Laravel\Boost\Mcp\ToolExecutor;
 use Laravel\Boost\Mcp\Tools\DatabaseConnections;
+use Laravel\Mcp\Exceptions\JsonRpcException;
 use Laravel\Mcp\Response;
-use Laravel\Mcp\Server\Exceptions\JsonRpcException;
+use Laravel\Mcp\Schema\Implementation;
 use Laravel\Mcp\Server\ServerContext;
-use Laravel\Mcp\Server\Transport\JsonRpcRequest;
+use Laravel\Mcp\Transport\JsonRpcRequest;
 
 function createServerContext(array $tools = []): ServerContext
 {
     return new ServerContext(
         supportedProtocolVersions: ['2025-01-01'],
         serverCapabilities: [],
-        serverName: 'test-server',
-        serverVersion: '1.0.0',
+        implementation: new Implementation('test-server', '1.0.0'),
         instructions: 'Test instructions',
         maxPaginationLength: 100,
         defaultPaginationLength: 50,


### PR DESCRIPTION
Follow-up to #815, which pinned to v0.7.0 to stop a fatal at class load. v0.7.1 moved `JsonRpcRequest`/`JsonRpcResponse`/`JsonRpcException` out of `Server\` and replaced `ServerContext::$serverName`/`$serverVersion` with an `Implementation` value object:

```php
// before
use Laravel\Mcp\Server\Transport\JsonRpcRequest;
new ServerContext(serverName: 'X', serverVersion: 'Y', ...);
```

```php
// after
use Laravel\Mcp\Transport\JsonRpcRequest;
new ServerContext(implementation: new Implementation('X', 'Y'), ...);
```

