### PR TITLE
fix: detect all common Docker Compose filenames in Sail check

### DIFF
--- a/src/Install/Sail.php
+++ b/src/Install/Sail.php
@@ -45,8 +45,12 @@ class Sail
         $binaryPath = self::binaryPath();
         $resolvedPath = str_starts_with($binaryPath, DIRECTORY_SEPARATOR) ? $binaryPath : base_path($binaryPath);
 
-        return file_exists($resolvedPath) &&
-            (file_exists(base_path('docker-compose.yml')) || file_exists(base_path('compose.yaml')));
+        return file_exists($resolvedPath) && (
+            file_exists(base_path('compose.yml'))
+            || file_exists(base_path('compose.yaml'))
+            || file_exists(base_path('docker-compose.yml'))
+            || file_exists(base_path('docker-compose.yaml'))
+        );
     }
 
     public function isActive(): bool

--- a/tests/Unit/Install/SailTest.php
+++ b/tests/Unit/Install/SailTest.php
@@ -4,6 +4,58 @@ declare(strict_types=1);
 
 use Laravel\Boost\Install\Sail;
 
+$sailTestDirs = [];
+
+afterEach(function (): void {
+    global $sailTestDirs;
+
+    foreach ($sailTestDirs ?? [] as $dir) {
+        removeSailTestDirectory($dir);
+    }
+
+    $sailTestDirs = [];
+});
+
+function removeSailTestDirectory(string $dir): void
+{
+    if (! is_dir($dir)) {
+        return;
+    }
+
+    $files = array_diff(scandir($dir), ['.', '..']);
+
+    foreach ($files as $file) {
+        $path = $dir . DIRECTORY_SEPARATOR . $file;
+        is_dir($path) ? removeSailTestDirectory($path) : unlink($path);
+    }
+
+    rmdir($dir);
+}
+
+/**
+ * Create an isolated project directory, point the app base path at it and,
+ * optionally, place a fake Sail binary so isInstalled() can find it.
+ */
+function makeSailTestProject(bool $withBinary = true): string
+{
+    global $sailTestDirs;
+
+    $tempDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'boost_sail_' . uniqid();
+    mkdir($tempDir);
+    $sailTestDirs[] = $tempDir;
+
+    app()->setBasePath($tempDir);
+
+    $binary = $tempDir . DIRECTORY_SEPARATOR . 'sail';
+    config(['boost.executable_paths.sail' => $binary]);
+
+    if ($withBinary) {
+        touch($binary);
+    }
+
+    return $tempDir;
+}
+
 test('isActive returns true when LARAVEL_SAIL env var is set', function (): void {
     putenv('LARAVEL_SAIL=1');
 
@@ -69,4 +121,31 @@ test('sail binary path defaults to vendor/bin/sail', function (): void {
     config(['boost.executable_paths.sail' => null]);
 
     expect(Sail::binaryPath())->toBe('vendor'.DIRECTORY_SEPARATOR.'bin'.DIRECTORY_SEPARATOR.'sail');
+});
+
+test('isInstalled detects every Docker Compose filename supported by default', function (string $composeFile): void {
+    $tempDir = makeSailTestProject();
+
+    touch($tempDir.DIRECTORY_SEPARATOR.$composeFile);
+
+    expect((new Sail)->isInstalled())->toBeTrue();
+})->with([
+    'compose.yml',
+    'compose.yaml',
+    'docker-compose.yml',
+    'docker-compose.yaml',
+]);
+
+test('isInstalled returns false when no Docker Compose file is present', function (): void {
+    makeSailTestProject();
+
+    expect((new Sail)->isInstalled())->toBeFalse();
+});
+
+test('isInstalled returns false when the sail binary is missing', function (): void {
+    $tempDir = makeSailTestProject(withBinary: false);
+
+    touch($tempDir.DIRECTORY_SEPARATOR.'docker-compose.yml');
+
+    expect((new Sail)->isInstalled())->toBeFalse();
 });

--- a/tests/Unit/Install/SailTest.php
+++ b/tests/Unit/Install/SailTest.php
@@ -4,6 +4,42 @@ declare(strict_types=1);
 
 use Laravel\Boost\Install\Sail;
 
+$sailTempDir = null;
+
+beforeEach(function (): void {
+    global $sailTempDir;
+
+    $sailTempDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'boost_sail_'.uniqid();
+    mkdir($sailTempDir);
+    app()->setBasePath($sailTempDir);
+
+    $binary = $sailTempDir.DIRECTORY_SEPARATOR.'sail';
+    config(['boost.executable_paths.sail' => $binary]);
+    touch($binary);
+});
+
+afterEach(function (): void {
+    global $sailTempDir;
+
+    if (is_dir($sailTempDir)) {
+        removeSailTestDirectory($sailTempDir);
+    }
+
+    $sailTempDir = null;
+});
+
+function removeSailTestDirectory(string $dir): void
+{
+    $files = array_diff(scandir($dir), ['.', '..']);
+
+    foreach ($files as $file) {
+        $path = $dir.DIRECTORY_SEPARATOR.$file;
+        is_dir($path) ? removeSailTestDirectory($path) : unlink($path);
+    }
+
+    rmdir($dir);
+}
+
 test('isActive returns true when LARAVEL_SAIL env var is set', function (): void {
     putenv('LARAVEL_SAIL=1');
 
@@ -71,48 +107,29 @@ test('sail binary path defaults to vendor/bin/sail', function (): void {
     expect(Sail::binaryPath())->toBe('vendor'.DIRECTORY_SEPARATOR.'bin'.DIRECTORY_SEPARATOR.'sail');
 });
 
-describe('isInstalled', function (): void {
-    beforeEach(function (): void {
-        $this->tempDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'boost_sail_'.uniqid();
-        mkdir($this->tempDir);
-        app()->setBasePath($this->tempDir);
+test('isInstalled detects every Docker Compose filename supported by default', function (string $composeFile): void {
+    global $sailTempDir;
 
-        $this->binary = $this->tempDir.DIRECTORY_SEPARATOR.'sail';
-        config(['boost.executable_paths.sail' => $this->binary]);
-        touch($this->binary);
-    });
+    touch($sailTempDir.DIRECTORY_SEPARATOR.$composeFile);
 
-    afterEach(function (): void {
-        foreach (new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($this->tempDir, FilesystemIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::CHILD_FIRST
-        ) as $path) {
-            $path->isDir() ? rmdir($path->getPathname()) : unlink($path->getPathname());
-        }
+    expect((new Sail)->isInstalled())->toBeTrue();
+})->with([
+    'compose.yml',
+    'compose.yaml',
+    'docker-compose.yml',
+    'docker-compose.yaml',
+]);
 
-        rmdir($this->tempDir);
-    });
+test('isInstalled returns false when no Docker Compose file is present', function (): void {
+    expect((new Sail)->isInstalled())->toBeFalse();
+});
 
-    test('detects every Docker Compose filename supported by default', function (string $composeFile): void {
-        touch($this->tempDir.DIRECTORY_SEPARATOR.$composeFile);
+test('isInstalled returns false when the sail binary is missing', function (): void {
+    global $sailTempDir;
 
-        expect((new Sail)->isInstalled())->toBeTrue();
-    })->with([
-        'compose.yml',
-        'compose.yaml',
-        'docker-compose.yml',
-        'docker-compose.yaml',
-    ]);
+    unlink($sailTempDir.DIRECTORY_SEPARATOR.'sail');
 
-    test('returns false when no Docker Compose file is present', function (): void {
-        expect((new Sail)->isInstalled())->toBeFalse();
-    });
+    touch($sailTempDir.DIRECTORY_SEPARATOR.'docker-compose.yml');
 
-    test('returns false when the sail binary is missing', function (): void {
-        unlink($this->binary);
-
-        touch($this->tempDir.DIRECTORY_SEPARATOR.'docker-compose.yml');
-
-        expect((new Sail)->isInstalled())->toBeFalse();
-    });
+    expect((new Sail)->isInstalled())->toBeFalse();
 });

--- a/tests/Unit/Install/SailTest.php
+++ b/tests/Unit/Install/SailTest.php
@@ -4,58 +4,6 @@ declare(strict_types=1);
 
 use Laravel\Boost\Install\Sail;
 
-$sailTestDirs = [];
-
-afterEach(function (): void {
-    global $sailTestDirs;
-
-    foreach ($sailTestDirs ?? [] as $dir) {
-        removeSailTestDirectory($dir);
-    }
-
-    $sailTestDirs = [];
-});
-
-function removeSailTestDirectory(string $dir): void
-{
-    if (! is_dir($dir)) {
-        return;
-    }
-
-    $files = array_diff(scandir($dir), ['.', '..']);
-
-    foreach ($files as $file) {
-        $path = $dir . DIRECTORY_SEPARATOR . $file;
-        is_dir($path) ? removeSailTestDirectory($path) : unlink($path);
-    }
-
-    rmdir($dir);
-}
-
-/**
- * Create an isolated project directory, point the app base path at it and,
- * optionally, place a fake Sail binary so isInstalled() can find it.
- */
-function makeSailTestProject(bool $withBinary = true): string
-{
-    global $sailTestDirs;
-
-    $tempDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'boost_sail_' . uniqid();
-    mkdir($tempDir);
-    $sailTestDirs[] = $tempDir;
-
-    app()->setBasePath($tempDir);
-
-    $binary = $tempDir . DIRECTORY_SEPARATOR . 'sail';
-    config(['boost.executable_paths.sail' => $binary]);
-
-    if ($withBinary) {
-        touch($binary);
-    }
-
-    return $tempDir;
-}
-
 test('isActive returns true when LARAVEL_SAIL env var is set', function (): void {
     putenv('LARAVEL_SAIL=1');
 
@@ -123,29 +71,48 @@ test('sail binary path defaults to vendor/bin/sail', function (): void {
     expect(Sail::binaryPath())->toBe('vendor'.DIRECTORY_SEPARATOR.'bin'.DIRECTORY_SEPARATOR.'sail');
 });
 
-test('isInstalled detects every Docker Compose filename supported by default', function (string $composeFile): void {
-    $tempDir = makeSailTestProject();
+describe('isInstalled', function (): void {
+    beforeEach(function (): void {
+        $this->tempDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'boost_sail_'.uniqid();
+        mkdir($this->tempDir);
+        app()->setBasePath($this->tempDir);
 
-    touch($tempDir.DIRECTORY_SEPARATOR.$composeFile);
+        $this->binary = $this->tempDir.DIRECTORY_SEPARATOR.'sail';
+        config(['boost.executable_paths.sail' => $this->binary]);
+        touch($this->binary);
+    });
 
-    expect((new Sail)->isInstalled())->toBeTrue();
-})->with([
-    'compose.yml',
-    'compose.yaml',
-    'docker-compose.yml',
-    'docker-compose.yaml',
-]);
+    afterEach(function (): void {
+        foreach (new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($this->tempDir, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        ) as $path) {
+            $path->isDir() ? rmdir($path->getPathname()) : unlink($path->getPathname());
+        }
 
-test('isInstalled returns false when no Docker Compose file is present', function (): void {
-    makeSailTestProject();
+        rmdir($this->tempDir);
+    });
 
-    expect((new Sail)->isInstalled())->toBeFalse();
-});
+    test('detects every Docker Compose filename supported by default', function (string $composeFile): void {
+        touch($this->tempDir.DIRECTORY_SEPARATOR.$composeFile);
 
-test('isInstalled returns false when the sail binary is missing', function (): void {
-    $tempDir = makeSailTestProject(withBinary: false);
+        expect((new Sail)->isInstalled())->toBeTrue();
+    })->with([
+        'compose.yml',
+        'compose.yaml',
+        'docker-compose.yml',
+        'docker-compose.yaml',
+    ]);
 
-    touch($tempDir.DIRECTORY_SEPARATOR.'docker-compose.yml');
+    test('returns false when no Docker Compose file is present', function (): void {
+        expect((new Sail)->isInstalled())->toBeFalse();
+    });
 
-    expect((new Sail)->isInstalled())->toBeFalse();
+    test('returns false when the sail binary is missing', function (): void {
+        unlink($this->binary);
+
+        touch($this->tempDir.DIRECTORY_SEPARATOR.'docker-compose.yml');
+
+        expect((new Sail)->isInstalled())->toBeFalse();
+    });
 });


### PR DESCRIPTION
## Summary

`Sail::isInstalled()` only recognized two Docker Compose filenames when deciding whether Sail is installed:

- `docker-compose.yml`
- `compose.yaml`

this meant the other two filenames that [Docker Compose officially supports](https://docs.docker.com/compose/intro/compose-application-model/#the-compose-file) were missed:

- `compose.yml`
- `docker-compose.yaml`

As a result, projects using one of those two valid filenames were incorrectly treated as not having Sail installed, even with the Sail binary present in `vendor/bin`

This PR updates the check to recognize all four filenames that Docker Compose looks for by default

## Why

Sail detection should match Docker's behavior - the filename a project happens to use shouldn't change whether Boost detects Sail.

 ## Behavior

Before `isInstalled()` returned `true` only when the binary existed **and** either `docker-compose.yml` or `compose.yaml` was present.

After, it returns `true` when the binary exists **and** any of the four supported filenames (listed above) is present.

The single call site is `src/Console/InstallCommand.php:251`, where the result populates the `available` flag for the Sail integration. Integrations are then filtered to only the available ones before being shown in the install prompt - so previously, projects using `compose.yml` or `docker-compose.yaml` weren't even offered the Sail option. With this change they are.

## Tests

Added coverage in `tests/Unit/Install/SailTest.php` for `isInstalled()`: a data-driven test asserting detection of all four supported filenames. I've also added cases for a missing compose file and a missing binary.

## Breaking changes

None. The change is purely additive - every case that returned `true` before still does. Selecting Sail in the install prompt remains opt-in.