### PR TITLE
Add MCP server icon metadata

### DIFF
--- a/resources/icons/boost.svg
+++ b/resources/icons/boost.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg fill="none" viewBox="0 0 41 40" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#f)">
+<rect transform="translate(.27734)" width="40" height="40" fill="url(#a)"/>
+<g filter="url(#e)">
+<ellipse cx="2.7773" cy="2.8125" rx="20" ry="19.688" fill="#EFB0F9"/>
+</g>
+<g filter="url(#d)">
+<ellipse cx="30.902" cy="31.562" rx="23.75" ry="23.438" fill="#B29FF4"/>
+</g>
+<mask id="b" x="0" y="20" width="41" height="20" style="mask-type:alpha" maskUnits="userSpaceOnUse">
+<rect transform="matrix(1 0 0 -1 .27734 40)" width="40" height="20" fill="#D9D9D9"/>
+</mask>
+<g mask="url(#b)">
+<g filter="url(#c)">
+<ellipse cx="10.902" cy="27.812" rx="20" ry="19.688" fill="#D8F8EF"/>
+</g>
+</g>
+<rect x="9.7004" y="9.4231" width="15.385" height="15.385" stroke="#000" stroke-width="3.8462"/>
+<rect x="14.028" y="13.75" width="18.269" height="18.269" stroke="#000" stroke-width=".96154"/>
+<rect x="16.911" y="16.635" width="12.5" height="12.5" stroke="#000" stroke-width=".96154"/>
+</g>
+<defs>
+<filter id="e" x="-35.973" y="-35.625" width="77.5" height="76.875" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur result="effect1_foregroundBlur_1_1027" stdDeviation="9.375"/>
+</filter>
+<filter id="d" x="-11.598" y="-10.625" width="85" height="84.375" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur result="effect1_foregroundBlur_1_1027" stdDeviation="9.375"/>
+</filter>
+<filter id="c" x="-27.848" y="-10.625" width="77.5" height="76.875" color-interpolation-filters="sRGB" filterUnits="userSpaceOnUse">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur result="effect1_foregroundBlur_1_1027" stdDeviation="9.375"/>
+</filter>
+<radialGradient id="a" cx="0" cy="0" r="1" gradientTransform="translate(20 20) scale(20)" gradientUnits="userSpaceOnUse">
+<stop stop-color="#EEE6F4" offset="0"/>
+<stop stop-color="#DBE0F6" offset="1"/>
+</radialGradient>
+<clipPath id="f">
+<rect transform="translate(.27734)" width="40" height="40" fill="#fff"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/Mcp/Boost.php
+++ b/src/Mcp/Boost.php
@@ -19,6 +19,7 @@ use Laravel\Boost\Mcp\Tools\LastError;
 use Laravel\Boost\Mcp\Tools\ReadLogEntries;
 use Laravel\Boost\Mcp\Tools\SearchDocs;
 use Laravel\Boost\Mcp\Tools\Tinker;
+use Laravel\Mcp\Schema\Icon;
 use Laravel\Mcp\Server;
 use Laravel\Mcp\Server\Prompt;
 use Laravel\Mcp\Server\Resource;
@@ -40,6 +41,51 @@ class Boost extends Server
      * The MCP server's instructions for the LLM.
      */
     protected string $instructions = 'Laravel ecosystem MCP server offering database schema access, error logs, semantic documentation search, and more. Boost helps with code generation.';
+
+    /**
+     * The icons exposed to MCP clients.
+     *
+     * @return list<Icon>
+     */
+    protected function icons(): array
+    {
+        $svg = <<<'SVG'
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" rx="12" fill="url(#bg)"/>
+  <g filter="url(#glowA)">
+    <ellipse cx="5" cy="5" rx="32" ry="31" fill="#EFB0F9"/>
+  </g>
+  <g filter="url(#glowB)">
+    <ellipse cx="50" cy="51" rx="38" ry="37" fill="#B29FF4"/>
+  </g>
+  <g filter="url(#glowC)">
+    <ellipse cx="17" cy="45" rx="32" ry="31" fill="#D8F8EF"/>
+  </g>
+  <rect x="15" y="15" width="25" height="25" stroke="#161615" stroke-width="6"/>
+  <rect x="22" y="22" width="29" height="29" stroke="#161615" stroke-width="2"/>
+  <rect x="27" y="27" width="20" height="20" stroke="#161615" stroke-width="2"/>
+  <defs>
+    <filter id="glowA" x="-57" y="-56" width="124" height="122" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="15"/>
+    </filter>
+    <filter id="glowB" x="-18" y="-16" width="136" height="134" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="15"/>
+    </filter>
+    <filter id="glowC" x="-45" y="-16" width="124" height="122" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="15"/>
+    </filter>
+    <radialGradient id="bg" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(32 32) scale(32)">
+      <stop stop-color="#EEE6F4"/>
+      <stop offset="1" stop-color="#DBE0F6"/>
+    </radialGradient>
+  </defs>
+</svg>
+SVG;
+
+        return [
+            Icon::from('data:image/svg+xml;base64,'.base64_encode($svg), 'image/svg+xml', ['64x64']),
+        ];
+    }
 
     /**
      * The default pagination length for resources that support pagination.

--- a/src/Mcp/Boost.php
+++ b/src/Mcp/Boost.php
@@ -49,41 +49,10 @@ class Boost extends Server
      */
     protected function icons(): array
     {
-        $svg = <<<'SVG'
-<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="64" height="64" rx="12" fill="url(#bg)"/>
-  <g filter="url(#glowA)">
-    <ellipse cx="5" cy="5" rx="32" ry="31" fill="#EFB0F9"/>
-  </g>
-  <g filter="url(#glowB)">
-    <ellipse cx="50" cy="51" rx="38" ry="37" fill="#B29FF4"/>
-  </g>
-  <g filter="url(#glowC)">
-    <ellipse cx="17" cy="45" rx="32" ry="31" fill="#D8F8EF"/>
-  </g>
-  <rect x="15" y="15" width="25" height="25" stroke="#161615" stroke-width="6"/>
-  <rect x="22" y="22" width="29" height="29" stroke="#161615" stroke-width="2"/>
-  <rect x="27" y="27" width="20" height="20" stroke="#161615" stroke-width="2"/>
-  <defs>
-    <filter id="glowA" x="-57" y="-56" width="124" height="122" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="15"/>
-    </filter>
-    <filter id="glowB" x="-18" y="-16" width="136" height="134" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="15"/>
-    </filter>
-    <filter id="glowC" x="-45" y="-16" width="124" height="122" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
-      <feGaussianBlur stdDeviation="15"/>
-    </filter>
-    <radialGradient id="bg" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(32 32) scale(32)">
-      <stop stop-color="#EEE6F4"/>
-      <stop offset="1" stop-color="#DBE0F6"/>
-    </radialGradient>
-  </defs>
-</svg>
-SVG;
+        $svg = (string) file_get_contents(__DIR__.'/../../resources/icons/boost.svg');
 
         return [
-            Icon::from('data:image/svg+xml;base64,'.base64_encode($svg), 'image/svg+xml', ['64x64']),
+            Icon::from('data:image/svg+xml;base64,'.base64_encode($svg), 'image/svg+xml', ['40x40']),
         ];
     }
 

--- a/tests/Feature/Mcp/BoostServerTest.php
+++ b/tests/Feature/Mcp/BoostServerTest.php
@@ -13,5 +13,11 @@ it('exposes an icon in the MCP server metadata', function (): void {
     expect($serverInfo['icons'])->toHaveCount(1)
         ->and($serverInfo['icons'][0]['src'])->toStartWith('data:image/svg+xml;base64,')
         ->and($serverInfo['icons'][0]['mimeType'])->toBe('image/svg+xml')
-        ->and($serverInfo['icons'][0]['sizes'])->toBe(['64x64']);
+        ->and($serverInfo['icons'][0]['sizes'])->toBe(['40x40']);
+
+    $decoded = base64_decode((string) str($serverInfo['icons'][0]['src'])->after('base64,'), true);
+
+    expect($decoded)
+        ->toBe((string) file_get_contents(__DIR__.'/../../../resources/icons/boost.svg'))
+        ->toStartWith('<svg');
 });

--- a/tests/Feature/Mcp/BoostServerTest.php
+++ b/tests/Feature/Mcp/BoostServerTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Mcp\Boost;
+use Laravel\Mcp\Server\Transport\FakeTransporter;
+
+it('exposes an icon in the MCP server metadata', function (): void {
+    $server = new Boost(new FakeTransporter);
+
+    $serverInfo = $server->createContext()->implementation->toArray();
+
+    expect($serverInfo['icons'])->toHaveCount(1)
+        ->and($serverInfo['icons'][0]['src'])->toStartWith('data:image/svg+xml;base64,')
+        ->and($serverInfo['icons'][0]['mimeType'])->toBe('image/svg+xml')
+        ->and($serverInfo['icons'][0]['sizes'])->toBe(['64x64']);
+});


### PR DESCRIPTION
## What changed

Adds icon metadata to the Laravel Boost MCP server so MCP clients can display a branded Boost icon in source/tool surfaces. Currently i'm using and tested in Codex App (OSX)

## Why

Clients that surface MCP server sources can read `serverInfo.icons` from the MCP initialize response. Boost already has branding, but the MCP server currently does not expose an icon, so clients fall back to a generic MCP/source icon.

The SVG is embedded as a data URI because the existing `art/` assets are excluded from package exports.

## Validation

- `vendor/bin/pint src/Mcp/Boost.php tests/Feature/Mcp/BoostServerTest.php --test`
- `vendor/bin/pest tests/Feature/Mcp`

## Example
<img width="234" height="108" alt="image" src="https://github.com/user-attachments/assets/b33e0678-6465-4075-bb0a-fc94498ec701" />
