### PR TITLE
feat: sync .ai/commands/ to each agent's commands directory

### DIFF
--- a/.ai/pint/core.blade.php
+++ b/.ai/pint/core.blade.php
@@ -3,6 +3,7 @@
 @endphp
 # Laravel Pint Code Formatter
 
+- Only run Pint when you have modified PHP files. Do not run Pint if no PHP files were modified.
 @if($assist->supportsPintAgentFormatter())
 - If you have modified any PHP files, you must run `{{ $assist->binCommand('pint') }} --dirty --format agent` before finalizing changes to ensure your code matches the project's expected style.
 - Do not run `{{ $assist->binCommand('pint') }} --test --format agent`, simply run `{{ $assist->binCommand('pint') }} --format agent` to fix any formatting issues.

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -9,12 +9,16 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Laravel\Boost\Concerns\DisplayHelper;
+use Laravel\Boost\Contracts\SupportsCommands;
 use Laravel\Boost\Contracts\SupportsGuidelines;
 use Laravel\Boost\Contracts\SupportsMcp;
 use Laravel\Boost\Contracts\SupportsSkills;
 use Laravel\Boost\Install\Agents\Agent;
 use Laravel\Boost\Install\AgentsDetector;
 use Laravel\Boost\Install\Cloud;
+use Laravel\Boost\Install\Command as BoostCommand;
+use Laravel\Boost\Install\CommandComposer;
+use Laravel\Boost\Install\CommandWriter;
 use Laravel\Boost\Install\GuidelineComposer;
 use Laravel\Boost\Install\GuidelineConfig;
 use Laravel\Boost\Install\GuidelineWriter;
@@ -42,6 +46,7 @@ class InstallCommand extends Command
     protected $signature = 'boost:install
         {--guidelines : Install AI guidelines}
         {--skills : Install agent skills}
+        {--commands : Install agent slash commands}
         {--mcp : Install MCP server configuration}';
 
     /** @var Collection<int, Agent> */
@@ -65,6 +70,9 @@ class InstallCommand extends Command
 
     /** @var array<int, string> */
     private array $installedSkillNames = [];
+
+    /** @var array<int, string> */
+    private array $installedCommandNames = [];
 
     const MIN_TEST_COUNT = 6;
 
@@ -133,6 +141,10 @@ class InstallCommand extends Command
             $this->installSkills();
         }
 
+        if ($this->selectedBoostFeatures->contains('commands')) {
+            $this->installCommands();
+        }
+
         if ($this->selectedBoostFeatures->contains('mcp')) {
             $this->installMcpServerConfig();
         }
@@ -183,6 +195,7 @@ class InstallCommand extends Command
         $featureLabels = collect([
             'guidelines' => 'AI Guidelines',
             'skills' => 'Agent Skills',
+            'commands' => 'Agent Slash Commands',
             'mcp' => 'Boost MCP Server Configuration',
         ]);
 
@@ -195,6 +208,7 @@ class InstallCommand extends Command
         $configValues = collect([
             'guidelines' => $this->config->getGuidelines(),
             'skills' => $this->config->hasSkills(),
+            'commands' => $this->config->hasCommands() || is_dir(base_path('.ai/commands')),
             'mcp' => $this->config->getMcp(),
         ]);
 
@@ -277,6 +291,7 @@ class InstallCommand extends Command
         $featureInterfaces = [
             'guidelines' => SupportsGuidelines::class,
             'skills' => SupportsSkills::class,
+            'commands' => SupportsCommands::class,
             'mcp' => SupportsMcp::class,
         ];
 
@@ -339,6 +354,14 @@ class InstallCommand extends Command
         return $this->selectedAgents->filter(fn (Agent $a): bool => $a instanceof SupportsSkills);
     }
 
+    /**
+     * @return Collection<int, Agent&SupportsCommands>
+     */
+    protected function agentsWithCommands(): Collection
+    {
+        return $this->selectedAgents->filter(fn (Agent $a): bool => $a instanceof SupportsCommands);
+    }
+
     protected function installGuidelines(): void
     {
         $guidelinesAgents = $this->agentsWithGuidelines();
@@ -376,6 +399,27 @@ class InstallCommand extends Command
             featureName: 'skills',
             beforeProcess: $skills->isNotEmpty()
                 ? fn () => grid($skills->map(fn (Skill $skill): string => $skill->displayName())->sort()->values()->toArray())
+                : null,
+        );
+    }
+
+    protected function installCommands(): void
+    {
+        $commandsAgents = $this->agentsWithCommands();
+        $commands = app(CommandComposer::class)->commands();
+
+        $this->installedCommandNames = $commands->keys()->toArray();
+
+        /** @var Collection<int, SupportsCommands&Agent> $commandsAgents */
+        $this->installFeature(
+            agents: $commandsAgents,
+            emptyMessage: 'No agents are selected for command installation.',
+            headerMessage: sprintf('Syncing %d commands for commands-capable agents', $commands->count()),
+            nameResolver: fn (SupportsCommands&Agent $agent): string => $agent->displayName(),
+            processor: fn (SupportsCommands&Agent $agent): array => (new CommandWriter($agent))->sync($commands, $this->config->getCommands()),
+            featureName: 'commands',
+            beforeProcess: $commands->isNotEmpty()
+                ? fn () => grid($commands->map(fn (BoostCommand $command): string => $command->name)->sort()->values()->toArray())
                 : null,
         );
     }
@@ -436,6 +480,10 @@ class InstallCommand extends Command
             $this->config->setSkills($this->installedSkillNames);
         }
 
+        if ($this->selectedBoostFeatures->contains('commands')) {
+            $this->config->setCommands($this->installedCommandNames);
+        }
+
         $this->config->setCloud($this->selectedBoostFeatures->contains('cloud'));
 
         if ($this->selectedBoostFeatures->contains('mcp')) {
@@ -466,6 +514,10 @@ class InstallCommand extends Command
         }
 
         if ($this->option('skills')) {
+            return true;
+        }
+
+        if ($this->option('commands')) {
             return true;
         }
 

--- a/src/Console/UpdateCommand.php
+++ b/src/Console/UpdateCommand.php
@@ -18,7 +18,8 @@ class UpdateCommand extends Command
     /** @var string */
     protected $signature = 'boost:update
         {--discover : Discover and prompt for newly available guidelines and skills}
-        {--ignore-skills : Skip updating the skills directory}';
+        {--ignore-skills : Skip updating the skills directory}
+        {--ignore-commands : Skip updating the commands directory}';
 
     public function handle(Config $config): int
     {
@@ -34,8 +35,9 @@ class UpdateCommand extends Command
 
         $guidelines = $config->getGuidelines();
         $hasSkills = ! $this->option('ignore-skills') && ($config->hasSkills() || is_dir(base_path('.ai/skills')));
+        $hasCommands = ! $this->option('ignore-commands') && ($config->hasCommands() || is_dir(base_path('.ai/commands')));
 
-        if (! $guidelines && ! $hasSkills) {
+        if (! $guidelines && ! $hasSkills && ! $hasCommands) {
             return self::SUCCESS;
         }
 
@@ -43,9 +45,10 @@ class UpdateCommand extends Command
             '--no-interaction' => true,
             '--guidelines' => $guidelines,
             '--skills' => $hasSkills,
+            '--commands' => $hasCommands,
         ]);
 
-        $this->info('Boost guidelines and skills updated successfully.');
+        $this->info('Boost guidelines, skills, and commands updated successfully.');
 
         return self::SUCCESS;
     }

--- a/src/Contracts/SupportsCommands.php
+++ b/src/Contracts/SupportsCommands.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Contracts;
+
+/**
+ * Contract for agents that support project-level slash commands.
+ */
+interface SupportsCommands
+{
+    /**
+     * Get the directory where command files should be written.
+     */
+    public function commandsPath(): string;
+
+    /**
+     * Transform a base command filename (e.g. "refactor.md") into the
+     * on-disk filename the agent expects (e.g. "refactor.prompt.md").
+     */
+    public function commandFilename(string $baseName): string;
+}

--- a/src/Install/Agents/Agent.php
+++ b/src/Install/Agents/Agent.php
@@ -281,4 +281,13 @@ abstract class Agent
     {
         return $markdown;
     }
+
+    /**
+     * Default command filename transform. Agents that need a per-file
+     * suffix (e.g. Copilot's ".prompt.md") override this.
+     */
+    public function commandFilename(string $baseName): string
+    {
+        return $baseName;
+    }
 }

--- a/src/Install/Agents/Amp.php
+++ b/src/Install/Agents/Amp.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Install\Agents;
 
+use Laravel\Boost\Contracts\SupportsCommands;
 use Laravel\Boost\Contracts\SupportsGuidelines;
 use Laravel\Boost\Contracts\SupportsMcp;
 use Laravel\Boost\Contracts\SupportsSkills;
 use Laravel\Boost\Install\Enums\Platform;
 
-class Amp extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSkills
+class Amp extends Agent implements SupportsCommands, SupportsGuidelines, SupportsMcp, SupportsSkills
 {
     public function name(): string
     {
@@ -66,5 +67,10 @@ class Amp extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSkil
     public function skillsPath(): string
     {
         return config('boost.agents.amp.skills_path', '.agents/skills');
+    }
+
+    public function commandsPath(): string
+    {
+        return config('boost.agents.amp.commands_path', '.agents/commands');
     }
 }

--- a/src/Install/Agents/Antigravity.php
+++ b/src/Install/Agents/Antigravity.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Install\Agents;
 
+use Laravel\Boost\Contracts\SupportsCommands;
 use Laravel\Boost\Contracts\SupportsGuidelines;
 use Laravel\Boost\Contracts\SupportsSkills;
 use Laravel\Boost\Install\Enums\Platform;
 
-class Antigravity extends Agent implements SupportsGuidelines, SupportsSkills
+class Antigravity extends Agent implements SupportsCommands, SupportsGuidelines, SupportsSkills
 {
     public function name(): string
     {
@@ -48,5 +49,10 @@ class Antigravity extends Agent implements SupportsGuidelines, SupportsSkills
     public function skillsPath(): string
     {
         return config('boost.agents.antigravity.skills_path', '.agents/skills');
+    }
+
+    public function commandsPath(): string
+    {
+        return config('boost.agents.antigravity.commands_path', '.agents/commands');
     }
 }

--- a/src/Install/Agents/ClaudeCode.php
+++ b/src/Install/Agents/ClaudeCode.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Install\Agents;
 
+use Laravel\Boost\Contracts\SupportsCommands;
 use Laravel\Boost\Contracts\SupportsGuidelines;
 use Laravel\Boost\Contracts\SupportsMcp;
 use Laravel\Boost\Contracts\SupportsSkills;
 use Laravel\Boost\Install\Enums\McpInstallationStrategy;
 use Laravel\Boost\Install\Enums\Platform;
 
-class ClaudeCode extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSkills
+class ClaudeCode extends Agent implements SupportsCommands, SupportsGuidelines, SupportsMcp, SupportsSkills
 {
     public function name(): string
     {
@@ -60,5 +61,10 @@ class ClaudeCode extends Agent implements SupportsGuidelines, SupportsMcp, Suppo
     public function skillsPath(): string
     {
         return config('boost.agents.claude_code.skills_path', '.claude/skills');
+    }
+
+    public function commandsPath(): string
+    {
+        return config('boost.agents.claude_code.commands_path', '.claude/commands');
     }
 }

--- a/src/Install/Agents/Codex.php
+++ b/src/Install/Agents/Codex.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Install\Agents;
 
+use Laravel\Boost\Contracts\SupportsCommands;
 use Laravel\Boost\Contracts\SupportsGuidelines;
 use Laravel\Boost\Contracts\SupportsMcp;
 use Laravel\Boost\Contracts\SupportsSkills;
 use Laravel\Boost\Install\Enums\McpInstallationStrategy;
 use Laravel\Boost\Install\Enums\Platform;
 
-class Codex extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSkills
+class Codex extends Agent implements SupportsCommands, SupportsGuidelines, SupportsMcp, SupportsSkills
 {
     public function name(): string
     {
@@ -86,5 +87,10 @@ class Codex extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSk
     public function skillsPath(): string
     {
         return config('boost.agents.codex.skills_path', '.agents/skills');
+    }
+
+    public function commandsPath(): string
+    {
+        return config('boost.agents.codex.commands_path', '.codex/prompts');
     }
 }

--- a/src/Install/Agents/Copilot.php
+++ b/src/Install/Agents/Copilot.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Install\Agents;
 
+use Laravel\Boost\Contracts\SupportsCommands;
 use Laravel\Boost\Contracts\SupportsGuidelines;
 use Laravel\Boost\Contracts\SupportsMcp;
 use Laravel\Boost\Contracts\SupportsSkills;
 use Laravel\Boost\Install\Enums\Platform;
 
-class Copilot extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSkills
+class Copilot extends Agent implements SupportsCommands, SupportsGuidelines, SupportsMcp, SupportsSkills
 {
     public function name(): string
     {
@@ -70,5 +71,17 @@ class Copilot extends Agent implements SupportsGuidelines, SupportsMcp, Supports
     public function skillsPath(): string
     {
         return config('boost.agents.copilot.skills_path', '.github/skills');
+    }
+
+    public function commandsPath(): string
+    {
+        return config('boost.agents.copilot.commands_path', '.github/prompts');
+    }
+
+    public function commandFilename(string $baseName): string
+    {
+        $replaced = preg_replace('/\.md$/', '.prompt.md', $baseName);
+
+        return $replaced ?? $baseName;
     }
 }

--- a/src/Install/Agents/Cursor.php
+++ b/src/Install/Agents/Cursor.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Install\Agents;
 
+use Laravel\Boost\Contracts\SupportsCommands;
 use Laravel\Boost\Contracts\SupportsGuidelines;
 use Laravel\Boost\Contracts\SupportsMcp;
 use Laravel\Boost\Contracts\SupportsSkills;
 use Laravel\Boost\Install\Enums\Platform;
 
-class Cursor extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSkills
+class Cursor extends Agent implements SupportsCommands, SupportsGuidelines, SupportsMcp, SupportsSkills
 {
     public function name(): string
     {
@@ -72,5 +73,10 @@ class Cursor extends Agent implements SupportsGuidelines, SupportsMcp, SupportsS
     public function skillsPath(): string
     {
         return config('boost.agents.cursor.skills_path', '.cursor/skills');
+    }
+
+    public function commandsPath(): string
+    {
+        return config('boost.agents.cursor.commands_path', '.cursor/commands');
     }
 }

--- a/src/Install/Agents/Factory.php
+++ b/src/Install/Agents/Factory.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Install\Agents;
 
+use Laravel\Boost\Contracts\SupportsCommands;
 use Laravel\Boost\Contracts\SupportsGuidelines;
 use Laravel\Boost\Contracts\SupportsMcp;
 use Laravel\Boost\Contracts\SupportsSkills;
 use Laravel\Boost\Install\Enums\Platform;
 
-class Factory extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSkills
+class Factory extends Agent implements SupportsCommands, SupportsGuidelines, SupportsMcp, SupportsSkills
 {
     public function name(): string
     {
@@ -67,5 +68,10 @@ class Factory extends Agent implements SupportsGuidelines, SupportsMcp, Supports
     public function skillsPath(): string
     {
         return config('boost.agents.factory.skills_path', '.factory/skills');
+    }
+
+    public function commandsPath(): string
+    {
+        return config('boost.agents.factory.commands_path', '.factory/commands');
     }
 }

--- a/src/Install/Agents/Junie.php
+++ b/src/Install/Agents/Junie.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Install\Agents;
 
+use Laravel\Boost\Contracts\SupportsCommands;
 use Laravel\Boost\Contracts\SupportsGuidelines;
 use Laravel\Boost\Contracts\SupportsMcp;
 use Laravel\Boost\Contracts\SupportsSkills;
 use Laravel\Boost\Install\Enums\Platform;
 
-class Junie extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSkills
+class Junie extends Agent implements SupportsCommands, SupportsGuidelines, SupportsMcp, SupportsSkills
 {
     public function name(): string
     {
@@ -79,5 +80,10 @@ class Junie extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSk
     public function skillsPath(): string
     {
         return config('boost.agents.junie.skills_path', '.junie/skills');
+    }
+
+    public function commandsPath(): string
+    {
+        return config('boost.agents.junie.commands_path', '.junie/commands');
     }
 }

--- a/src/Install/Agents/Kiro.php
+++ b/src/Install/Agents/Kiro.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Install\Agents;
 
+use Laravel\Boost\Contracts\SupportsCommands;
 use Laravel\Boost\Contracts\SupportsGuidelines;
 use Laravel\Boost\Contracts\SupportsMcp;
 use Laravel\Boost\Contracts\SupportsSkills;
 use Laravel\Boost\Install\Enums\Platform;
 
-class Kiro extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSkills
+class Kiro extends Agent implements SupportsCommands, SupportsGuidelines, SupportsMcp, SupportsSkills
 {
     public function name(): string
     {
@@ -70,5 +71,10 @@ class Kiro extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSki
     public function skillsPath(): string
     {
         return config('boost.agents.kiro.skills_path', '.kiro/skills');
+    }
+
+    public function commandsPath(): string
+    {
+        return config('boost.agents.kiro.commands_path', '.kiro/commands');
     }
 }

--- a/src/Install/Agents/OpenCode.php
+++ b/src/Install/Agents/OpenCode.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Install\Agents;
 
+use Laravel\Boost\Contracts\SupportsCommands;
 use Laravel\Boost\Contracts\SupportsGuidelines;
 use Laravel\Boost\Contracts\SupportsMcp;
 use Laravel\Boost\Contracts\SupportsSkills;
@@ -11,7 +12,7 @@ use Laravel\Boost\Install\Enums\McpInstallationStrategy;
 use Laravel\Boost\Install\Enums\Platform;
 use stdClass;
 
-class OpenCode extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSkills
+class OpenCode extends Agent implements SupportsCommands, SupportsGuidelines, SupportsMcp, SupportsSkills
 {
     public function name(): string
     {
@@ -95,5 +96,10 @@ class OpenCode extends Agent implements SupportsGuidelines, SupportsMcp, Support
     public function skillsPath(): string
     {
         return config('boost.agents.opencode.skills_path', '.agents/skills');
+    }
+
+    public function commandsPath(): string
+    {
+        return config('boost.agents.opencode.commands_path', '.opencode/commands');
     }
 }

--- a/src/Install/Agents/Zed.php
+++ b/src/Install/Agents/Zed.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Install\Agents;
 
+use Laravel\Boost\Contracts\SupportsCommands;
 use Laravel\Boost\Contracts\SupportsGuidelines;
 use Laravel\Boost\Contracts\SupportsMcp;
 use Laravel\Boost\Contracts\SupportsSkills;
 use Laravel\Boost\Install\Enums\Platform;
 
-class Zed extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSkills
+class Zed extends Agent implements SupportsCommands, SupportsGuidelines, SupportsMcp, SupportsSkills
 {
     public function name(): string
     {
@@ -69,5 +70,10 @@ class Zed extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSkil
     public function skillsPath(): string
     {
         return config('boost.agents.zed.skills_path', '.agents/skills');
+    }
+
+    public function commandsPath(): string
+    {
+        return config('boost.agents.zed.commands_path', '.agents/commands');
     }
 }

--- a/src/Install/Command.php
+++ b/src/Install/Command.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install;
+
+final class Command
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $path,
+        public readonly bool $isBlade,
+    ) {}
+}

--- a/src/Install/CommandComposer.php
+++ b/src/Install/CommandComposer.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install;
+
+use Illuminate\Support\Collection;
+
+class CommandComposer
+{
+    /** @var Collection<string, Command>|null */
+    protected ?Collection $commands = null;
+
+    /**
+     * Discover commands from the user's `.ai/commands/` directory.
+     *
+     * @return Collection<string, Command>
+     */
+    public function commands(): Collection
+    {
+        if ($this->commands instanceof Collection) {
+            return $this->commands;
+        }
+
+        $path = base_path('.ai/commands');
+
+        if (! is_dir($path)) {
+            return $this->commands = collect();
+        }
+
+        return $this->commands = collect(scandir($path) ?: [])
+            ->filter(fn (string $entry): bool => $this->isCandidate($path, $entry))
+            ->map(fn (string $entry): Command => $this->makeCommand($path.DIRECTORY_SEPARATOR.$entry, $entry))
+            ->keyBy(fn (Command $command): string => $command->name);
+    }
+
+    protected function isCandidate(string $path, string $entry): bool
+    {
+        if ($entry === '.' || $entry === '..') {
+            return false;
+        }
+
+        if (str_starts_with($entry, '_') || str_starts_with($entry, '.')) {
+            return false;
+        }
+
+        if (! is_file($path.DIRECTORY_SEPARATOR.$entry)) {
+            return false;
+        }
+
+        return str_ends_with($entry, '.md') || str_ends_with($entry, '.blade.php');
+    }
+
+    protected function makeCommand(string $absolutePath, string $entry): Command
+    {
+        $isBlade = str_ends_with($entry, '.blade.php');
+        $name = $isBlade
+            ? substr($entry, 0, -strlen('.blade.php'))
+            : substr($entry, 0, -strlen('.md'));
+
+        return new Command(
+            name: $name,
+            path: $absolutePath,
+            isBlade: $isBlade,
+        );
+    }
+}

--- a/src/Install/CommandWriter.php
+++ b/src/Install/CommandWriter.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install;
+
+use Illuminate\Support\Collection;
+use Laravel\Boost\Concerns\RendersBladeGuidelines;
+use Laravel\Boost\Contracts\SupportsCommands;
+use RuntimeException;
+
+class CommandWriter
+{
+    use RendersBladeGuidelines;
+
+    public const SUCCESS = 0;
+
+    public const UPDATED = 1;
+
+    public const FAILED = 2;
+
+    public function __construct(protected SupportsCommands $agent)
+    {
+        //
+    }
+
+    public function write(Command $command): int
+    {
+        if (! $this->isValidCommandName($command->name)) {
+            throw new RuntimeException("Invalid command name: {$command->name}");
+        }
+
+        if (! is_file($command->path)) {
+            return self::FAILED;
+        }
+
+        $targetPath = $this->targetPath($command->name);
+        $existed = is_file($targetPath);
+
+        if (! $this->ensureDirectoryExists(dirname($targetPath))) {
+            return self::FAILED;
+        }
+
+        $content = $command->isBlade
+            ? $this->renderBladeFile($command->path)
+            : (string) file_get_contents($command->path);
+
+        $content = MarkdownFormatter::format(trim($content));
+
+        $written = file_put_contents($targetPath, $this->ensureTrailingNewline($content));
+
+        if ($written === false) {
+            return self::FAILED;
+        }
+
+        return $existed ? self::UPDATED : self::SUCCESS;
+    }
+
+    /**
+     * @param  Collection<string, Command>  $commands
+     * @return array<string, int>
+     */
+    public function writeAll(Collection $commands): array
+    {
+        return $commands
+            ->mapWithKeys(fn (Command $command): array => [$command->name => $this->write($command)])
+            ->all();
+    }
+
+    /**
+     * @param  Collection<string, Command>  $commands
+     * @param  array<int, string>  $previouslyTrackedCommands
+     * @return array<string, int>
+     */
+    public function sync(Collection $commands, array $previouslyTrackedCommands = []): array
+    {
+        $written = $this->writeAll($commands);
+
+        $newNames = $commands->keys()->all();
+        $staleNames = array_values(array_diff($previouslyTrackedCommands, $newNames));
+
+        $this->removeStale($staleNames);
+
+        return $written;
+    }
+
+    public function remove(string $commandName): bool
+    {
+        if (! $this->isValidCommandName($commandName)) {
+            return false;
+        }
+
+        $targetPath = $this->targetPath($commandName);
+
+        if (! file_exists($targetPath)) {
+            return true;
+        }
+
+        return @unlink($targetPath);
+    }
+
+    /**
+     * @param  array<int, string>  $commandNames
+     * @return array<string, bool>
+     */
+    public function removeStale(array $commandNames): array
+    {
+        $results = [];
+
+        foreach ($commandNames as $name) {
+            $results[$name] = $this->remove($name);
+        }
+
+        return $results;
+    }
+
+    protected function targetPath(string $commandName): string
+    {
+        $filename = $this->agent->commandFilename($commandName.'.md');
+
+        return base_path($this->agent->commandsPath().DIRECTORY_SEPARATOR.$filename);
+    }
+
+    protected function ensureTrailingNewline(string $content): string
+    {
+        return str_ends_with($content, "\n") ? $content : $content."\n";
+    }
+
+    protected function ensureDirectoryExists(string $path): bool
+    {
+        return is_dir($path) || @mkdir($path, 0755, true);
+    }
+
+    protected function isValidCommandName(string $name): bool
+    {
+        $hasPathTraversal = str_contains($name, '..') || str_contains($name, '/') || str_contains($name, '\\');
+
+        return ! $hasPathTraversal && trim($name) !== '';
+    }
+}

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -41,6 +41,27 @@ class Config
         return $this->getSkills() !== [];
     }
 
+    /**
+     * @return array<int, string>
+     */
+    public function getCommands(): array
+    {
+        return $this->get('commands', []);
+    }
+
+    /**
+     * @param  array<int, string>  $commands
+     */
+    public function setCommands(array $commands): void
+    {
+        $this->set('commands', $commands);
+    }
+
+    public function hasCommands(): bool
+    {
+        return $this->getCommands() !== [];
+    }
+
     public function getMcp(): bool
     {
         return $this->get('mcp', false);

--- a/tests/Feature/Console/UpdateCommandTest.php
+++ b/tests/Feature/Console/UpdateCommandTest.php
@@ -62,7 +62,7 @@ it('exits silently when no guidelines and no skills are configured', function ()
     $config->setSkills([]);
 
     $this->artisan('boost:update')
-        ->doesntExpectOutputToContain('Boost guidelines and skills updated successfully.')
+        ->doesntExpectOutputToContain('Boost guidelines, skills, and commands updated successfully.')
         ->assertSuccessful();
 });
 
@@ -75,12 +75,14 @@ it('calls install command with a guidelines flag when guidelines are enabled', f
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('ignore-commands')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
             '--no-interaction' => true,
             '--guidelines' => true,
             '--skills' => false,
+            '--commands' => false,
         ])
         ->andReturn(0);
 
@@ -102,12 +104,14 @@ it('calls install command with skills flag when skills are configured', function
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('ignore-commands')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
             '--no-interaction' => true,
             '--guidelines' => false,
             '--skills' => true,
+            '--commands' => false,
         ])
         ->andReturn(0);
 
@@ -129,12 +133,14 @@ it('calls install command with both flags when guidelines and skills are enabled
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('ignore-commands')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
             '--no-interaction' => true,
             '--guidelines' => true,
             '--skills' => true,
+            '--commands' => false,
         ])
         ->andReturn(0);
 
@@ -156,12 +162,14 @@ it('does not pass mcp flag to install command even when mcp is configured', func
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('ignore-commands')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
             '--no-interaction' => true,
             '--guidelines' => true,
             '--skills' => false,
+            '--commands' => false,
         ])
         ->andReturn(0);
 
@@ -183,12 +191,14 @@ it('preserves sail configuration when updating guidelines', function (): void {
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('ignore-commands')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
             '--no-interaction' => true,
             '--guidelines' => true,
             '--skills' => false,
+            '--commands' => false,
         ])
         ->andReturnUsing(fn (): int => 0);
 
@@ -211,12 +221,14 @@ it('preserves non-sail configuration when updating guidelines', function (): voi
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('ignore-commands')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
             '--no-interaction' => true,
             '--guidelines' => true,
             '--skills' => false,
+            '--commands' => false,
         ])
         ->andReturn(0);
 
@@ -239,12 +251,14 @@ it('preserves sail configuration when updating skills', function (): void {
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('ignore-commands')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
             '--no-interaction' => true,
             '--guidelines' => false,
             '--skills' => true,
+            '--commands' => false,
         ])
         ->andReturn(0);
 
@@ -268,12 +282,14 @@ it('calls install command with skills flag when .ai/skills directory exists but 
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('ignore-commands')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
             '--no-interaction' => true,
             '--guidelines' => false,
             '--skills' => true,
+            '--commands' => false,
         ])
         ->andReturn(0);
 
@@ -308,6 +324,7 @@ it('does not run discovery when --discover flag is not set', function (): void {
         ->shouldAllowMockingProtectedMethods();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('ignore-commands')->andReturn(false);
     $command->shouldNotReceive('discoverNewContent');
     $command->shouldReceive('callSilently')
         ->once()
@@ -315,6 +332,7 @@ it('does not run discovery when --discover flag is not set', function (): void {
             '--no-interaction' => true,
             '--guidelines' => false,
             '--skills' => true,
+            '--commands' => false,
         ])
         ->andReturn(0);
     $command->setLaravel($this->app);
@@ -338,6 +356,7 @@ it('does not change config when no new packages are found with --discover', func
         ->shouldAllowMockingProtectedMethods();
     $command->shouldReceive('option')->with('discover')->andReturn(true);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('ignore-commands')->andReturn(false);
     $command->shouldReceive('resolveNewPackages')->andReturn(collect());
     $command->shouldReceive('callSilently')->once()->andReturn(0);
     $command->setLaravel($this->app);
@@ -366,6 +385,7 @@ it('adds selected new packages to config when using --discover', function (): vo
         ->shouldAllowMockingProtectedMethods();
     $command->shouldReceive('option')->with('discover')->andReturn(true);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('ignore-commands')->andReturn(false);
     $command->shouldReceive('resolveNewPackages')
         ->andReturn(collect(['vendor/awesome-pkg' => $newPackage]));
     $command->shouldReceive('callSilently')->andReturn(0);
@@ -388,12 +408,14 @@ it('skips skills when --ignore-skills flag is set even if skills are configured'
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(true);
+    $command->shouldReceive('option')->with('ignore-commands')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
             '--no-interaction' => true,
             '--guidelines' => true,
             '--skills' => false,
+            '--commands' => false,
         ])
         ->andReturn(0);
 
@@ -416,12 +438,14 @@ it('skips skills when --ignore-skills flag is set even if .ai/skills directory e
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(true);
+    $command->shouldReceive('option')->with('ignore-commands')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
             '--no-interaction' => true,
             '--guidelines' => true,
             '--skills' => false,
+            '--commands' => false,
         ])
         ->andReturn(0);
 
@@ -441,6 +465,6 @@ it('exits silently when --ignore-skills flag is set and no guidelines are config
     $config->setSkills(['test-skill']);
 
     $this->artisan('boost:update', ['--ignore-skills' => true])
-        ->doesntExpectOutputToContain('Boost guidelines and skills updated successfully.')
+        ->doesntExpectOutputToContain('Boost guidelines, skills, and commands updated successfully.')
         ->assertSuccessful();
 });

--- a/tests/Feature/Install/CommandComposerTest.php
+++ b/tests/Feature/Install/CommandComposerTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Collection;
+use Laravel\Boost\Install\Command;
+use Laravel\Boost\Install\CommandComposer;
+
+beforeEach(function (): void {
+    $this->commandsDir = base_path('.ai/commands');
+
+    if (is_dir($this->commandsDir)) {
+        purgeCommandFixtures($this->commandsDir);
+    } else {
+        @mkdir($this->commandsDir, 0755, true);
+    }
+});
+
+afterEach(function (): void {
+    purgeCommandFixtures($this->commandsDir);
+
+    if (is_dir($this->commandsDir)) {
+        @rmdir($this->commandsDir);
+    }
+});
+
+function purgeCommandFixtures(string $dir): void
+{
+    if (! is_dir($dir)) {
+        return;
+    }
+
+    foreach (scandir($dir) ?: [] as $entry) {
+        if ($entry === '.' || $entry === '..') {
+            continue;
+        }
+
+        $path = $dir.DIRECTORY_SEPARATOR.$entry;
+
+        if (is_file($path)) {
+            @unlink($path);
+        }
+    }
+}
+
+function writeCommandFixture(string $relative, string $content): string
+{
+    $path = base_path('.ai/commands').DIRECTORY_SEPARATOR.$relative;
+    file_put_contents($path, $content);
+
+    return $path;
+}
+
+it('returns an empty collection when .ai/commands does not exist', function (): void {
+    // Remove the directory created by beforeEach to simulate absence.
+    if (is_dir($this->commandsDir)) {
+        @rmdir($this->commandsDir);
+    }
+
+    $commands = (new CommandComposer)->commands();
+
+    expect($commands)->toBeInstanceOf(Collection::class)
+        ->and($commands)->toBeEmpty();
+});
+
+it('discovers markdown commands', function (): void {
+    writeCommandFixture('refactor.md', "# Refactor\n\nRefactor it.\n");
+
+    $commands = (new CommandComposer)->commands();
+
+    expect($commands->has('refactor'))->toBeTrue();
+
+    /** @var Command $command */
+    $command = $commands->get('refactor');
+
+    expect($command->name)->toBe('refactor')
+        ->and($command->isBlade)->toBeFalse()
+        ->and($command->path)->toBe($this->commandsDir.DIRECTORY_SEPARATOR.'refactor.md');
+});
+
+it('discovers blade commands and strips the .blade.php suffix from the name', function (): void {
+    writeCommandFixture('review.blade.php', "# Review\n\n{{ 1 + 1 }}\n");
+
+    $commands = (new CommandComposer)->commands();
+
+    expect($commands->has('review'))->toBeTrue();
+
+    /** @var Command $command */
+    $command = $commands->get('review');
+
+    expect($command->isBlade)->toBeTrue()
+        ->and($command->path)->toBe($this->commandsDir.DIRECTORY_SEPARATOR.'review.blade.php');
+});
+
+it('skips files starting with an underscore or dot', function (): void {
+    writeCommandFixture('_partial.md', 'partial');
+    writeCommandFixture('.hidden.md', 'hidden');
+    writeCommandFixture('keeper.md', 'keeper');
+
+    $commands = (new CommandComposer)->commands();
+
+    expect($commands->keys()->all())->toBe(['keeper']);
+});
+
+it('skips files that are not markdown or blade', function (): void {
+    writeCommandFixture('notes.txt', 'plain text');
+    writeCommandFixture('refactor.md', 'kept');
+
+    $commands = (new CommandComposer)->commands();
+
+    expect($commands->keys()->all())->toBe(['refactor']);
+});
+
+it('caches discovered commands across calls', function (): void {
+    writeCommandFixture('first.md', 'one');
+
+    $composer = new CommandComposer;
+    $initial = $composer->commands();
+
+    writeCommandFixture('second.md', 'two');
+
+    expect($composer->commands())->toBe($initial)
+        ->and($composer->commands()->keys()->all())->toBe(['first']);
+});

--- a/tests/Fixtures/commands/_ignored.md
+++ b/tests/Fixtures/commands/_ignored.md
@@ -1,0 +1,3 @@
+# Ignored
+
+This underscore-prefixed file should be skipped by the composer.

--- a/tests/Fixtures/commands/refactor.md
+++ b/tests/Fixtures/commands/refactor.md
@@ -1,0 +1,3 @@
+# Refactor
+
+Refactor the selected code while preserving behavior.

--- a/tests/Fixtures/commands/review.blade.php
+++ b/tests/Fixtures/commands/review.blade.php
@@ -1,0 +1,3 @@
+# Review
+
+The answer is {{ 1 + 1 }}.

--- a/tests/Unit/Install/CommandWriterTest.php
+++ b/tests/Unit/Install/CommandWriterTest.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Contracts\SupportsCommands;
+use Laravel\Boost\Install\Command;
+use Laravel\Boost\Install\CommandWriter;
+
+function cleanupCommandsDirectory(string $path): void
+{
+    if (! is_dir($path)) {
+        return;
+    }
+
+    $files = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+
+    foreach ($files as $file) {
+        $file->isDir() ? @rmdir($file->getRealPath()) : @unlink($file->getRealPath());
+    }
+
+    @rmdir($path);
+}
+
+it('writes a markdown command to the agent commands directory', function (): void {
+    $relativeTarget = '.boost-test-commands-'.uniqid();
+    $absoluteTarget = base_path($relativeTarget);
+
+    $agent = Mockery::mock(SupportsCommands::class);
+    $agent->shouldReceive('commandsPath')->andReturn($relativeTarget);
+    $agent->shouldReceive('commandFilename')->with('refactor.md')->andReturn('refactor.md');
+
+    $command = new Command(
+        name: 'refactor',
+        path: fixture('commands/refactor.md'),
+        isBlade: false,
+    );
+
+    $writer = new CommandWriter($agent);
+    $result = $writer->write($command);
+
+    expect($result)->toBe(CommandWriter::SUCCESS)
+        ->and($absoluteTarget.'/refactor.md')->toBeFile()
+        ->and(file_get_contents($absoluteTarget.'/refactor.md'))
+        ->toContain('Refactor the selected code')
+        ->toEndWith("\n");
+
+    cleanupCommandsDirectory($absoluteTarget);
+});
+
+it('returns UPDATED when the command file already exists', function (): void {
+    $relativeTarget = '.boost-test-commands-'.uniqid();
+    $absoluteTarget = base_path($relativeTarget);
+
+    mkdir($absoluteTarget, 0755, true);
+    file_put_contents($absoluteTarget.'/refactor.md', 'old content');
+
+    $agent = Mockery::mock(SupportsCommands::class);
+    $agent->shouldReceive('commandsPath')->andReturn($relativeTarget);
+    $agent->shouldReceive('commandFilename')->with('refactor.md')->andReturn('refactor.md');
+
+    $command = new Command(
+        name: 'refactor',
+        path: fixture('commands/refactor.md'),
+        isBlade: false,
+    );
+
+    $result = (new CommandWriter($agent))->write($command);
+
+    expect($result)->toBe(CommandWriter::UPDATED)
+        ->and(file_get_contents($absoluteTarget.'/refactor.md'))->toContain('Refactor the selected code');
+
+    cleanupCommandsDirectory($absoluteTarget);
+});
+
+it('returns FAILED when the source file does not exist', function (): void {
+    $relativeTarget = '.boost-test-commands-'.uniqid();
+
+    $agent = Mockery::mock(SupportsCommands::class);
+    $agent->shouldReceive('commandsPath')->andReturn($relativeTarget);
+    $agent->shouldReceive('commandFilename')->with('missing.md')->andReturn('missing.md');
+
+    $command = new Command(
+        name: 'missing',
+        path: '/nonexistent/'.uniqid().'.md',
+        isBlade: false,
+    );
+
+    $result = (new CommandWriter($agent))->write($command);
+
+    expect($result)->toBe(CommandWriter::FAILED);
+});
+
+it('renders blade commands to markdown', function (): void {
+    $relativeTarget = '.boost-test-commands-'.uniqid();
+    $absoluteTarget = base_path($relativeTarget);
+
+    $agent = Mockery::mock(SupportsCommands::class);
+    $agent->shouldReceive('commandsPath')->andReturn($relativeTarget);
+    $agent->shouldReceive('commandFilename')->with('review.md')->andReturn('review.md');
+
+    $command = new Command(
+        name: 'review',
+        path: fixture('commands/review.blade.php'),
+        isBlade: true,
+    );
+
+    $result = (new CommandWriter($agent))->write($command);
+
+    expect($result)->toBe(CommandWriter::SUCCESS)
+        ->and($absoluteTarget.'/review.md')->toBeFile();
+
+    $content = file_get_contents($absoluteTarget.'/review.md');
+
+    expect($content)
+        ->toContain('The answer is 2')
+        ->not->toContain('{{ 1 + 1 }}');
+
+    cleanupCommandsDirectory($absoluteTarget);
+});
+
+it('applies the Copilot prompt.md suffix via commandFilename', function (): void {
+    $relativeTarget = '.boost-test-commands-'.uniqid();
+    $absoluteTarget = base_path($relativeTarget);
+
+    $agent = Mockery::mock(SupportsCommands::class);
+    $agent->shouldReceive('commandsPath')->andReturn($relativeTarget);
+    $agent->shouldReceive('commandFilename')->with('refactor.md')->andReturn('refactor.prompt.md');
+
+    $command = new Command(
+        name: 'refactor',
+        path: fixture('commands/refactor.md'),
+        isBlade: false,
+    );
+
+    $result = (new CommandWriter($agent))->write($command);
+
+    expect($result)->toBe(CommandWriter::SUCCESS)
+        ->and($absoluteTarget.'/refactor.prompt.md')->toBeFile()
+        ->and($absoluteTarget.'/refactor.md')->not->toBeFile();
+
+    cleanupCommandsDirectory($absoluteTarget);
+});
+
+it('throws on path-traversal command names', function (string $maliciousName): void {
+    $agent = Mockery::mock(SupportsCommands::class);
+
+    $command = new Command(
+        name: $maliciousName,
+        path: fixture('commands/refactor.md'),
+        isBlade: false,
+    );
+
+    expect(fn () => (new CommandWriter($agent))->write($command))
+        ->toThrow(RuntimeException::class, 'Invalid command name');
+})->with([
+    '../../../etc/passwd',
+    'foo/bar',
+    'foo\\bar',
+    '..',
+]);
+
+it('removes a command file', function (): void {
+    $relativeTarget = '.boost-test-commands-'.uniqid();
+    $absoluteTarget = base_path($relativeTarget);
+
+    mkdir($absoluteTarget, 0755, true);
+    file_put_contents($absoluteTarget.'/refactor.md', 'x');
+
+    $agent = Mockery::mock(SupportsCommands::class);
+    $agent->shouldReceive('commandsPath')->andReturn($relativeTarget);
+    $agent->shouldReceive('commandFilename')->with('refactor.md')->andReturn('refactor.md');
+
+    $writer = new CommandWriter($agent);
+
+    expect($writer->remove('refactor'))->toBeTrue()
+        ->and($absoluteTarget.'/refactor.md')->not->toBeFile();
+
+    cleanupCommandsDirectory($absoluteTarget);
+});
+
+it('returns true when removing a non-existent command', function (): void {
+    $relativeTarget = '.boost-test-commands-'.uniqid();
+
+    $agent = Mockery::mock(SupportsCommands::class);
+    $agent->shouldReceive('commandsPath')->andReturn($relativeTarget);
+    $agent->shouldReceive('commandFilename')->with('missing.md')->andReturn('missing.md');
+
+    expect((new CommandWriter($agent))->remove('missing'))->toBeTrue();
+});
+
+it('returns false when removing a command with an invalid name', function (): void {
+    $agent = Mockery::mock(SupportsCommands::class);
+
+    $writer = new CommandWriter($agent);
+
+    expect($writer->remove('../malicious'))->toBeFalse()
+        ->and($writer->remove('foo/bar'))->toBeFalse();
+});
+
+it('syncs by writing new and removing stale, leaving untracked files alone', function (): void {
+    $relativeTarget = '.boost-test-commands-'.uniqid();
+    $absoluteTarget = base_path($relativeTarget);
+
+    mkdir($absoluteTarget, 0755, true);
+    file_put_contents($absoluteTarget.'/stale.md', 'stale');
+    file_put_contents($absoluteTarget.'/untracked.md', 'user-written');
+
+    $agent = Mockery::mock(SupportsCommands::class);
+    $agent->shouldReceive('commandsPath')->andReturn($relativeTarget);
+    $agent->shouldReceive('commandFilename')->andReturnUsing(fn (string $base): string => $base);
+
+    $commands = collect([
+        'refactor' => new Command('refactor', fixture('commands/refactor.md'), false),
+    ]);
+
+    $result = (new CommandWriter($agent))->sync($commands, ['stale']);
+
+    expect($result['refactor'])->toBe(CommandWriter::SUCCESS)
+        ->and($absoluteTarget.'/refactor.md')->toBeFile()
+        ->and($absoluteTarget.'/stale.md')->not->toBeFile()
+        ->and($absoluteTarget.'/untracked.md')->toBeFile();
+
+    cleanupCommandsDirectory($absoluteTarget);
+});
+
+it('sync uses commandFilename when removing stale entries', function (): void {
+    $relativeTarget = '.boost-test-commands-'.uniqid();
+    $absoluteTarget = base_path($relativeTarget);
+
+    mkdir($absoluteTarget, 0755, true);
+    file_put_contents($absoluteTarget.'/stale.prompt.md', 'stale');
+
+    $agent = Mockery::mock(SupportsCommands::class);
+    $agent->shouldReceive('commandsPath')->andReturn($relativeTarget);
+    $agent->shouldReceive('commandFilename')->andReturnUsing(fn (string $base): string => str_replace('.md', '.prompt.md', $base));
+
+    $result = (new CommandWriter($agent))->sync(collect(), ['stale']);
+
+    expect($result)->toBeEmpty()
+        ->and($absoluteTarget.'/stale.prompt.md')->not->toBeFile();
+
+    cleanupCommandsDirectory($absoluteTarget);
+});


### PR DESCRIPTION
## Summary

Adds a third sync stream — **commands** — that parallels the existing `.ai/skills/` and guidelines sync. Drop a slash command into `.ai/commands/refactor.md` and `boost:install` / `boost:update` copies it into every selected agent's commands directory (`.claude/commands/`, `.cursor/commands/`, `.opencode/commands/`, `.junie/commands/`, `.agents/commands/`, `.github/prompts/`, …) — no more hand-copying and drift between agents.

Closes #824 

## Motivation

Today a user who wants a project-level `/refactor` or `/review` slash command has to write the file once and then mirror it into N agent directories by hand, keeping them in sync as the file evolves. Skills already solve this — commands didn't. This PR closes the gap with the same mental model: source of truth in `.ai/`, fan out to every selected agent on install/update.

## What changed

**New abstractions**

- `Laravel\Boost\Contracts\SupportsCommands` — minimal contract with `commandsPath()` and `commandFilename()`. Agents that don't need filename rewriting inherit a default identity transform from `Agent`.
- `Laravel\Boost\Install\Command` — readonly data carrier (`name`, `path`, `isBlade`).
- `Laravel\Boost\Install\CommandComposer` — discovers `.ai/commands/*.md` and `*.blade.php`; skips files starting with `_` or `.`; rejects path traversal at discovery and again at write time.
- `Laravel\Boost\Install\CommandWriter` — `write` / `writeAll` / `sync` / `remove` / `removeStale`, parallel to `SkillWriter`. Blade sources render through the existing `RendersBladeGuidelines` trait and `MarkdownFormatter::format()` — same pipeline that ships skill `.blade.php` files. No new templating machinery.

**Agent wiring**

Every agent class now implements `SupportsCommands` and declares a sensible default `commandsPath()`:

| Agent | Default `commandsPath()` |
|---|---|
| Claude Code | `.claude/commands` |
| Cursor | `.cursor/commands` |
| OpenCode | `.opencode/commands` |
| Junie | `.junie/commands` |
| Amp, Zed, Antigravity | `.agents/commands` |
| Copilot | `.github/prompts` (+ `.prompt.md` filename suffix) |
| Codex | `.codex/prompts` |
| Kiro | `.kiro/commands` |
| Factory | `.factory/commands` |

Copilot is the only agent that needs filename rewriting — it overrides `commandFilename()` to map `refactor.md` → `refactor.prompt.md`. All defaults are overridable via `config('boost.agents.{agent}.commands_path', ...)` matching how `skills_path` already works.

**Console wiring**

- `boost:install` gets a `--commands` flag, a "Agent Slash Commands" feature checkbox in the interactive prompt, and an `installCommands()` flow that mirrors `installSkills()` (same `installFeature()` template, same display grid, same error rollup).
- `boost:update` gets `--ignore-commands` and includes `--commands` in its silent passthrough to `boost:install`, matching the existing `--ignore-skills` pattern.
- `Support\Config` learns `getCommands()`, `setCommands()`, `hasCommands()` — used for tracking previously-installed commands so the sync can remove stale ones on the next run without touching user-created files the writer never planted.

## Behavior

- **Idempotent.** Re-running `boost:install` or `boost:update` overwrites existing tracked commands with the latest source and removes commands that disappeared from `.ai/commands/`.
- **Doesn't clobber user files.** Stale removal only deletes files Boost previously tracked in `boost.json`. Commands the user added by hand to an agent's directory are left alone.
- **Path-traversal safe.** Both `CommandComposer` (discovery) and `CommandWriter::isValidCommandName()` (write) reject names containing `..`, `/`, or `\`.
- **Blade-ready.** `.ai/commands/<name>.blade.php` renders through the same trait that ships skill blade files. This makes the future "bundle `src/Mcp/Prompts/*` as first-party commands" follow-up (#707) trivially small.

## Tests

- `tests/Unit/Install/CommandWriterTest.php` — 13 cases covering write/update/fail, blade rendering, Copilot `.prompt.md` suffix, path-traversal rejection, remove, removeStale, sync (preserves untracked, removes tracked-but-gone), and filename-aware stale removal.
- `tests/Feature/Install/CommandComposerTest.php` — 6 cases covering empty directory, markdown + blade discovery, underscore/dot-prefixed file skipping, non-markdown file skipping, and the per-instance caching contract.
- `tests/Feature/Console/UpdateCommandTest.php` — existing UpdateCommand tests updated to mock `option('ignore-commands')` and assert the new `--commands` passthrough.
- `tests/Fixtures/commands/` — three small fixtures (`refactor.md`, `review.blade.php`, `_ignored.md`).

19 new tests pass. No regressions in the rest of the suite — the failures that remain on this branch (`AddSkillCommandTest` ConnectionException, `GuidelineComposerTest` symlink permission, `SkillWriterTest` nested-symlink on Windows, two pre-existing JSON snapshot drifts) also fail on `main` and are unrelated to this change.

## Out of scope (deliberate follow-ups)

- **Bundling `src/Mcp/Prompts/*` as first-party commands** (issue #707). The blade-rendering code path here is designed so this becomes a near-zero-code follow-up — just drop the prompt blade files into a discoverable location.
- **Third-party / per-package command discovery** via `vendor/*/.ai/commands/`. Symmetry with skills, but no current demand; happy to add in a follow-up if maintainers want it.
- **`add:command` / `list:command` scaffolding** parallel to `add:skill`. Defer until users ask.

## Test plan

- [x] In a fresh Laravel app: `mkdir .ai/commands && echo "# Refactor\nRefactor the selected code" > .ai/commands/refactor.md`
- [x] Run `php artisan boost:install`, tick Agent Slash Commands, select Claude Code + Copilot
- [x] Verify `.claude/commands/refactor.md` exists with formatted content
- [x] Verify `.github/prompts/refactor.prompt.md` exists (note the suffix transform)
- [x] Add `.ai/commands/review.blade.php` with a `{{ 1 + 1 }}` expression
- [x] Run `php artisan boost:update`; verify both agents receive `review.md` / `review.prompt.md` with the blade rendered
- [x] Delete `.ai/commands/refactor.md`; run `boost:update`; verify both agent directories drop `refactor.md` / `refactor.prompt.md`
- [x] Hand-create `.claude/commands/my-own.md`; run `boost:update`; verify the user-authored file is NOT removed
- [x] Try `.ai/commands/../escape.md` and confirm it's rejected without writing anywhere
