### PR TITLE
fix: prefer opencode.jsonc when updating existing configuration

### DIFF
--- a/src/Install/Agents/OpenCode.php
+++ b/src/Install/Agents/OpenCode.php
@@ -38,7 +38,7 @@ class OpenCode extends Agent implements SupportsGuidelines, SupportsMcp, Support
     public function projectDetectionConfig(): array
     {
         return [
-            'files' => ['opencode.json'],
+            'files' => ['opencode.json', 'opencode.jsonc'],
         ];
     }
 
@@ -49,7 +49,13 @@ class OpenCode extends Agent implements SupportsGuidelines, SupportsMcp, Support
 
     public function mcpConfigPath(): string
     {
-        return config('boost.agents.opencode.mcp_config_path', 'opencode.json');
+        if ($configured = config('boost.agents.opencode.mcp_config_path')) {
+            return $configured;
+        }
+
+        return file_exists(base_path('opencode.jsonc'))
+            ? 'opencode.jsonc'
+            : 'opencode.json';
     }
 
     public function guidelinesPath(): string

--- a/tests/Unit/Install/Agents/OpenCodeTest.php
+++ b/tests/Unit/Install/Agents/OpenCodeTest.php
@@ -12,11 +12,11 @@ beforeEach(function (): void {
     $this->strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
 });
 
-test('projectDetectionConfig only uses opencode.json', function (): void {
+test('projectDetectionConfig checks for both opencode.jsonc and opencode.json', function (): void {
     $agent = new OpenCode($this->strategyFactory);
 
     expect($agent->projectDetectionConfig())->toBe([
-        'files' => ['opencode.json'],
+        'files' => ['opencode.json', 'opencode.jsonc'],
     ]);
 });
 
@@ -32,6 +32,25 @@ test('detectInProject returns false when only AGENTS.md exists', function (): vo
         unlink($tempDir.DIRECTORY_SEPARATOR.'AGENTS.md');
         rmdir($tempDir);
     }
+});
+
+test('mcpConfigPath prefers opencode.jsonc when it exists', function (): void {
+    $agent = new OpenCode($this->strategyFactory);
+    $jsoncPath = base_path('opencode.jsonc');
+
+    touch($jsoncPath);
+
+    try {
+        expect($agent->mcpConfigPath())->toBe('opencode.jsonc');
+    } finally {
+        unlink($jsoncPath);
+    }
+});
+
+test('mcpConfigPath returns opencode.json when jsonc does not exist', function (): void {
+    $agent = new OpenCode($this->strategyFactory);
+
+    expect($agent->mcpConfigPath())->toBe('opencode.json');
 });
 
 test('httpMcpServerConfig returns remote type config', function (): void {


### PR DESCRIPTION
## Description

When running `php artisan boost:install` with the OpenCode agent selected, if an `opencode.jsonc` file already exists in the project, the command now updates it in place instead of creating a new `opencode.json` file.

## Why This Fix

The issue reported in #851 showed that the install command always created `opencode.json` regardless of whether `opencode.jsonc` already existed. This is problematic for users who have already configured OpenCode with a `.jsonc` file (which supports comments).

## Changes Made

1. Modified `OpenCode::projectDetectionConfig()` to detect both `opencode.jsonc` and `opencode.json` files
2. Updated `OpenCode::mcpConfigPath()` to prefer `opencode.jsonc` when it exists, falling back to `opencode.json` as the default
3. Added comprehensive tests to verify the new behavior

## Backwards Compatibility

This change is fully backwards compatible:
- Projects with existing `opencode.json` continue to work
- Projects with `opencode.jsonc` are now handled correctly
- New projects default to creating `opencode.json` as before