### PR TITLE
fix: remove .idea from Junie project detection

### DIFF
--- a/src/Install/Agents/Junie.php
+++ b/src/Install/Agents/Junie.php
@@ -53,7 +53,7 @@ class Junie extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSk
     public function projectDetectionConfig(): array
     {
         return [
-            'paths' => ['.idea', '.junie'],
+            'paths' => ['.junie'],
         ];
     }
 

--- a/tests/Unit/Install/Agents/JunieTest.php
+++ b/tests/Unit/Install/Agents/JunieTest.php
@@ -20,3 +20,25 @@ test('httpMcpServerConfig returns npx mcp-remote config', function (): void {
         'args' => ['-y', 'mcp-remote', 'https://nightwatch.laravel.com/mcp'],
     ]);
 });
+
+test('projectDetectionConfig only uses .junie dir', function (): void {
+    $agent = new Junie($this->strategyFactory);
+
+    expect($agent->projectDetectionConfig())->toBe([
+        'paths' => ['.junie'],
+    ]);
+});
+
+test('detectInProject returns false when only .idea dir exists', function (): void {
+    $agent = new Junie(new DetectionStrategyFactory(app()));
+    $tempDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'boost_junie_'.uniqid();
+    mkdir($tempDir);
+    mkdir($tempDir.DIRECTORY_SEPARATOR.'.idea');
+
+    try {
+        expect($agent->detectInProject($tempDir))->toBeFalse();
+    } finally {
+        rmdir($tempDir.DIRECTORY_SEPARATOR.'.idea');
+        rmdir($tempDir);
+    }
+});


### PR DESCRIPTION
## Problem

`Junie::projectDetectionConfig()` included `.idea` in its `paths` array alongside `.junie`. `DirectoryDetectionStrategy` (via `CompositeDetectionStrategy`) uses **OR logic** — if *any* configured path exists, detection returns `true`.

`.idea` is created by any JetBrains IDE (PHPStorm, IntelliJ, WebStorm, Rider, etc.) regardless of whether Junie is installed. Any project opened in a JetBrains IDE was falsely detected as a Junie project, causing Boost to incorrectly install Junie configuration for users who don't have Junie.

## Fix

Remove `.idea` from the `paths` array in `projectDetectionConfig()`. The `.junie` directory is the reliable, Junie-specific signal.

**Before:**
```php
'paths' => ['.idea', '.junie'],
```

**After:**
```php
'paths' => ['.junie'],
```

## Tests

- Added `projectDetectionConfig only uses .junie dir` — config-shape test that catches future regressions
- Added `detectInProject returns false when only .idea dir exists` — behavioural regression test: creates a temp dir with only `.idea`, calls `detectInProject()`, asserts `false`

## Related

Same root cause as #831 (OpenCode) and #832 (Codex), both merged. This completes the false-positive detection audit across all agents.

## Checklist

- [x] `vendor/bin/pest` — all tests pass
- [x] `vendor/bin/phpstan --verbose` — no errors