### PR TITLE
fix: preserve literal $N patterns when replacing guidelines block

### DIFF
--- a/src/Install/GuidelineWriter.php
+++ b/src/Install/GuidelineWriter.php
@@ -61,7 +61,7 @@ class GuidelineWriter
                 // Replace ALL existing boost guidelines blocks in-place
                 // If the user added guidelines after ours then let's
                 // make sure we keep the flow.
-                $newContent = preg_replace($pattern, $replacement, $content, 1);
+                $newContent = preg_replace_callback($pattern, fn (array $m): string => $replacement, $content, 1);
                 $replaced = true;
             } else {
                 // No existing Boost guidelines found, append to end of existing file

--- a/tests/Unit/Install/GuidelineWriterTest.php
+++ b/tests/Unit/Install/GuidelineWriterTest.php
@@ -293,6 +293,48 @@ test('it preserves user content after guidelines when replacing', function (): v
     unlink($tempFile);
 });
 
+test('it preserves dollar-sign literals in guidelines when replacing existing block', function (): void {
+    $tempFile = tempnam(sys_get_temp_dir(), 'boost_test_');
+    $initialContent = "# My Project\n\n<laravel-boost-guidelines>\nold guidelines\n</laravel-boost-guidelines>\n";
+    file_put_contents($tempFile, $initialContent);
+
+    $agent = Mockery::mock(SupportsGuidelines::class);
+    $agent->shouldReceive('guidelinesPath')->andReturn($tempFile);
+    $agent->shouldReceive('frontmatter')->andReturn(false);
+    $agent->shouldReceive('transformGuidelines')->andReturnUsing(fn ($markdown) => $markdown);
+
+    $writer = new GuidelineWriter($agent);
+    $writer->write('Apple Developer Program renewal ($99/yr) before the anniversary');
+
+    $content = file_get_contents($tempFile);
+    expect($content)->toContain('($99/yr)');
+
+    unlink($tempFile);
+});
+
+test('it preserves backslash and dollar patterns in guidelines when replacing existing block', function (): void {
+    $tempFile = tempnam(sys_get_temp_dir(), 'boost_test_');
+    $initialContent = "# My Project\n\n<laravel-boost-guidelines>\nold guidelines\n</laravel-boost-guidelines>\n";
+    file_put_contents($tempFile, $initialContent);
+
+    $agent = Mockery::mock(SupportsGuidelines::class);
+    $agent->shouldReceive('guidelinesPath')->andReturn($tempFile);
+    $agent->shouldReceive('frontmatter')->andReturn(false);
+    $agent->shouldReceive('transformGuidelines')->andReturnUsing(fn ($markdown) => $markdown);
+
+    $writer = new GuidelineWriter($agent);
+    $writer->write('Use $1 and $2 capture groups, cost $99, path C:\\Users\\dev');
+
+    $content = file_get_contents($tempFile);
+    expect($content)
+        ->toContain('$1')
+        ->toContain('$2')
+        ->toContain('$99')
+        ->toContain('C:\\Users\\dev');
+
+    unlink($tempFile);
+});
+
 test('it retries file locking on contention', function (): void {
     expect(true)->toBeTrue(); // Mark as passing for now
 })->todo();


### PR DESCRIPTION
## Summary

- `GuidelineWriter::write()` used `preg_replace()` with user-provided guideline content as the replacement string
- PHP's `preg_replace()` interprets `$N` and `\N` in replacement strings as backreferences — since the pattern `/<laravel-boost-guidelines>.*?<\/laravel-boost-guidelines>/s` has no capture groups, any `$99`, `$1`, `\1`, `\\` in user guidelines silently evaluates to empty string
- Root cause: the bug only fires on **update** (when `<laravel-boost-guidelines>` already exists in the file) — first install uses string concatenation, which is safe
- Real-world impact: dollar amounts (`$99/yr`), regex patterns (`$1`, `\1`), AWS CLI capture groups, and backslash paths are silently corrupted in regenerated `CLAUDE.md`

## Fix

One-line change in `GuidelineWriter::write()`:

```php
// Before (buggy): $N in $replacement interpreted as backreferences
$newContent = preg_replace($pattern, $replacement, $content, 1);

// After (fixed): callback return value is never parsed for backreferences
$newContent = preg_replace_callback($pattern, fn (array $m): string => $replacement, $content, 1);
```

## Test plan

- [x] `vendor/bin/pest` — 801 tests pass
- [x] `vendor/bin/phpstan` — no errors
- [x] New regression test: `it preserves dollar-sign literals in guidelines when replacing existing block`
- [x] New regression test: `it preserves backslash and dollar patterns in guidelines when replacing existing block`

Closes #800 (Bug 2)