### PR TITLE
Testing with interactive ptys

### DIFF
--- a/src/Console/AddSkillCommand.php
+++ b/src/Console/AddSkillCommand.php
@@ -249,7 +249,7 @@ class AddSkillCommand extends Command
             return true;
         }
 
-        if (! stream_isatty(STDIN)) {
+        if (! $this->input->isInteractive()) {
             return false;
         }
 
@@ -335,7 +335,7 @@ class AddSkillCommand extends Command
 
         $this->displayAuditResults($auditResults, $skillNames);
 
-        if (! stream_isatty(STDIN)) {
+        if (! $this->input->isInteractive()) {
             return true;
         }
 

--- a/tests/Feature/Console/AddSkillCommandTest.php
+++ b/tests/Feature/Console/AddSkillCommandTest.php
@@ -143,6 +143,7 @@ it('skips existing skills without --force flag', function (): void {
     $this->artisan('boost:add-skill', [
         'repo' => 'owner/repo',
         '--all' => true,
+        '--no-interaction' => true,
     ])->assertSuccessful();
 
     $this->assertFileContains(['existing content'], '.ai/skills/skill-one/SKILL.md');
@@ -289,6 +290,7 @@ it('displays audit results before installing skills when risk is medium or highe
     $this->artisan('boost:add-skill', [
         'repo' => 'owner/repo',
         '--all' => true,
+        '--no-interaction' => true,
     ])
         ->expectsOutputToContain('Security Audit')
         ->expectsOutputToContain('Skills installed')
@@ -457,6 +459,7 @@ it('audits only skills that will be installed', function (): void {
     $this->artisan('boost:add-skill', [
         'repo' => 'owner/repo',
         '--all' => true,
+        '--no-interaction' => true,
     ])->assertSuccessful();
 
     Http::assertSent(function ($request): bool {


### PR DESCRIPTION
Hi there!

I was trying to work on another PR and noticed that running `pest` with a regular interactive shell would just hang forever.  I _think_ these changes fix the same pattern across a few tests - they do locally for me - but I've not done a full sweep of macos vs Debian vs Rocky vs Fedora vs ...  But on macos and debian running `pest` now passes.


