### PR TITLE
feat: Add --fresh for clean skill output rebuilds

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -42,7 +42,8 @@ class InstallCommand extends Command
     protected $signature = 'boost:install
         {--guidelines : Install AI guidelines}
         {--skills : Install agent skills}
-        {--mcp : Install MCP server configuration}';
+        {--mcp : Install MCP server configuration}
+        {--fresh : Delete each agent\'s generated skills directory before installing}';
 
     /** @var Collection<int, Agent> */
     private Collection $selectedAgents;
@@ -372,7 +373,7 @@ class InstallCommand extends Command
             emptyMessage: 'No agents are selected for skill installation.',
             headerMessage: sprintf('Syncing %d skills for skills-capable agents', $skills->count()),
             nameResolver: fn (SupportsSkills&Agent $agent): string => $agent->displayName(),
-            processor: fn (SupportsSkills&Agent $agent): array => (new SkillWriter($agent))->sync($skills, $this->config->getSkills()),
+            processor: fn (SupportsSkills&Agent $agent): array => (new SkillWriter($agent))->sync($skills, $this->config->getSkills(), (bool) $this->option('fresh')),
             featureName: 'skills',
             beforeProcess: $skills->isNotEmpty()
                 ? fn () => grid($skills->map(fn (Skill $skill): string => $skill->displayName())->sort()->values()->toArray())

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -6,6 +6,7 @@ namespace Laravel\Boost\Console;
 
 use Exception;
 use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Laravel\Boost\Concerns\DisplayHelper;
@@ -43,13 +44,15 @@ use function Laravel\Prompts\note;
 
 class InstallCommand extends Command
 {
+    use ConfirmableTrait;
     use DisplayHelper;
 
     protected $signature = 'boost:install
         {--guidelines : Install AI guidelines}
         {--skills : Install agent skills}
         {--mcp : Install MCP server configuration}
-        {--fresh : Delete each agent\'s generated skills directory before installing}';
+        {--fresh : Delete and rebuild each selected agent\'s skills directory from Boost and .ai/skills}
+        {--force : Run a fresh skill rebuild without confirmation}';
 
     /** @var Collection<int, Agent> */
     private Collection $selectedAgents;
@@ -94,6 +97,16 @@ class InstallCommand extends Command
         $this->displayBoostHeader('Install', $this->projectName);
         $this->discoverEnvironment();
         $this->collectInstallationPreferences();
+
+        if ($this->selectedBoostFeatures->contains('skills')
+            && $this->option('fresh')
+            && ! $this->confirmToProceed(
+                "A fresh skill rebuild will recreate each selected agent's skills directory from scratch. Custom skills must be stored in [.ai/skills] as described in the documentation.",
+                true,
+            )) {
+            return self::FAILURE;
+        }
+
         $this->performInstallation();
 
         $this->reportRenderFailures();

--- a/src/Console/UpdateCommand.php
+++ b/src/Console/UpdateCommand.php
@@ -18,7 +18,8 @@ class UpdateCommand extends Command
     /** @var string */
     protected $signature = 'boost:update
         {--discover : Discover and prompt for newly available guidelines and skills}
-        {--ignore-skills : Skip updating the skills directory}';
+        {--ignore-skills : Skip updating the skills directory}
+        {--fresh : Delete each agent\'s generated skills directory and rebuild it from scratch}';
 
     public function handle(Config $config): int
     {
@@ -33,7 +34,7 @@ class UpdateCommand extends Command
         }
 
         $guidelines = $config->getGuidelines();
-        $hasSkills = ! $this->option('ignore-skills') && ($config->hasSkills() || is_dir(base_path('.ai/skills')));
+        $hasSkills = ! $this->option('ignore-skills') && ($config->hasSkills() || is_dir(base_path('.ai/skills')) || $this->option('fresh'));
 
         if (! $guidelines && ! $hasSkills) {
             return self::SUCCESS;
@@ -43,6 +44,7 @@ class UpdateCommand extends Command
             '--no-interaction' => true,
             '--guidelines' => $guidelines,
             '--skills' => $hasSkills,
+            '--fresh' => (bool) $this->option('fresh'),
         ]);
 
         $this->info('Boost guidelines and skills updated successfully.');

--- a/src/Console/UpdateCommand.php
+++ b/src/Console/UpdateCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laravel\Boost\Console;
 
 use Illuminate\Console\Command;
+use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Support\Collection;
 use Laravel\Boost\Install\ThirdPartyPackage;
 use Laravel\Boost\Support\Config;
@@ -15,12 +16,15 @@ use function Laravel\Prompts\multiselect;
 #[AsCommand('boost:update', 'Update the Laravel Boost guidelines & skills to the latest guidance')]
 class UpdateCommand extends Command
 {
+    use ConfirmableTrait;
+
     /** @var string */
     protected $signature = 'boost:update
         {--discover : Discover and prompt for newly available guidelines and skills (default)}
         {--no-discover : Skip discovering and prompting for newly available guidelines and skills}
         {--ignore-skills : Skip updating the skills directory}
-        {--fresh : Delete each agent\'s generated skills directory and rebuild it from scratch}';
+        {--fresh : Delete and rebuild each selected agent\'s skills directory from Boost and .ai/skills}
+        {--force : Run a fresh skill rebuild without confirmation}';
 
     public function handle(Config $config): int
     {
@@ -30,23 +34,37 @@ class UpdateCommand extends Command
             return self::FAILURE;
         }
 
+        $guidelines = $config->getGuidelines();
+        $hasSkills = ! $this->option('ignore-skills') && ($config->hasSkills() || is_dir(base_path('.ai/skills')));
+        $fresh = $hasSkills && (bool) $this->option('fresh');
+
+        if ($fresh && ! $this->confirmToProceed(
+            "A fresh skill rebuild will recreate each selected agent's skills directory from scratch. Custom skills must be stored in [.ai/skills] as described in the documentation.",
+            true,
+        )) {
+            return self::FAILURE;
+        }
+
         if (! $this->option('no-discover')) {
             $this->discoverNewContent($config);
         }
-
-        $guidelines = $config->getGuidelines();
-        $hasSkills = ! $this->option('ignore-skills') && ($config->hasSkills() || is_dir(base_path('.ai/skills')) || $this->option('fresh'));
 
         if (! $guidelines && ! $hasSkills) {
             return self::SUCCESS;
         }
 
-        $this->callSilently(InstallCommand::class, [
+        $arguments = [
             '--no-interaction' => true,
             '--guidelines' => $guidelines,
             '--skills' => $hasSkills,
-            '--fresh' => (bool) $this->option('fresh'),
-        ]);
+            '--fresh' => $fresh,
+        ];
+
+        if ($fresh) {
+            $arguments['--force'] = true;
+        }
+
+        $this->callSilently(InstallCommand::class, $arguments);
 
         $this->info('Boost guidelines and skills updated successfully.');
 

--- a/src/Install/SkillWriter.php
+++ b/src/Install/SkillWriter.php
@@ -161,17 +161,7 @@ class SkillWriter
     protected function deleteDirectory(string $path): bool
     {
         if (is_link($path)) {
-            if (@unlink($path)) {
-                return true;
-            }
-
-            // On Windows, directory symlinks can require rmdir instead of unlink,
-            // even when the symlink target no longer exists (dangling symlinks).
-            if (@rmdir($path)) {
-                return true;
-            }
-
-            return ! file_exists($path) && ! is_link($path);
+            return $this->deleteSymlink($path);
         }
 
         if (is_file($path)) {
@@ -189,11 +179,7 @@ class SkillWriter
 
         foreach ($files as $file) {
             if ($file->isLink()) {
-                $linkPath = $file->getPathname();
-
-                if (! @unlink($linkPath) && is_dir($linkPath)) {
-                    @rmdir($linkPath);
-                }
+                $this->deleteSymlink($file->getPathname());
 
                 continue;
             }
@@ -202,6 +188,21 @@ class SkillWriter
         }
 
         return @rmdir($path) || ! is_dir($path);
+    }
+
+    protected function deleteSymlink(string $path): bool
+    {
+        if (@unlink($path)) {
+            return true;
+        }
+
+        // On Windows, directory symlinks can require rmdir instead of unlink,
+        // even when the symlink target no longer exists (dangling symlinks).
+        if (@rmdir($path)) {
+            return true;
+        }
+
+        return ! file_exists($path) && ! is_link($path);
     }
 
     protected function copyDirectory(string $source, string $target): bool

--- a/src/Install/SkillWriter.php
+++ b/src/Install/SkillWriter.php
@@ -108,8 +108,15 @@ class SkillWriter
      * @param  array<int, string>  $previouslyTrackedSkills
      * @return array<string, int>
      */
-    public function sync(Collection $skills, array $previouslyTrackedSkills = []): array
+    public function sync(Collection $skills, array $previouslyTrackedSkills = [], bool $fresh = false): array
     {
+        $targetRoot = base_path($this->agent->skillsPath());
+        $canonicalRoot = base_path('.ai'.DIRECTORY_SEPARATOR.'skills');
+
+        if ($fresh && ! $this->pathsMatch($targetRoot, $canonicalRoot)) {
+            $this->deleteDirectory($targetRoot);
+        }
+
         $written = $this->writeAll($skills);
 
         $newSkillNames = $skills->keys()->all();

--- a/src/Install/SkillWriter.php
+++ b/src/Install/SkillWriter.php
@@ -113,7 +113,15 @@ class SkillWriter
         $targetRoot = base_path($this->agent->skillsPath());
         $canonicalRoot = base_path('.ai'.DIRECTORY_SEPARATOR.'skills');
 
-        if ($fresh && ! $this->pathsMatch($targetRoot, $canonicalRoot)) {
+        if ($fresh && (
+            $this->pathsMatch($targetRoot, $canonicalRoot)
+            || $this->pathIsWithin($targetRoot, $canonicalRoot)
+            || $this->pathIsWithin($canonicalRoot, $targetRoot)
+        )) {
+            throw new RuntimeException('Fresh skill target overlaps the canonical .ai/skills directory.');
+        }
+
+        if ($fresh) {
             $this->deleteDirectory($targetRoot);
         }
 
@@ -295,10 +303,23 @@ class SkillWriter
 
     protected function pathsMatch(string $left, string $right): bool
     {
-        $resolvedLeft = realpath($left) ?: $left;
-        $resolvedRight = realpath($right) ?: $right;
+        return $this->normalizePath($left) === $this->normalizePath($right);
+    }
 
-        return rtrim($resolvedLeft, DIRECTORY_SEPARATOR) === rtrim($resolvedRight, DIRECTORY_SEPARATOR);
+    protected function pathIsWithin(string $path, string $directory): bool
+    {
+        return str_starts_with(
+            $this->normalizePath($path),
+            $this->normalizePath($directory).DIRECTORY_SEPARATOR,
+        );
+    }
+
+    protected function normalizePath(string $path): string
+    {
+        $resolvedPath = realpath($path) ?: $path;
+        $normalizedPath = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $resolvedPath);
+
+        return rtrim($normalizedPath, DIRECTORY_SEPARATOR);
     }
 
     protected function relativePath(string $target, string $from): string

--- a/tests/Feature/Console/InstallCommandNonInteractiveTest.php
+++ b/tests/Feature/Console/InstallCommandNonInteractiveTest.php
@@ -37,9 +37,14 @@ function makeTestInstallCommand(Config $config, ?AgentsDetector $detector = null
 
     return new class($detector ?? app(AgentsDetector::class), Mockery::mock(Cloud::class), $config, $nightwatch, $sail, $terminal) extends InstallCommand
     {
+        public bool $performedInstallation = false;
+
         protected function displayBoostHeader(string $featureName, string $projectName, ?Theme $theme = null): void {}
 
-        protected function performInstallation(): void {}
+        protected function performInstallation(): void
+        {
+            $this->performedInstallation = true;
+        }
 
         protected function outro(): void {}
     };
@@ -75,4 +80,47 @@ it('silently drops stale agents no longer in the available list in non-interacti
     $command->setLaravel(app());
 
     expect($command->run($input, new NullOutput))->toBe(0);
+})->skipOnWindows();
+
+it('cancels a non-interactive fresh install without force', function (): void {
+    $config = new Config;
+    $config->setAgents(['claude_code']);
+    $config->setSkills(['test-skill']);
+
+    $command = makeTestInstallCommand($config);
+
+    expect($command->getDefinition()->hasOption('force'))->toBeTrue();
+
+    $input = new ArrayInput([
+        '--skills' => true,
+        '--fresh' => true,
+    ], $command->getDefinition());
+    $input->setInteractive(false);
+
+    $command->setLaravel(app());
+
+    expect($command->run($input, new NullOutput))->toBe(InstallCommand::FAILURE)
+        ->and($command->performedInstallation)->toBeFalse();
+})->skipOnWindows();
+
+it('forces a non-interactive fresh install', function (): void {
+    $config = new Config;
+    $config->setAgents(['claude_code']);
+    $config->setSkills(['test-skill']);
+
+    $command = makeTestInstallCommand($config);
+
+    expect($command->getDefinition()->hasOption('force'))->toBeTrue();
+
+    $input = new ArrayInput([
+        '--skills' => true,
+        '--fresh' => true,
+        '--force' => true,
+    ], $command->getDefinition());
+    $input->setInteractive(false);
+
+    $command->setLaravel(app());
+
+    expect($command->run($input, new NullOutput))->toBe(InstallCommand::SUCCESS)
+        ->and($command->performedInstallation)->toBeTrue();
 })->skipOnWindows();

--- a/tests/Feature/Console/UpdateCommandTest.php
+++ b/tests/Feature/Console/UpdateCommandTest.php
@@ -75,12 +75,14 @@ it('calls install command with a guidelines flag when guidelines are enabled', f
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('fresh')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
             '--no-interaction' => true,
             '--guidelines' => true,
             '--skills' => false,
+            '--fresh' => false,
         ])
         ->andReturn(0);
 
@@ -102,12 +104,14 @@ it('calls install command with skills flag when skills are configured', function
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('fresh')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
             '--no-interaction' => true,
             '--guidelines' => false,
             '--skills' => true,
+            '--fresh' => false,
         ])
         ->andReturn(0);
 
@@ -129,12 +133,14 @@ it('calls install command with both flags when guidelines and skills are enabled
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('fresh')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
             '--no-interaction' => true,
             '--guidelines' => true,
             '--skills' => true,
+            '--fresh' => false,
         ])
         ->andReturn(0);
 
@@ -156,12 +162,14 @@ it('does not pass mcp flag to install command even when mcp is configured', func
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('fresh')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
             '--no-interaction' => true,
             '--guidelines' => true,
             '--skills' => false,
+            '--fresh' => false,
         ])
         ->andReturn(0);
 
@@ -183,12 +191,14 @@ it('preserves sail configuration when updating guidelines', function (): void {
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('fresh')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
             '--no-interaction' => true,
             '--guidelines' => true,
             '--skills' => false,
+            '--fresh' => false,
         ])
         ->andReturnUsing(fn (): int => 0);
 
@@ -211,12 +221,14 @@ it('preserves non-sail configuration when updating guidelines', function (): voi
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('fresh')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
             '--no-interaction' => true,
             '--guidelines' => true,
             '--skills' => false,
+            '--fresh' => false,
         ])
         ->andReturn(0);
 
@@ -239,12 +251,14 @@ it('preserves sail configuration when updating skills', function (): void {
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('fresh')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
             '--no-interaction' => true,
             '--guidelines' => false,
             '--skills' => true,
+            '--fresh' => false,
         ])
         ->andReturn(0);
 
@@ -268,12 +282,14 @@ it('calls install command with skills flag when .ai/skills directory exists but 
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('fresh')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
             '--no-interaction' => true,
             '--guidelines' => false,
             '--skills' => true,
+            '--fresh' => false,
         ])
         ->andReturn(0);
 
@@ -308,6 +324,7 @@ it('does not run discovery when --discover flag is not set', function (): void {
         ->shouldAllowMockingProtectedMethods();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('fresh')->andReturn(false);
     $command->shouldNotReceive('discoverNewContent');
     $command->shouldReceive('callSilently')
         ->once()
@@ -315,6 +332,7 @@ it('does not run discovery when --discover flag is not set', function (): void {
             '--no-interaction' => true,
             '--guidelines' => false,
             '--skills' => true,
+            '--fresh' => false,
         ])
         ->andReturn(0);
     $command->setLaravel($this->app);
@@ -338,6 +356,7 @@ it('does not change config when no new packages are found with --discover', func
         ->shouldAllowMockingProtectedMethods();
     $command->shouldReceive('option')->with('discover')->andReturn(true);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('fresh')->andReturn(false);
     $command->shouldReceive('resolveNewPackages')->andReturn(collect());
     $command->shouldReceive('callSilently')->once()->andReturn(0);
     $command->setLaravel($this->app);
@@ -366,6 +385,7 @@ it('adds selected new packages to config when using --discover', function (): vo
         ->shouldAllowMockingProtectedMethods();
     $command->shouldReceive('option')->with('discover')->andReturn(true);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('fresh')->andReturn(false);
     $command->shouldReceive('resolveNewPackages')
         ->andReturn(collect(['vendor/awesome-pkg' => $newPackage]));
     $command->shouldReceive('callSilently')->andReturn(0);
@@ -388,12 +408,14 @@ it('skips skills when --ignore-skills flag is set even if skills are configured'
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(true);
+    $command->shouldReceive('option')->with('fresh')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
             '--no-interaction' => true,
             '--guidelines' => true,
             '--skills' => false,
+            '--fresh' => false,
         ])
         ->andReturn(0);
 
@@ -416,12 +438,14 @@ it('skips skills when --ignore-skills flag is set even if .ai/skills directory e
     $command = Mockery::mock(UpdateCommand::class)->makePartial();
     $command->shouldReceive('option')->with('discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(true);
+    $command->shouldReceive('option')->with('fresh')->andReturn(false);
     $command->shouldReceive('callSilently')
         ->once()
         ->with(InstallCommand::class, [
             '--no-interaction' => true,
             '--guidelines' => true,
             '--skills' => false,
+            '--fresh' => false,
         ])
         ->andReturn(0);
 
@@ -443,4 +467,62 @@ it('exits silently when --ignore-skills flag is set and no guidelines are config
     $this->artisan('boost:update', ['--ignore-skills' => true])
         ->doesntExpectOutputToContain('Boost guidelines and skills updated successfully.')
         ->assertSuccessful();
+});
+
+it('forwards the fresh flag to the install command', function (): void {
+    $config = new Config;
+    $config->setAgents(['claude_code']);
+    $config->setGuidelines(true);
+    $config->setSkills(['test-skill']);
+
+    $command = Mockery::mock(UpdateCommand::class)->makePartial();
+    $command->shouldReceive('option')->with('discover')->andReturn(false);
+    $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('fresh')->andReturn(true);
+    $command->shouldReceive('callSilently')
+        ->once()
+        ->with(InstallCommand::class, [
+            '--no-interaction' => true,
+            '--guidelines' => true,
+            '--skills' => true,
+            '--fresh' => true,
+        ])
+        ->andReturn(0);
+
+    $input = new ArrayInput([]);
+    $output = new OutputStyle($input, new BufferedOutput);
+
+    $command->setLaravel($this->app);
+    $command->setOutput($output);
+
+    expect($command->handle($config))->toBe(0);
+});
+
+it('enables skills when --fresh is set even with no skills configured', function (): void {
+    $config = new Config;
+    $config->setAgents(['claude_code']);
+    $config->setGuidelines(false);
+    $config->setSkills([]);
+
+    $command = Mockery::mock(UpdateCommand::class)->makePartial();
+    $command->shouldReceive('option')->with('discover')->andReturn(false);
+    $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('option')->with('fresh')->andReturn(true);
+    $command->shouldReceive('callSilently')
+        ->once()
+        ->with(InstallCommand::class, [
+            '--no-interaction' => true,
+            '--guidelines' => false,
+            '--skills' => true,
+            '--fresh' => true,
+        ])
+        ->andReturn(0);
+
+    $input = new ArrayInput([]);
+    $output = new OutputStyle($input, new BufferedOutput);
+
+    $command->setLaravel($this->app);
+    $command->setOutput($output);
+
+    expect($command->handle($config))->toBe(0);
 });

--- a/tests/Feature/Console/UpdateCommandTest.php
+++ b/tests/Feature/Console/UpdateCommandTest.php
@@ -33,6 +33,50 @@ afterEach(function (): void {
     }
 });
 
+function makeTestUpdateCommand(): UpdateCommand
+{
+    return new class extends UpdateCommand
+    {
+        public ?string $calledCommand = null;
+
+        /** @var null|array<string, bool> */
+        public ?array $calledArguments = null;
+
+        public ?bool $confirmation = null;
+
+        public int $confirmationCalls = 0;
+
+        /** @var array<int, string> */
+        public array $packagesToDiscover = [];
+
+        public int $discoveryCalls = 0;
+
+        public function confirmToProceed($warning = 'Application In Production', $callback = null): bool
+        {
+            $this->confirmationCalls++;
+
+            return $this->confirmation ?? parent::confirmToProceed($warning, $callback);
+        }
+
+        public function callSilently($command, array $arguments = []): int
+        {
+            $this->calledCommand = $command;
+            $this->calledArguments = $arguments;
+
+            return self::SUCCESS;
+        }
+
+        protected function discoverNewContent(Config $config): void
+        {
+            $this->discoveryCalls++;
+
+            if ($this->packagesToDiscover !== []) {
+                $config->setPackages(array_merge($config->getPackages(), $this->packagesToDiscover));
+            }
+        }
+    };
+}
+
 it('it shows an error when boost.json does not exist', function (): void {
     $this->artisan('boost:update')
         ->expectsOutputToContain('Please set up Boost with [php artisan boost:install] first.')
@@ -501,36 +545,110 @@ it('exits silently when --ignore-skills flag is set and no guidelines are config
         ->assertSuccessful();
 });
 
-it('forwards the fresh flag to the install command', function (): void {
+it('confirms and forwards the fresh flag to the install command', function (): void {
     $config = new Config;
     $config->setAgents(['claude_code']);
     $config->setGuidelines(true);
     $config->setSkills(['test-skill']);
 
-    $command = Mockery::mock(UpdateCommand::class)->makePartial();
-    $command->shouldReceive('option')->with('no-discover')->andReturn(true);
-    $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
-    $command->shouldReceive('option')->with('fresh')->andReturn(true);
-    $command->shouldReceive('callSilently')
-        ->once()
-        ->with(InstallCommand::class, [
+    $command = makeTestUpdateCommand();
+    $command->confirmation = true;
+
+    $input = new ArrayInput([
+        '--no-discover' => true,
+        '--fresh' => true,
+    ], $command->getDefinition());
+
+    $command->setLaravel($this->app);
+
+    expect($command->run($input, new BufferedOutput))->toBe(0)
+        ->and($command->confirmationCalls)->toBe(1)
+        ->and($command->calledCommand)->toBe(InstallCommand::class)
+        ->and($command->calledArguments)->toBe([
             '--no-interaction' => true,
             '--guidelines' => true,
             '--skills' => true,
             '--fresh' => true,
-        ])
-        ->andReturn(0);
-
-    $input = new ArrayInput([]);
-    $output = new OutputStyle($input, new BufferedOutput);
-
-    $command->setLaravel($this->app);
-    $command->setOutput($output);
-
-    expect($command->handle($config))->toBe(0);
+            '--force' => true,
+        ]);
 });
 
-it('enables skills when --fresh is set even with no skills configured', function (): void {
+it('cancels a fresh update when confirmation is declined', function (): void {
+    $config = new Config;
+    $config->setAgents(['claude_code']);
+    $config->setGuidelines(true);
+    $config->setSkills(['test-skill']);
+
+    $command = makeTestUpdateCommand();
+    $command->confirmation = false;
+
+    $input = new ArrayInput([
+        '--no-discover' => true,
+        '--fresh' => true,
+    ], $command->getDefinition());
+
+    $command->setLaravel($this->app);
+
+    expect($command->run($input, new BufferedOutput))->toBe(UpdateCommand::FAILURE)
+        ->and($command->confirmationCalls)->toBe(1)
+        ->and($command->calledCommand)->toBeNull()
+        ->and($command->calledArguments)->toBeNull();
+});
+
+it('does not discover or persist packages when a fresh update is declined', function (): void {
+    $config = new Config;
+    $config->setAgents(['claude_code']);
+    $config->setGuidelines(true);
+    $config->setSkills(['test-skill']);
+    $config->setPackages(['vendor/existing-package']);
+
+    $command = makeTestUpdateCommand();
+    $command->confirmation = false;
+    $command->packagesToDiscover = ['vendor/new-package'];
+
+    $input = new ArrayInput([
+        '--fresh' => true,
+    ], $command->getDefinition());
+
+    $command->setLaravel($this->app);
+
+    expect($command->run($input, new BufferedOutput))->toBe(UpdateCommand::FAILURE)
+        ->and($command->confirmationCalls)->toBe(1)
+        ->and($command->discoveryCalls)->toBe(0)
+        ->and($config->getPackages())->toBe(['vendor/existing-package'])
+        ->and($command->calledCommand)->toBeNull();
+});
+
+it('forces a fresh update without confirmation', function (): void {
+    $config = new Config;
+    $config->setAgents(['claude_code']);
+    $config->setGuidelines(true);
+    $config->setSkills(['test-skill']);
+
+    $command = makeTestUpdateCommand();
+
+    $input = new ArrayInput([
+        '--no-discover' => true,
+        '--fresh' => true,
+        '--force' => true,
+    ], $command->getDefinition());
+    $input->setInteractive(false);
+
+    $command->setLaravel($this->app);
+
+    expect($command->run($input, new BufferedOutput))->toBe(UpdateCommand::SUCCESS)
+        ->and($command->confirmationCalls)->toBe(1)
+        ->and($command->calledCommand)->toBe(InstallCommand::class)
+        ->and($command->calledArguments)->toBe([
+            '--no-interaction' => true,
+            '--guidelines' => true,
+            '--skills' => true,
+            '--fresh' => true,
+            '--force' => true,
+        ]);
+});
+
+it('does not enable skills when --fresh is set with no skills configured', function (): void {
     $config = new Config;
     $config->setAgents(['claude_code']);
     $config->setGuidelines(false);
@@ -540,15 +658,7 @@ it('enables skills when --fresh is set even with no skills configured', function
     $command->shouldReceive('option')->with('no-discover')->andReturn(true);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
     $command->shouldReceive('option')->with('fresh')->andReturn(true);
-    $command->shouldReceive('callSilently')
-        ->once()
-        ->with(InstallCommand::class, [
-            '--no-interaction' => true,
-            '--guidelines' => false,
-            '--skills' => true,
-            '--fresh' => true,
-        ])
-        ->andReturn(0);
+    $command->shouldNotReceive('callSilently');
 
     $input = new ArrayInput([]);
     $output = new OutputStyle($input, new BufferedOutput);
@@ -556,7 +666,34 @@ it('enables skills when --fresh is set even with no skills configured', function
     $command->setLaravel($this->app);
     $command->setOutput($output);
 
-    expect($command->handle($config))->toBe(0);
+    expect($command->handle($config))->toBe(UpdateCommand::SUCCESS);
+});
+
+it('updates only guidelines when --fresh is set on a guidelines-only project', function (): void {
+    $config = new Config;
+    $config->setAgents(['claude_code']);
+    $config->setGuidelines(true);
+    $config->setSkills([]);
+
+    $command = makeTestUpdateCommand();
+
+    $input = new ArrayInput([
+        '--no-discover' => true,
+        '--fresh' => true,
+    ], $command->getDefinition());
+    $input->setInteractive(false);
+
+    $command->setLaravel($this->app);
+
+    expect($command->run($input, new BufferedOutput))->toBe(UpdateCommand::SUCCESS)
+        ->and($command->confirmationCalls)->toBe(0)
+        ->and($command->calledCommand)->toBe(InstallCommand::class)
+        ->and($command->calledArguments)->toBe([
+            '--no-interaction' => true,
+            '--guidelines' => true,
+            '--skills' => false,
+            '--fresh' => false,
+        ]);
 });
 
 it('skips new-package discovery prompt when running in non-interactive mode', function (): void {

--- a/tests/Unit/Install/SkillWriterTest.php
+++ b/tests/Unit/Install/SkillWriterTest.php
@@ -9,7 +9,7 @@ use Laravel\Boost\Install\SkillWriter;
 function cleanupSkillDirectory(string $path): void
 {
     if (is_link($path)) {
-        @unlink($path);
+        @unlink($path) || @rmdir($path);
 
         return;
     }
@@ -25,7 +25,7 @@ function cleanupSkillDirectory(string $path): void
 
     foreach ($files as $file) {
         if ($file->isLink()) {
-            @unlink($file->getPathname());
+            @unlink($file->getPathname()) || @rmdir($file->getPathname());
 
             continue;
         }
@@ -616,6 +616,46 @@ it('removes directory containing nested symlinks', function (): void {
 
     cleanupSkillDirectory($absoluteTarget);
     cleanupSkillDirectory($linkTargetDir);
+});
+
+it('removes directory containing nested dangling symlinks', function (): void {
+    $relativeTarget = '.boost-test-skills-'.uniqid();
+    $absoluteTarget = base_path($relativeTarget);
+    $skillDir = $absoluteTarget.'/symlink-skill';
+    $nestedDir = $skillDir.'/references';
+    $linkTargetDir = base_path('.boost-link-target-'.uniqid());
+
+    mkdir($nestedDir, 0755, true);
+    mkdir($linkTargetDir, 0755, true);
+    file_put_contents($skillDir.'/SKILL.md', 'test');
+
+    $symlinkPath = $nestedDir.'/linked-dir';
+
+    if (! @symlink($linkTargetDir, $symlinkPath)) {
+        cleanupSkillDirectory($absoluteTarget);
+        cleanupSkillDirectory($linkTargetDir);
+        $this->markTestSkipped('Symlinks not supported in this environment');
+    }
+
+    cleanupSkillDirectory($linkTargetDir);
+
+    if (! is_link($symlinkPath)) {
+        cleanupSkillDirectory($absoluteTarget);
+        $this->markTestSkipped('Dangling symlink not detectable in this environment');
+    }
+
+    $agent = Mockery::mock(SupportsSkills::class);
+    $agent->shouldReceive('skillsPath')->andReturn($relativeTarget);
+
+    $writer = new SkillWriter($agent);
+    $result = $writer->remove('symlink-skill');
+
+    expect($result)->toBeTrue()
+        ->and($skillDir)->not->toBeDirectory()
+        ->and(is_link($symlinkPath))->toBeFalse()
+        ->and($linkTargetDir)->not->toBeDirectory();
+
+    cleanupSkillDirectory($absoluteTarget);
 });
 
 it('creates canonical directory and symlinks custom skill when canonical does not exist', function (): void {

--- a/tests/Unit/Install/SkillWriterTest.php
+++ b/tests/Unit/Install/SkillWriterTest.php
@@ -1069,6 +1069,149 @@ it('creates relative symlink when skills path is outside the project root', func
     cleanupSkillDirectory($canonicalSkillPath);
 });
 
+it('fresh sync removes untracked entries before rewriting skills', function (): void {
+    $sourceDir = fixture('skills/test-skill');
+    $relativeTarget = '.boost-test-skills-'.uniqid();
+    $absoluteTarget = base_path($relativeTarget);
+
+    $orphanedDir = $absoluteTarget.'/orphaned-skill';
+    mkdir($orphanedDir, 0755, true);
+    file_put_contents($orphanedDir.'/SKILL.md', 'orphaned content');
+
+    $agent = Mockery::mock(SupportsSkills::class);
+    $agent->shouldReceive('skillsPath')->andReturn($relativeTarget);
+
+    $skills = collect([
+        'new-skill' => new Skill('new-skill', 'boost', $sourceDir, 'New skill'),
+    ]);
+
+    $writer = new SkillWriter($agent);
+    $result = $writer->sync($skills, [], fresh: true);
+
+    expect($result['new-skill'])->toBe(SkillWriter::SUCCESS)
+        ->and($absoluteTarget.'/new-skill/SKILL.md')->toBeFile()
+        ->and($orphanedDir)->not->toBeDirectory();
+
+    cleanupSkillDirectory($absoluteTarget);
+});
+
+it('fresh sync removes dangling symlinks', function (): void {
+    $sourceDir = fixture('skills/test-skill');
+    $relativeTarget = '.boost-test-skills-'.uniqid();
+    $absoluteTarget = base_path($relativeTarget);
+    $danglingTarget = base_path('.boost-dangling-'.uniqid());
+    $danglingLink = $absoluteTarget.'/deleted-custom-skill';
+
+    mkdir($danglingTarget, 0755, true);
+    mkdir($absoluteTarget, 0755, true);
+
+    if (! @symlink($danglingTarget, $danglingLink)) {
+        cleanupSkillDirectory($danglingTarget);
+        cleanupSkillDirectory($absoluteTarget);
+        $this->markTestSkipped('Symlinks not supported in this environment');
+    }
+
+    cleanupSkillDirectory($danglingTarget);
+
+    $agent = Mockery::mock(SupportsSkills::class);
+    $agent->shouldReceive('skillsPath')->andReturn($relativeTarget);
+
+    $skills = collect([
+        'new-skill' => new Skill('new-skill', 'boost', $sourceDir, 'New skill'),
+    ]);
+
+    $writer = new SkillWriter($agent);
+    $result = $writer->sync($skills, [], fresh: true);
+
+    expect($result['new-skill'])->toBe(SkillWriter::SUCCESS)
+        ->and(is_link($danglingLink))->toBeFalse()
+        ->and($absoluteTarget.'/new-skill/SKILL.md')->toBeFile();
+
+    cleanupSkillDirectory($absoluteTarget);
+});
+
+it('fresh sync preserves canonical skills behind symlinks', function (): void {
+    $relativeTarget = '.boost-test-skills-'.uniqid();
+    $absoluteTarget = base_path($relativeTarget);
+    $skillName = 'test-skill-'.uniqid();
+    $canonicalSkillPath = base_path('.ai/skills/'.$skillName);
+
+    mkdir($canonicalSkillPath, 0755, true);
+    copy(fixture('skills/test-skill/SKILL.md'), $canonicalSkillPath.'/SKILL.md');
+
+    $agent = Mockery::mock(SupportsSkills::class);
+    $agent->shouldReceive('skillsPath')->andReturn($relativeTarget);
+
+    $skills = collect([
+        $skillName => new Skill($skillName, 'boost', $canonicalSkillPath, 'Custom skill', custom: true),
+    ]);
+
+    $writer = new SkillWriter($agent);
+    $writer->sync($skills);
+
+    $result = $writer->sync($skills, [], fresh: true);
+
+    expect($result[$skillName])->toBe(SkillWriter::SUCCESS)
+        ->and($canonicalSkillPath)->toBeDirectory()
+        ->and($canonicalSkillPath.'/SKILL.md')->toBeFile();
+
+    $linkedPath = $absoluteTarget.'/'.$skillName;
+
+    if (is_link($linkedPath)) {
+        expect(realpath($linkedPath))->toBe(realpath($canonicalSkillPath));
+    } else {
+        expect($linkedPath)->toBeDirectory();
+    }
+
+    cleanupSkillDirectory($absoluteTarget);
+    cleanupSkillDirectory($canonicalSkillPath);
+});
+
+it('fresh sync preserves canonical custom skills when target is the canonical skills path', function (): void {
+    $skillName = 'test-skill-'.uniqid();
+    $canonicalSkillPath = base_path('.ai/skills/'.$skillName);
+
+    mkdir($canonicalSkillPath, 0755, true);
+    copy(fixture('skills/test-skill/SKILL.md'), $canonicalSkillPath.'/SKILL.md');
+
+    $agent = Mockery::mock(SupportsSkills::class);
+    $agent->shouldReceive('skillsPath')->andReturn('.ai/skills');
+
+    $skills = collect([
+        $skillName => new Skill($skillName, 'boost', $canonicalSkillPath, 'Custom skill', custom: true),
+    ]);
+
+    $writer = new SkillWriter($agent);
+    $result = $writer->sync($skills, [], fresh: true);
+
+    expect($result[$skillName])->toBe(SkillWriter::UPDATED)
+        ->and($canonicalSkillPath)->toBeDirectory()
+        ->and($canonicalSkillPath.'/SKILL.md')->toBeFile();
+
+    cleanupSkillDirectory($canonicalSkillPath);
+});
+
+it('fresh sync works when the skills directory does not exist', function (): void {
+    $sourceDir = fixture('skills/test-skill');
+    $relativeTarget = '.boost-test-skills-'.uniqid();
+    $absoluteTarget = base_path($relativeTarget);
+
+    $agent = Mockery::mock(SupportsSkills::class);
+    $agent->shouldReceive('skillsPath')->andReturn($relativeTarget);
+
+    $skills = collect([
+        'new-skill' => new Skill('new-skill', 'boost', $sourceDir, 'New skill'),
+    ]);
+
+    $writer = new SkillWriter($agent);
+    $result = $writer->sync($skills, [], fresh: true);
+
+    expect($result['new-skill'])->toBe(SkillWriter::SUCCESS)
+        ->and($absoluteTarget.'/new-skill/SKILL.md')->toBeFile();
+
+    cleanupSkillDirectory($absoluteTarget);
+});
+
 it('writes skill files with a trailing newline', function (): void {
     $sourceDir = fixture('skills/test-skill');
     $relativeTarget = '.boost-test-skills-'.uniqid();

--- a/tests/Unit/Install/SkillWriterTest.php
+++ b/tests/Unit/Install/SkillWriterTest.php
@@ -1207,29 +1207,31 @@ it('fresh sync preserves canonical skills behind symlinks', function (): void {
     cleanupSkillDirectory($canonicalSkillPath);
 });
 
-it('fresh sync preserves canonical custom skills when target is the canonical skills path', function (): void {
-    $skillName = 'test-skill-'.uniqid();
-    $canonicalSkillPath = base_path('.ai/skills/'.$skillName);
-
-    mkdir($canonicalSkillPath, 0755, true);
-    copy(fixture('skills/test-skill/SKILL.md'), $canonicalSkillPath.'/SKILL.md');
-
+it('fresh sync rejects targets that overlap the canonical skills directory', function (string $skillsPath): void {
     $agent = Mockery::mock(SupportsSkills::class);
-    $agent->shouldReceive('skillsPath')->andReturn('.ai/skills');
+    $agent->shouldReceive('skillsPath')->andReturn($skillsPath);
 
-    $skills = collect([
-        $skillName => new Skill($skillName, 'boost', $canonicalSkillPath, 'Custom skill', custom: true),
-    ]);
+    $writer = new class($agent) extends SkillWriter
+    {
+        /** @var array<int, string> */
+        public array $deletedPaths = [];
 
-    $writer = new SkillWriter($agent);
-    $result = $writer->sync($skills, [], fresh: true);
+        protected function deleteDirectory(string $path): bool
+        {
+            $this->deletedPaths[] = $path;
 
-    expect($result[$skillName])->toBe(SkillWriter::UPDATED)
-        ->and($canonicalSkillPath)->toBeDirectory()
-        ->and($canonicalSkillPath.'/SKILL.md')->toBeFile();
+            return true;
+        }
+    };
 
-    cleanupSkillDirectory($canonicalSkillPath);
-});
+    expect(fn (): array => $writer->sync(collect(), [], fresh: true))
+        ->toThrow(RuntimeException::class, 'Fresh skill target overlaps the canonical .ai/skills directory.')
+        ->and($writer->deletedPaths)->toBeEmpty();
+})->with([
+    'canonical directory' => '.ai/skills',
+    'canonical directory ancestor' => '.ai',
+    'canonical directory descendant' => '.ai/skills/generated-output',
+]);
 
 it('fresh sync works when the skills directory does not exist', function (): void {
     $sourceDir = fixture('skills/test-skill');
@@ -1250,6 +1252,24 @@ it('fresh sync works when the skills directory does not exist', function (): voi
         ->and($absoluteTarget.'/new-skill/SKILL.md')->toBeFile();
 
     cleanupSkillDirectory($absoluteTarget);
+});
+
+it('fresh sync leaves generated output empty when there are no skills to write', function (): void {
+    $relativeTarget = '.boost-test-skills-'.uniqid();
+    $absoluteTarget = base_path($relativeTarget);
+    $existingSkill = $absoluteTarget.'/existing-skill';
+
+    mkdir($existingSkill, 0755, true);
+    file_put_contents($existingSkill.'/SKILL.md', 'existing content');
+
+    $agent = Mockery::mock(SupportsSkills::class);
+    $agent->shouldReceive('skillsPath')->andReturn($relativeTarget);
+
+    $writer = new SkillWriter($agent);
+    $result = $writer->sync(collect(), [], fresh: true);
+
+    expect($result)->toBe([])
+        ->and($absoluteTarget)->not->toBeDirectory();
 });
 
 it('writes skill files with a trailing newline', function (): void {


### PR DESCRIPTION
Adds a `--fresh` flag to `boost:update` and `boost:install` that deletes each selected agent’s generated skills directory before running the normal skill sync.

## Why

We have run into this a few times in real projects: generated skill folders can end up with dangling symlinks, stale files, or broken copied directories after switching between operating systems, resolving merge conflicts, or committing generated agent output by mistake.

The fix was always straightforward: delete the generated skills folder manually, then rerun `boost:update` or `boost:install`.

This flag makes that cleanup an explicit Boost workflow instead of a manual recovery step.

## Behavior

When `--fresh` is passed, Boost removes the generated skills directory for each selected agent before syncing skills again.

Default behavior is unchanged unless `--fresh` is passed.

`.ai/skills` remains untouched.

## Use case

This is useful when generated agent directories contain files that are no longer part of the current Boost sync result. Without deleting the generated directory first, those stale files can remain present and continue influencing the agent.

Example:

```bash
php artisan boost:update --fresh
```

or:

```bash
php artisan boost:install --fresh
```

## Safety

The source `.ai/skills` directory is preserved.

Running `boost:update` or `boost:install` without `--fresh` behaves exactly as before.

## Tests

Tests cover:

* `boost:update --fresh`
* `boost:install --fresh`
* `.ai/skills` is preserved
* only selected agents are cleaned
* normal behavior is unchanged without `--fresh`
