### PR TITLE
Fix Zed detection when the binary is `zeditor`

### DIFF
--- a/src/Install/Agents/Zed.php
+++ b/src/Install/Agents/Zed.php
@@ -28,7 +28,7 @@ class Zed extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSkil
                 'paths' => ['/Applications/Zed.app'],
             ],
             Platform::Linux => [
-                'command' => 'command -v zed',
+                'command' => 'command -v zed || command -v zeditor',
             ],
             Platform::Windows => [
                 'command' => 'cmd /c where zed 2>nul',


### PR DESCRIPTION
On some Linux distributions (e.g. Arch Linux) the zed editor binary is `zeditor`. This is mentioned in the official [CLI Reference documentation](https://zed.dev/docs/reference/cli).

> **Linux:** The CLI is included with Zed packages. The binary name may vary by distribution (commonly `zed` or `zeditor`).

This should fix detection for those distros.