### PR TITLE
docs: use handle() in action class example instead of execute

### DIFF
--- a/.ai/laravel/skill/laravel-best-practices/rules/architecture.md
+++ b/.ai/laravel/skill/laravel-best-practices/rules/architecture.md
@@ -9,7 +9,7 @@ class CreateOrderAction
 {
     public function __construct(private InventoryService $inventory) {}
 
-    public function execute(array $data): Order
+    public function handle(array $data): Order
     {
         $order = Order::create($data);
         $this->inventory->reserve($order);


### PR DESCRIPTION
Using handle() for action methods instead of aligns with Laravel conventions and matches the framework’s naming style in jobs, middleware, and similar classes.