### PR TITLE
Support laravel/mcp 0.8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "illuminate/contracts": "^11.45.3|^12.41.1|^13.0",
         "illuminate/routing": "^11.45.3|^12.41.1|^13.0",
         "illuminate/support": "^11.45.3|^12.41.1|^13.0",
-        "laravel/mcp": "^0.7.1",
+        "laravel/mcp": "^0.7.1|^0.8.0",
         "laravel/prompts": "^0.3.10",
         "laravel/roster": "^0.5.0"
     },


### PR DESCRIPTION
Currently locked to `laravel/mcp` 0.7.x, so packages pulling in 0.8.0 fail to resolve.

This widens the constraint to allow `^0.7.1|^0.8.0`.