### PR TITLE
fix: unterminated single quote string

### DIFF
--- a/.ai/laravel/skill/laravel-best-practices/rules/style.md
+++ b/.ai/laravel/skill/laravel-best-practices/rules/style.md
@@ -44,7 +44,7 @@ Strings — use `Str` and fluent `Str::of()` over raw PHP:
 // Incorrect
 $slug = strtolower(str_replace(' ', '-', $title));
 $short = substr($text, 0, 100) . '...';
-$class = substr(strrchr('App\Models\User', '\'), 1);
+$class = substr(strrchr('App\Models\User', '\\'), 1);
 
 // Correct
 $slug = Str::slug($title);


### PR DESCRIPTION
Resolves #863 

Fixed the incorrect example by properly escaping the backslash in the `strrchr()` call.

The example’s intent unchanged and the PHP snippet is valid