### PR TITLE
fix: remove AGENTS.md from Codex project detection

### DIFF
--- a/src/Install/Agents/Codex.php
+++ b/src/Install/Agents/Codex.php
@@ -38,7 +38,7 @@ class Codex extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSk
     {
         return [
             'paths' => ['.codex'],
-            'files' => ['AGENTS.md', '.codex/config.toml'],
+            'files' => ['.codex/config.toml'],
         ];
     }
 

--- a/tests/Unit/Install/Agents/CodexTest.php
+++ b/tests/Unit/Install/Agents/CodexTest.php
@@ -97,8 +97,31 @@ test('includes config.toml in project detection', function (): void {
     $detection = $codex->projectDetectionConfig();
 
     expect($detection['files'])->toContain('.codex/config.toml')
-        ->toContain('AGENTS.md');
+        ->not->toContain('AGENTS.md');
     expect($detection['paths'])->toContain('.codex');
+});
+
+test('projectDetectionConfig only uses .codex dir and config.toml', function (): void {
+    $codex = new Codex($this->strategyFactory);
+
+    expect($codex->projectDetectionConfig())->toBe([
+        'paths' => ['.codex'],
+        'files' => ['.codex/config.toml'],
+    ]);
+});
+
+test('detectInProject returns false when only AGENTS.md exists', function (): void {
+    $codex = new Codex(new DetectionStrategyFactory(app()));
+    $tempDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'boost_codex_'.uniqid();
+    mkdir($tempDir);
+    touch($tempDir.DIRECTORY_SEPARATOR.'AGENTS.md');
+
+    try {
+        expect($codex->detectInProject($tempDir))->toBeFalse();
+    } finally {
+        unlink($tempDir.DIRECTORY_SEPARATOR.'AGENTS.md');
+        rmdir($tempDir);
+    }
 });
 
 test('returns correct guidelines path', function (): void {


### PR DESCRIPTION
## Problem

`Codex::projectDetectionConfig()` included `AGENTS.md` in its `files` array alongside `.codex/config.toml`. `FileDetectionStrategy` (and `CompositeDetectionStrategy`) use **OR logic** — if *any* configured file/path exists, detection returns `true`.

Since 8 other agents (Cursor, OpenCode, Junie, Factory, Kiro, Amp, Copilot, Antigravity) write `AGENTS.md` as their guidelines file, any project using those agents was falsely detected as a Codex project. This caused Boost to incorrectly install Codex configuration for users who don't have Codex.

## Fix

Remove `AGENTS.md` from the `files` array in `projectDetectionConfig()`. The `.codex` directory and `.codex/config.toml` are Codex-specific signals that won't trigger on other agents' projects.

**Before:**
```php
'files' => ['AGENTS.md', '.codex/config.toml'],
```

**After:**
```php
'files' => ['.codex/config.toml'],
```

## Tests

- Updated the existing `includes config.toml in project detection` test to assert `AGENTS.md` is **not** in the detection config (it was pinning the broken behaviour)
- Added `projectDetectionConfig only uses .codex dir and config.toml` — config-shape test that will catch any future regression
- Added `detectInProject returns false when only AGENTS.md exists` — behavioural regression test: creates a temp dir with only `AGENTS.md`, calls `detectInProject()`, asserts `false`

## Relationship to #831

This is the follow-up to #831 (OpenCode false-positive fix). Same root cause, same pattern, same fix. OpenCode was higher severity because it had only `AGENTS.md` as a signal; Codex was lower severity because `.codex` directory was its primary signal — but the false positive still fired on projects with `AGENTS.md` and no `.codex` dir.

## Checklist

- [x] `vendor/bin/pest` — 785 passed, 0 failures
- [x] `vendor/bin/phpstan --verbose` — no errors