### PR TITLE
Fix Inertia v3 layout props API name in upgrade prompt

### DIFF
--- a/src/Mcp/Prompts/UpgradeInertiav3/upgrade-inertia-v3.blade.php
+++ b/src/Mcp/Prompts/UpgradeInertiav3/upgrade-inertia-v3.blade.php
@@ -390,7 +390,7 @@ After completing the upgrade, the following new features are available. Do **not
 - **Standalone HTTP requests (`useHttp`)** - Make HTTP requests without triggering page visits. Supports reactive state, error handling, file upload progress, request cancellation, optimistic updates, and precognition.
 - **Optimistic updates** - Chain `router.optimistic()` before a visit to apply changes instantly on the client. Props revert automatically on failure. Works with router visits, `<Form>`, `useForm`, and `useHttp`.
 - **Instant visits** - Swap to the target page component immediately via `<Link href="/dashboard" component="Dashboard">` while the server request fires in the background.
-- **Layout props (`useLayoutProps`)** - Persistent layouts can declare defaults that pages override via `setLayoutProps()`. Supports named layouts, nested layouts, and static props.
+- **Layout props (`setLayoutProps`)** - Persistent layouts can declare defaults that pages override via `setLayoutProps()`. Supports named layouts, nested layouts, and static props.
 - **Exception handling (`handleExceptionsUsing`)** - Full control over error page rendering with access to shared data via `withSharedData()`.
 - **Default layout** - Set a default layout in `createInertiaApp()` instead of on every page.
 - **Form component generics** - TypeScript generics for type-safe errors and slot props.


### PR DESCRIPTION
The Inertia v3 upgrade prompt labels the layout-props feature as `useLayoutProps`, but `@inertiajs/vue3` v3 exports no such function. The actual API is `setLayoutProps` (and `resetLayoutProps`), per `@inertiajs/vue3/types/layoutProps.d.ts` and `index.d.ts`. The line's own description already references `setLayoutProps()` — this fixes the inconsistent label.