### PR TITLE
Add Factory Droid agent

### DIFF
--- a/src/BoostManager.php
+++ b/src/BoostManager.php
@@ -12,6 +12,7 @@ use Laravel\Boost\Install\Agents\ClaudeCode;
 use Laravel\Boost\Install\Agents\Codex;
 use Laravel\Boost\Install\Agents\Copilot;
 use Laravel\Boost\Install\Agents\Cursor;
+use Laravel\Boost\Install\Agents\Factory;
 use Laravel\Boost\Install\Agents\Gemini;
 use Laravel\Boost\Install\Agents\Junie;
 use Laravel\Boost\Install\Agents\Kiro;
@@ -27,6 +28,7 @@ class BoostManager
         'claude_code' => ClaudeCode::class,
         'codex' => Codex::class,
         'copilot' => Copilot::class,
+        'factory' => Factory::class,
         'kiro' => Kiro::class,
         'opencode' => OpenCode::class,
         'gemini' => Gemini::class,

--- a/src/Install/Agents/Factory.php
+++ b/src/Install/Agents/Factory.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install\Agents;
+
+use Laravel\Boost\Contracts\SupportsGuidelines;
+use Laravel\Boost\Contracts\SupportsMcp;
+use Laravel\Boost\Contracts\SupportsSkills;
+use Laravel\Boost\Install\Enums\Platform;
+
+class Factory extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSkills
+{
+    public function name(): string
+    {
+        return 'factory';
+    }
+
+    public function displayName(): string
+    {
+        return 'Factory Droid';
+    }
+
+    public function systemDetectionConfig(Platform $platform): array
+    {
+        return match ($platform) {
+            Platform::Darwin, Platform::Linux => [
+                'command' => 'command -v droid',
+                'paths' => ['~/.factory'],
+            ],
+            Platform::Windows => [
+                'command' => 'cmd /c where droid 2>nul',
+                'paths' => ['%USERPROFILE%\\.factory'],
+            ],
+        };
+    }
+
+    public function projectDetectionConfig(): array
+    {
+        return [
+            'paths' => ['.factory'],
+        ];
+    }
+
+    public function mcpConfigPath(): string
+    {
+        return config('boost.agents.factory.mcp_config_path', '.factory/mcp.json');
+    }
+
+    /** {@inheritDoc} */
+    public function mcpServerConfig(string $command, array $args = [], array $env = []): array
+    {
+        return collect([
+            'type' => 'stdio',
+            'command' => $command,
+            'args' => $args,
+            'env' => $env,
+        ])->filter(fn ($value): bool => ! in_array($value, [[], null, ''], true))
+            ->toArray();
+    }
+
+    public function guidelinesPath(): string
+    {
+        return config('boost.agents.factory.guidelines_path', 'AGENTS.md');
+    }
+
+    public function skillsPath(): string
+    {
+        return config('boost.agents.factory.skills_path', '.factory/skills');
+    }
+}

--- a/tests/Unit/BoostManagerTest.php
+++ b/tests/Unit/BoostManagerTest.php
@@ -9,8 +9,10 @@ use Laravel\Boost\Install\Agents\ClaudeCode;
 use Laravel\Boost\Install\Agents\Codex;
 use Laravel\Boost\Install\Agents\Copilot;
 use Laravel\Boost\Install\Agents\Cursor;
+use Laravel\Boost\Install\Agents\Factory;
 use Laravel\Boost\Install\Agents\Gemini;
 use Laravel\Boost\Install\Agents\Junie;
+use Laravel\Boost\Install\Agents\Kiro;
 use Laravel\Boost\Install\Agents\OpenCode;
 use Tests\Unit\Install\ExampleAgent;
 
@@ -25,6 +27,8 @@ it('returns default agents', function (): void {
         'claude_code' => ClaudeCode::class,
         'codex' => Codex::class,
         'copilot' => Copilot::class,
+        'factory' => Factory::class,
+        'kiro' => Kiro::class,
         'opencode' => OpenCode::class,
         'gemini' => Gemini::class,
         'antigravity' => Antigravity::class,

--- a/tests/Unit/Install/Agents/FactoryTest.php
+++ b/tests/Unit/Install/Agents/FactoryTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Install\Agents;
+
+use Illuminate\Support\Facades\File;
+use Laravel\Boost\Install\Agents\Factory;
+use Laravel\Boost\Install\Detection\DetectionStrategyFactory;
+use Laravel\Boost\Install\Enums\Platform;
+use Mockery;
+
+beforeEach(function (): void {
+    $this->strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
+});
+
+test('name returns factory', function (): void {
+    $agent = new Factory($this->strategyFactory);
+
+    expect($agent->name())->toBe('factory');
+});
+
+test('displayName returns Factory Droid', function (): void {
+    $agent = new Factory($this->strategyFactory);
+
+    expect($agent->displayName())->toBe('Factory Droid');
+});
+
+test('guidelinesPath returns AGENTS.md by default', function (): void {
+    $agent = new Factory($this->strategyFactory);
+
+    expect($agent->guidelinesPath())->toBe('AGENTS.md');
+});
+
+test('skillsPath returns .factory/skills by default', function (): void {
+    $agent = new Factory($this->strategyFactory);
+
+    expect($agent->skillsPath())->toBe('.factory/skills');
+});
+
+test('mcpConfigPath returns .factory/mcp.json by default', function (): void {
+    $agent = new Factory($this->strategyFactory);
+
+    expect($agent->mcpConfigPath())->toBe('.factory/mcp.json');
+});
+
+test('projectDetectionConfig detects via .factory directory', function (): void {
+    $agent = new Factory($this->strategyFactory);
+
+    expect($agent->projectDetectionConfig())->toBe([
+        'paths' => ['.factory'],
+    ]);
+});
+
+test('systemDetectionConfig detects droid on macOS and linux', function (Platform $platform): void {
+    $agent = new Factory($this->strategyFactory);
+
+    expect($agent->systemDetectionConfig($platform))->toBe([
+        'command' => 'command -v droid',
+        'paths' => ['~/.factory'],
+    ]);
+})->with([Platform::Darwin, Platform::Linux]);
+
+test('systemDetectionConfig detects droid on windows', function (): void {
+    $agent = new Factory($this->strategyFactory);
+
+    expect($agent->systemDetectionConfig(Platform::Windows))->toBe([
+        'command' => 'cmd /c where droid 2>nul',
+        'paths' => ['%USERPROFILE%\\.factory'],
+    ]);
+});
+
+test('mcpServerConfig returns factory stdio config', function (): void {
+    $agent = new Factory($this->strategyFactory);
+
+    expect($agent->mcpServerConfig('php', ['artisan', 'boost:mcp']))->toBe([
+        'type' => 'stdio',
+        'command' => 'php',
+        'args' => ['artisan', 'boost:mcp'],
+    ]);
+});
+
+test('mcpServerConfig includes environment variables', function (): void {
+    $agent = new Factory($this->strategyFactory);
+
+    expect($agent->mcpServerConfig('herd', ['php', '/path/to/mcp'], ['SITE_PATH' => '/project']))->toBe([
+        'type' => 'stdio',
+        'command' => 'herd',
+        'args' => ['php', '/path/to/mcp'],
+        'env' => ['SITE_PATH' => '/project'],
+    ]);
+});
+
+test('httpMcpServerConfig returns default http config', function (): void {
+    $agent = new Factory($this->strategyFactory);
+
+    expect($agent->httpMcpServerConfig('https://nightwatch.laravel.com/mcp'))->toBe([
+        'type' => 'http',
+        'url' => 'https://nightwatch.laravel.com/mcp',
+    ]);
+});
+
+test('installMcp writes factory project mcp config', function (): void {
+    $mcpPath = '.factory/mcp.json';
+
+    File::shouldReceive('ensureDirectoryExists')
+        ->once()
+        ->with(dirname($mcpPath));
+
+    File::shouldReceive('exists')
+        ->once()
+        ->with($mcpPath)
+        ->andReturn(false);
+
+    File::shouldReceive('put')
+        ->once()
+        ->withArgs(function (string $path, string $content) use ($mcpPath): bool {
+            if ($path !== $mcpPath) {
+                return false;
+            }
+
+            $decoded = json_decode($content, true);
+
+            return isset($decoded['mcpServers']['laravel-boost'])
+                && $decoded['mcpServers']['laravel-boost']['type'] === 'stdio'
+                && $decoded['mcpServers']['laravel-boost']['command'] === 'php'
+                && $decoded['mcpServers']['laravel-boost']['args'] === ['artisan', 'boost:mcp']
+                && ! isset($decoded['mcpServers']['laravel-boost']['env']);
+        })
+        ->andReturn(true);
+
+    $agent = new Factory($this->strategyFactory);
+
+    expect($agent->installMcp('laravel-boost', 'php', ['artisan', 'boost:mcp']))->toBeTrue();
+});

--- a/tests/Unit/Install/AgentsDetectorTest.php
+++ b/tests/Unit/Install/AgentsDetectorTest.php
@@ -12,6 +12,7 @@ use Laravel\Boost\Install\Agents\ClaudeCode;
 use Laravel\Boost\Install\Agents\Codex;
 use Laravel\Boost\Install\Agents\Copilot;
 use Laravel\Boost\Install\Agents\Cursor;
+use Laravel\Boost\Install\Agents\Factory;
 use Laravel\Boost\Install\Agents\Gemini;
 use Laravel\Boost\Install\Agents\Junie;
 use Laravel\Boost\Install\Agents\Kiro;
@@ -33,9 +34,9 @@ it('returns collection of all registered agents', function (): void {
     $agents = $this->detector->getAgents();
 
     expect($agents)->toBeInstanceOf(Collection::class)
-        ->and($agents->count())->toBe(10)
+        ->and($agents->count())->toBe(11)
         ->and($agents->keys()->toArray())->toBe([
-            'amp', 'junie', 'cursor', 'claude_code', 'codex', 'copilot', 'kiro', 'opencode', 'gemini', 'antigravity',
+            'amp', 'junie', 'cursor', 'claude_code', 'codex', 'copilot', 'factory', 'kiro', 'opencode', 'gemini', 'antigravity',
         ]);
 
     $agents->each(function ($agent): void {
@@ -62,6 +63,7 @@ it('returns an array of detected agents names for system discovery', function ()
     $this->container->bind(ClaudeCode::class, fn () => $mockOther);
     $this->container->bind(Codex::class, fn () => $mockOther);
     $this->container->bind(Copilot::class, fn () => $mockOther);
+    $this->container->bind(Factory::class, fn () => $mockOther);
     $this->container->bind(Kiro::class, fn () => $mockOther);
     $this->container->bind(OpenCode::class, fn () => $mockOther);
     $this->container->bind(Gemini::class, fn () => $mockOther);
@@ -84,6 +86,7 @@ it('returns an empty array when no agents are detected for system discovery', fu
     $this->container->bind(ClaudeCode::class, fn () => $mockAgent);
     $this->container->bind(Codex::class, fn () => $mockAgent);
     $this->container->bind(Copilot::class, fn () => $mockAgent);
+    $this->container->bind(Factory::class, fn () => $mockAgent);
     $this->container->bind(Kiro::class, fn () => $mockAgent);
     $this->container->bind(OpenCode::class, fn () => $mockAgent);
     $this->container->bind(Gemini::class, fn () => $mockAgent);
@@ -116,6 +119,7 @@ it('returns an array of detected agent names for project discovery', function ()
     $this->container->bind(ClaudeCode::class, fn () => $mockClaudeCode);
     $this->container->bind(Codex::class, fn () => $mockOther);
     $this->container->bind(Copilot::class, fn () => $mockOther);
+    $this->container->bind(Factory::class, fn () => $mockOther);
     $this->container->bind(Kiro::class, fn () => $mockOther);
     $this->container->bind(OpenCode::class, fn () => $mockOther);
     $this->container->bind(Gemini::class, fn () => $mockOther);
@@ -140,6 +144,7 @@ it('returns an empty array when no agents are detected for project discovery', f
     $this->container->bind(ClaudeCode::class, fn () => $mockAgent);
     $this->container->bind(Codex::class, fn () => $mockAgent);
     $this->container->bind(Copilot::class, fn () => $mockAgent);
+    $this->container->bind(Factory::class, fn () => $mockAgent);
     $this->container->bind(Kiro::class, fn () => $mockAgent);
     $this->container->bind(OpenCode::class, fn () => $mockAgent);
     $this->container->bind(Gemini::class, fn () => $mockAgent);


### PR DESCRIPTION
Adds support for Factory Droid as a Laravel Boost agent.

This includes:
- registering the `factory` agent with `BoostManager`
- detecting Factory Droid via the `droid` CLI and `.factory` project directory
- supporting guidelines, skills, and MCP configuration for Factory Droid
- adding unit coverage for Factory agent behavior and agent detection

References:
- Factory skills location: https://docs.factory.ai/cli/configuration/skills#where-skills-live
- Factory MCP configuration: https://docs.factory.ai/cli/configuration/mcp#configuration