### PR TITLE
Fix table-prefix corrupting "ORDER BY … DESC" and schema-qualified queries

### DIFF
--- a/src/Mcp/Tools/DatabaseQuery.php
+++ b/src/Mcp/Tools/DatabaseQuery.php
@@ -102,19 +102,44 @@ class DatabaseQuery extends Tool
     {
         $cteNames = $this->extractCteNames($query);
 
-        $pattern = '/\b(FROM|JOIN|INTO|UPDATE|TABLE|DESCRIBE|DESC)\s+([`"\']?)(\w+)\2/i';
+        // `DESCRIBE`/`DESC` as a statement only appears at the very start of a
+        // query, where the following identifier is a table name. Handle it
+        // separately and anchored to the start so we never confuse it with the
+        // `ORDER BY ... DESC` sort direction elsewhere in the query.
+        $describePattern = '/^(\s*)(DESCRIBE|DESC)\s+((?:[`"]?\w+[`"]?\s*\.\s*)?)([`"\']?)(\w+)\4/i';
 
-        return preg_replace_callback($pattern, function (array $matches) use ($prefix, $cteNames): string {
-            $keyword = $matches[1];
-            $quote = $matches[2];
-            $tableName = $matches[3];
+        $query = preg_replace_callback($describePattern, function (array $matches) use ($prefix, $cteNames): string {
+            [$full, $leading, $keyword, $qualifier, $quote, $tableName] = $matches;
 
-            if (str_starts_with($tableName, $prefix) || in_array($tableName, $cteNames, true)) {
-                return $matches[0];
+            if ($this->tableIsPrefixedOrCte($tableName, $prefix, $cteNames)) {
+                return $full;
             }
 
-            return "{$keyword} {$quote}{$prefix}{$tableName}{$quote}";
+            return "{$leading}{$keyword} {$qualifier}{$quote}{$prefix}{$tableName}{$quote}";
         }, $query) ?? $query;
+
+        // Table references introduced by these keywords may be schema/database
+        // qualified (e.g. `public.users`); only the table segment is prefixed,
+        // never the schema/database qualifier.
+        $pattern = '/\b(FROM|JOIN|INTO|UPDATE|TABLE)\s+((?:[`"]?\w+[`"]?\s*\.\s*)?)([`"\']?)(\w+)\3/i';
+
+        return preg_replace_callback($pattern, function (array $matches) use ($prefix, $cteNames): string {
+            [$full, $keyword, $qualifier, $quote, $tableName] = $matches;
+
+            if ($this->tableIsPrefixedOrCte($tableName, $prefix, $cteNames)) {
+                return $full;
+            }
+
+            return "{$keyword} {$qualifier}{$quote}{$prefix}{$tableName}{$quote}";
+        }, $query) ?? $query;
+    }
+
+    /**
+     * @param  array<int, string>  $cteNames
+     */
+    protected function tableIsPrefixedOrCte(string $tableName, string $prefix, array $cteNames): bool
+    {
+        return str_starts_with($tableName, $prefix) || in_array($tableName, $cteNames, true);
     }
 
     /**

--- a/src/Mcp/Tools/DatabaseQuery.php
+++ b/src/Mcp/Tools/DatabaseQuery.php
@@ -102,10 +102,7 @@ class DatabaseQuery extends Tool
     {
         $cteNames = $this->extractCteNames($query);
 
-        // `DESCRIBE`/`DESC` as a statement only appears at the very start of a
-        // query, where the following identifier is a table name. Handle it
-        // separately and anchored to the start so we never confuse it with the
-        // `ORDER BY ... DESC` sort direction elsewhere in the query.
+        // Anchored to the start so the `ORDER BY ... DESC` sort direction is never matched.
         $describePattern = '/^(\s*)(DESCRIBE|DESC)\s+((?:[`"]?\w+[`"]?\s*\.\s*)?)([`"\']?)(\w+)\4/i';
 
         $query = preg_replace_callback($describePattern, function (array $matches) use ($prefix, $cteNames): string {
@@ -118,9 +115,6 @@ class DatabaseQuery extends Tool
             return "{$leading}{$keyword} {$qualifier}{$quote}{$prefix}{$tableName}{$quote}";
         }, $query) ?? $query;
 
-        // Table references introduced by these keywords may be schema/database
-        // qualified (e.g. `public.users`); only the table segment is prefixed,
-        // never the schema/database qualifier.
         $pattern = '/\b(FROM|JOIN|INTO|UPDATE|TABLE)\s+((?:[`"]?\w+[`"]?\s*\.\s*)?)([`"\']?)(\w+)\3/i';
 
         return preg_replace_callback($pattern, function (array $matches) use ($prefix, $cteNames): string {

--- a/tests/Feature/Mcp/Tools/DatabaseQueryTest.php
+++ b/tests/Feature/Mcp/Tools/DatabaseQueryTest.php
@@ -139,6 +139,17 @@ it('adds table prefix to queries', function (): void {
         'DESCRIBE users' => 'DESCRIBE wp_users',
         'DESC users' => 'DESC wp_users',
         'DESCRIBE `users`' => 'DESCRIBE `wp_users`',
+        // The `ORDER BY ... DESC` sort direction must NOT be treated as a
+        // `DESC <table>` statement (regression: it used to prefix the next word).
+        'SELECT * FROM users ORDER BY name DESC' => 'SELECT * FROM wp_users ORDER BY name DESC',
+        'SELECT * FROM users ORDER BY name DESC LIMIT 10' => 'SELECT * FROM wp_users ORDER BY name DESC LIMIT 10',
+        'SELECT * FROM users ORDER BY name DESC OFFSET 5' => 'SELECT * FROM wp_users ORDER BY name DESC OFFSET 5',
+        'SELECT * FROM users ORDER BY created_at DESC, name ASC' => 'SELECT * FROM wp_users ORDER BY created_at DESC, name ASC',
+        // Schema/database-qualified table names: only the table segment is prefixed.
+        'SELECT * FROM public.users' => 'SELECT * FROM public.wp_users',
+        'SELECT * FROM public.users JOIN public.posts ON public.users.id = public.posts.user_id' => 'SELECT * FROM public.wp_users JOIN public.wp_posts ON public.users.id = public.posts.user_id',
+        'SELECT * FROM "public"."users"' => 'SELECT * FROM "public"."wp_users"',
+        'SELECT * FROM `mydb`.`users`' => 'SELECT * FROM `mydb`.`wp_users`',
     ];
 
     foreach ($testCases as $input => $expected) {

--- a/tests/Feature/Mcp/Tools/DatabaseQueryTest.php
+++ b/tests/Feature/Mcp/Tools/DatabaseQueryTest.php
@@ -139,13 +139,10 @@ it('adds table prefix to queries', function (): void {
         'DESCRIBE users' => 'DESCRIBE wp_users',
         'DESC users' => 'DESC wp_users',
         'DESCRIBE `users`' => 'DESCRIBE `wp_users`',
-        // The `ORDER BY ... DESC` sort direction must NOT be treated as a
-        // `DESC <table>` statement (regression: it used to prefix the next word).
         'SELECT * FROM users ORDER BY name DESC' => 'SELECT * FROM wp_users ORDER BY name DESC',
         'SELECT * FROM users ORDER BY name DESC LIMIT 10' => 'SELECT * FROM wp_users ORDER BY name DESC LIMIT 10',
         'SELECT * FROM users ORDER BY name DESC OFFSET 5' => 'SELECT * FROM wp_users ORDER BY name DESC OFFSET 5',
         'SELECT * FROM users ORDER BY created_at DESC, name ASC' => 'SELECT * FROM wp_users ORDER BY created_at DESC, name ASC',
-        // Schema/database-qualified table names: only the table segment is prefixed.
         'SELECT * FROM public.users' => 'SELECT * FROM public.wp_users',
         'SELECT * FROM public.users JOIN public.posts ON public.users.id = public.posts.user_id' => 'SELECT * FROM public.wp_users JOIN public.wp_posts ON public.users.id = public.posts.user_id',
         'SELECT * FROM "public"."users"' => 'SELECT * FROM "public"."wp_users"',


### PR DESCRIPTION
Closes #867

## Problem

The `database-query` MCP tool injects the connection's table prefix into queries via `DatabaseQuery::addPrefixToQuery()`. When a prefix is configured, two cases produce invalid SQL:

1. **`ORDER BY … DESC`** — `DESC` is in the keyword alternation (for the `DESC <table>` describe shorthand), so the token *after* a sort-direction `DESC` gets prefixed:

   ```
   -- prefix "wp_"
   SELECT * FROM users ORDER BY name DESC LIMIT 10
   -- became:
   SELECT * FROM wp_users ORDER BY name DESC wp_LIMIT 10   -- syntax error
   ```

   (`ORDER BY … DESC LIMIT`/`OFFSET` is an extremely common query shape.)

2. **Schema/database-qualified names** — `(\w+)` captures only the first identifier, so the schema is prefixed instead of the table:

   ```
   SELECT * FROM public.users  ->  SELECT * FROM wp_public.users
   ```

## Fix

- `DESCRIBE`/`DESC` statements only ever appear at the **start** of a query, so match them with a separate start-anchored pass and remove `DESC` from the general keyword regex. The `ORDER BY … DESC` sort keyword is no longer treated as a table reference.
- The general table regex now captures an optional `schema.`/`db.` qualifier (bare, `"quoted"`, or `` `backtick` ``) and prefixes only the table segment.
- Extracted a small `tableIsPrefixedOrCte()` helper shared by both passes.

## Tests

Added regression cases to the existing "adds table prefix to queries" test: `ORDER BY … DESC` (+ `LIMIT`/`OFFSET`/multi-column), and qualified names (bare, quoted, backtick). The existing `DESC users` / `DESCRIBE users` describe-shorthand cases still pass.

- `DatabaseQueryTest`: 6 passed, 163 assertions
- Full Feature + Unit suites: 817 passed
- Pint + PHPStan clean
