### PR TITLE
fix: remove AGENTS.md from OpenCode project detection

### DIFF
--- a/src/Install/Agents/OpenCode.php
+++ b/src/Install/Agents/OpenCode.php
@@ -38,7 +38,7 @@ class OpenCode extends Agent implements SupportsGuidelines, SupportsMcp, Support
     public function projectDetectionConfig(): array
     {
         return [
-            'files' => ['AGENTS.md', 'opencode.json'],
+            'files' => ['opencode.json'],
         ];
     }
 

--- a/tests/Unit/Install/Agents/OpenCodeTest.php
+++ b/tests/Unit/Install/Agents/OpenCodeTest.php
@@ -12,6 +12,28 @@ beforeEach(function (): void {
     $this->strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
 });
 
+test('projectDetectionConfig only uses opencode.json', function (): void {
+    $agent = new OpenCode($this->strategyFactory);
+
+    expect($agent->projectDetectionConfig())->toBe([
+        'files' => ['opencode.json'],
+    ]);
+});
+
+test('detectInProject returns false when only AGENTS.md exists', function (): void {
+    $agent = new OpenCode(new DetectionStrategyFactory(app()));
+    $tempDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'boost_opencode_'.uniqid();
+    mkdir($tempDir);
+    touch($tempDir.DIRECTORY_SEPARATOR.'AGENTS.md');
+
+    try {
+        expect($agent->detectInProject($tempDir))->toBeFalse();
+    } finally {
+        unlink($tempDir.DIRECTORY_SEPARATOR.'AGENTS.md');
+        rmdir($tempDir);
+    }
+});
+
 test('httpMcpServerConfig returns remote type config', function (): void {
     $agent = new OpenCode($this->strategyFactory);
 


### PR DESCRIPTION
## Problem

`OpenCode::projectDetectionConfig()` returned `['files' => ['AGENTS.md', 'opencode.json']]`. `FileDetectionStrategy` uses OR logic — if **any** file in the array exists, detection returns `true`.

Since 8 other agents (Cursor, Codex, Junie, Factory, Kiro, Amp, Copilot, Antigravity) write `AGENTS.md` as their guidelines file, any project using those agents was falsely detected as using OpenCode. Boost would then incorrectly install OpenCode configuration for users who don't have OpenCode installed.

## Fix

Remove `AGENTS.md` from the files array. `opencode.json` is the reliable, OpenCode-specific project signal — it only exists when OpenCode is actually configured for a project.

## Tests

- **Config shape test** — asserts `projectDetectionConfig()` returns only `opencode.json`
- **Behavioral regression test** — creates a temp directory containing only `AGENTS.md` (no `opencode.json`), calls `detectInProject()`, and asserts `false`. This directly proves the false positive is eliminated.