### PR TITLE
fix: restrict Pint guideline to only run on PHP file changes

### DIFF
--- a/.ai/pint/core.blade.php
+++ b/.ai/pint/core.blade.php
@@ -4,9 +4,11 @@
 # Laravel Pint Code Formatter
 
 @if($assist->supportsPintAgentFormatter())
+- Only run Pint when you have modified PHP files. Do not run Pint if no PHP files were modified.
 - If you have modified any PHP files, you must run `{{ $assist->binCommand('pint') }} --dirty --format agent` before finalizing changes to ensure your code matches the project's expected style.
 - Do not run `{{ $assist->binCommand('pint') }} --test --format agent`, simply run `{{ $assist->binCommand('pint') }} --format agent` to fix any formatting issues.
 @else
+- Only run Pint when you have modified PHP files. Do not run Pint if no PHP files were modified.
 - If you have modified any PHP files, you must run `{{ $assist->binCommand('pint') }} --dirty` before finalizing changes to ensure your code matches the project's expected style.
 - Do not run `{{ $assist->binCommand('pint') }} --test`, simply run `{{ $assist->binCommand('pint') }}` to fix any formatting issues.
 @endif


### PR DESCRIPTION
## Problem

Closes #825.

The Pint guideline in `.ai/pint/core.blade.php` used a positive conditional — "If you have modified any PHP files, run Pint" — but did not explicitly forbid running Pint when *no* PHP files were changed. Agents treated the instruction as ambiguous and ran Pint unconditionally, including after changes to CSS, JS, Blade templates, and other non-PHP files.

## Fix

Adds an explicit prohibition as the first bullet in both formatter branches:

> Only run Pint when you have modified PHP files. Do not run Pint if no PHP files were modified.

This matches the wording suggested by the issue reporter and makes the constraint unambiguous for all agents.

## Testing

- `vendor/bin/pest` — 783 passed, 0 failures
- `vendor/bin/phpstan --verbose` — no errors