### PR TITLE
feat: add Pi agent support

### DIFF
--- a/src/BoostManager.php
+++ b/src/BoostManager.php
@@ -16,6 +16,7 @@ use Laravel\Boost\Install\Agents\Factory;
 use Laravel\Boost\Install\Agents\Junie;
 use Laravel\Boost\Install\Agents\Kiro;
 use Laravel\Boost\Install\Agents\OpenCode;
+use Laravel\Boost\Install\Agents\Pi;
 use Laravel\Boost\Install\Agents\Zed;
 
 class BoostManager
@@ -33,6 +34,7 @@ class BoostManager
         'opencode' => OpenCode::class,
         'antigravity' => Antigravity::class,
         'zed' => Zed::class,
+        'pi' => Pi::class,
     ];
 
     /**

--- a/src/Install/Agents/Pi.php
+++ b/src/Install/Agents/Pi.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install\Agents;
+
+use Laravel\Boost\Contracts\SupportsGuidelines;
+use Laravel\Boost\Contracts\SupportsSkills;
+use Laravel\Boost\Install\Enums\Platform;
+
+class Pi extends Agent implements SupportsGuidelines, SupportsSkills
+{
+    public function name(): string
+    {
+        return 'pi';
+    }
+
+    public function displayName(): string
+    {
+        return 'Pi';
+    }
+
+    public function systemDetectionConfig(Platform $platform): array
+    {
+        return match ($platform) {
+            Platform::Darwin, Platform::Linux => [
+                'command' => 'which pi',
+            ],
+            Platform::Windows => [
+                'command' => 'cmd /c where pi 2>nul',
+            ],
+        };
+    }
+
+    public function projectDetectionConfig(): array
+    {
+        return [
+            'paths' => ['.pi'],
+            'files' => ['.pi/settings.json'],
+        ];
+    }
+
+    public function guidelinesPath(): string
+    {
+        return config('boost.agents.pi.guidelines_path', 'AGENTS.md');
+    }
+
+    public function skillsPath(): string
+    {
+        return config('boost.agents.pi.skills_path', '.pi/skills');
+    }
+}

--- a/tests/Feature/Install/Agents/AgentPathResolutionTest.php
+++ b/tests/Feature/Install/Agents/AgentPathResolutionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Laravel\Boost\Install\Agents\Cursor;
 use Laravel\Boost\Install\Agents\Junie;
+use Laravel\Boost\Install\Agents\Pi;
 use Laravel\Boost\Install\Detection\DetectionStrategyFactory;
 
 test('Junie returns absolute PHP_BINARY path', function (): void {
@@ -109,4 +110,15 @@ test('Junie uses config when configured', function (): void {
     // Config takes precedence over useAbsolutePathForMcp
     expect($junie->getPhpPath(true))->toBe('/custom/php');
     expect($junie->getPhpPath(false))->toBe('/custom/php');
+});
+
+test('Pi uses AGENTS.md and .pi/skills defaults', function (): void {
+    config(['boost.executable_paths.php' => null]);
+    $strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
+    $pi = new Pi($strategyFactory);
+
+    expect($pi->getPhpPath())->toBe('php')
+        ->and($pi->getArtisanPath())->toBe('artisan')
+        ->and($pi->guidelinesPath())->toBe('AGENTS.md')
+        ->and($pi->skillsPath())->toBe('.pi/skills');
 });

--- a/tests/Unit/BoostManagerTest.php
+++ b/tests/Unit/BoostManagerTest.php
@@ -13,6 +13,7 @@ use Laravel\Boost\Install\Agents\Factory;
 use Laravel\Boost\Install\Agents\Junie;
 use Laravel\Boost\Install\Agents\Kiro;
 use Laravel\Boost\Install\Agents\OpenCode;
+use Laravel\Boost\Install\Agents\Pi;
 use Laravel\Boost\Install\Agents\Zed;
 use Tests\Unit\Install\ExampleAgent;
 
@@ -32,6 +33,7 @@ it('returns default agents', function (): void {
         'opencode' => OpenCode::class,
         'antigravity' => Antigravity::class,
         'zed' => Zed::class,
+        'pi' => Pi::class,
     ]);
 });
 

--- a/tests/Unit/Install/AgentsDetectorTest.php
+++ b/tests/Unit/Install/AgentsDetectorTest.php
@@ -16,6 +16,7 @@ use Laravel\Boost\Install\Agents\Factory;
 use Laravel\Boost\Install\Agents\Junie;
 use Laravel\Boost\Install\Agents\Kiro;
 use Laravel\Boost\Install\Agents\OpenCode;
+use Laravel\Boost\Install\Agents\Pi;
 use Laravel\Boost\Install\Agents\Zed;
 use Laravel\Boost\Install\AgentsDetector;
 use Laravel\Boost\Install\Enums\Platform;
@@ -34,9 +35,9 @@ it('returns collection of all registered agents', function (): void {
     $agents = $this->detector->getAgents();
 
     expect($agents)->toBeInstanceOf(Collection::class)
-        ->and($agents->count())->toBe(11)
+        ->and($agents->count())->toBe(12)
         ->and($agents->keys()->toArray())->toBe([
-            'amp', 'junie', 'cursor', 'claude_code', 'codex', 'copilot', 'factory', 'kiro', 'opencode', 'antigravity', 'zed',
+            'amp', 'junie', 'cursor', 'claude_code', 'codex', 'copilot', 'factory', 'kiro', 'opencode', 'antigravity', 'zed', 'pi',
         ]);
 
     $agents->each(function ($agent): void {
@@ -68,6 +69,7 @@ it('returns an array of detected agents names for system discovery', function ()
     $this->container->bind(OpenCode::class, fn () => $mockOther);
     $this->container->bind(Antigravity::class, fn () => $mockOther);
     $this->container->bind(Zed::class, fn () => $mockOther);
+    $this->container->bind(Pi::class, fn () => $mockOther);
 
     $detector = new AgentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverSystemInstalledAgents();
@@ -91,6 +93,7 @@ it('returns an empty array when no agents are detected for system discovery', fu
     $this->container->bind(OpenCode::class, fn () => $mockAgent);
     $this->container->bind(Antigravity::class, fn () => $mockAgent);
     $this->container->bind(Zed::class, fn () => $mockAgent);
+    $this->container->bind(Pi::class, fn () => $mockAgent);
 
     $detector = new AgentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverSystemInstalledAgents();
@@ -124,6 +127,7 @@ it('returns an array of detected agent names for project discovery', function ()
     $this->container->bind(OpenCode::class, fn () => $mockOther);
     $this->container->bind(Antigravity::class, fn () => $mockOther);
     $this->container->bind(Zed::class, fn () => $mockOther);
+    $this->container->bind(Pi::class, fn () => $mockOther);
 
     $detector = new AgentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverProjectInstalledAgents($basePath);
@@ -149,6 +153,7 @@ it('returns an empty array when no agents are detected for project discovery', f
     $this->container->bind(OpenCode::class, fn () => $mockAgent);
     $this->container->bind(Antigravity::class, fn () => $mockAgent);
     $this->container->bind(Zed::class, fn () => $mockAgent);
+    $this->container->bind(Pi::class, fn () => $mockAgent);
 
     $detector = new AgentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverProjectInstalledAgents($basePath);


### PR DESCRIPTION
## Summary
- add Pi as a supported Boost agent
- detect Pi from the `pi` binary and `.pi/settings.json` project config
- install Pi guidelines to `AGENTS.md` and skills to `.pi/skills`

## Test Plan
- `vendor/bin/pest tests/Unit/BoostManagerTest.php tests/Unit/Install/AgentsDetectorTest.php tests/Feature/Install/Agents/AgentPathResolutionTest.php`
- `vendor/bin/pint --test src/BoostManager.php src/Install/Agents/Pi.php tests/Feature/Install/Agents/AgentPathResolutionTest.php tests/Unit/BoostManagerTest.php tests/Unit/Install/AgentsDetectorTest.php`