### PR TITLE
Make enum guideline generation deterministic

### DIFF
--- a/.ai/php/core.blade.php
+++ b/.ai/php/core.blade.php
@@ -6,7 +6,7 @@
 - Always use curly braces for control structures, even for single-line bodies.
 - Use PHP 8 constructor property promotion: `public function __construct(public GitHub $github) { }`. Do not leave empty zero-parameter `__construct()` methods unless the constructor is private.
 - Use explicit return type declarations and type hints for all method parameters: `function isAccessible(User $user, ?string $path = null): bool`
-@if(empty($assist->enums()) || !preg_match('/[A-Z]{3,8}/', $assist->enumContents()))
+@if(empty($assist->enums()) || !preg_match('/^\s*case\s+[A-Z][A-Z0-9_]{2,}/m', $assist->enumContents()))
 - Use TitleCase for Enum keys: `FavoritePerson`, `BestLake`, `Monthly`.
 @else
 - Follow existing application Enum naming conventions.

--- a/src/Install/GuidelineAssist.php
+++ b/src/Install/GuidelineAssist.php
@@ -79,17 +79,11 @@ class GuidelineAssist
             }
         }
 
-        ksort($enums);
-
         return $enums;
     }
 
     public function enumContents(): string
     {
-        if ($this->enumPaths === []) {
-            return '';
-        }
-
         return collect($this->enumPaths)
             ->sortKeys()
             ->map(fn (string $path): string => is_file($path) ? (file_get_contents($path) ?: '') : '')

--- a/src/Install/GuidelineAssist.php
+++ b/src/Install/GuidelineAssist.php
@@ -79,6 +79,8 @@ class GuidelineAssist
             }
         }
 
+        ksort($enums);
+
         return $enums;
     }
 
@@ -88,13 +90,11 @@ class GuidelineAssist
             return '';
         }
 
-        $path = current($this->enumPaths);
-
-        if (! is_file($path)) {
-            return '';
-        }
-
-        return file_get_contents($path) ?: '';
+        return collect($this->enumPaths)
+            ->sortKeys()
+            ->map(fn (string $path): string => is_file($path) ? (file_get_contents($path) ?: '') : '')
+            ->filter()
+            ->join(PHP_EOL);
     }
 
     public function inertia(): Inertia

--- a/tests/Feature/Install/GuidelineComposerTest.php
+++ b/tests/Feature/Install/GuidelineComposerTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\Blade;
+use Laravel\Boost\Install\GuidelineAssist;
 use Laravel\Boost\Install\GuidelineComposer;
 use Laravel\Boost\Install\GuidelineConfig;
 use Laravel\Boost\Install\Herd;
@@ -1235,3 +1237,20 @@ test('symlinked custom guideline file does not produce duplicates', function ():
         @rmdir($customDir);
     }
 });
+
+test('php core guideline adapts enum naming guidance to the application enums', function (array $enums, ?string $fixtureName, string $expected, string $notExpected): void {
+    $assist = Mockery::mock(GuidelineAssist::class);
+    $assist->shouldReceive('enums')->andReturn($enums);
+    $assist->shouldReceive('enumContents')->andReturn($fixtureName === null ? '' : fixtureContent($fixtureName));
+
+    $rendered = Blade::render(file_get_contents(testDirectory('../.ai/php/core.blade.php')), ['assist' => $assist]);
+
+    expect($rendered)
+        ->toContain($expected)
+        ->not->toContain($notExpected);
+})->with([
+    'no enums' => [[], null, 'Use TitleCase for Enum keys', 'Follow existing application Enum naming conventions'],
+    'TitleCase keys' => [['App\Enums\FlashKey' => 'FlashKey.php'], 'Enums/FlashKey.php', 'Use TitleCase for Enum keys', 'Follow existing application Enum naming conventions'],
+    'TitleCase keys with uppercase values' => [['App\Enums\Currency' => 'Currency.php'], 'Enums/Currency.php', 'Use TitleCase for Enum keys', 'Follow existing application Enum naming conventions'],
+    'uppercase keys' => [['App\Enums\CountryCode' => 'CountryCode.php'], 'Enums/CountryCode.php', 'Follow existing application Enum naming conventions', 'Use TitleCase for Enum keys'],
+]);

--- a/tests/Fixtures/Enums/CountryCode.php
+++ b/tests/Fixtures/Enums/CountryCode.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Enums;
+
+enum CountryCode: string
+{
+    case USA = 'USA';
+    case IND = 'IND';
+}

--- a/tests/Fixtures/Enums/Currency.php
+++ b/tests/Fixtures/Enums/Currency.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Enums;
+
+enum Currency: string
+{
+    case Usd = 'USD';
+    case Eur = 'EUR';
+}

--- a/tests/Fixtures/Enums/FlashKey.php
+++ b/tests/Fixtures/Enums/FlashKey.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Enums;
+
+enum FlashKey: string
+{
+    case Success = 'success';
+    case Error = 'error';
+}

--- a/tests/Unit/Install/GuidelineAssistTest.php
+++ b/tests/Unit/Install/GuidelineAssistTest.php
@@ -155,48 +155,41 @@ test('enumContents returns empty string when app directory does not exist', func
 });
 
 test('enumContents includes all discovered enum files in stable order', function (): void {
-    $tempDir = sys_get_temp_dir().'/boost-enum-contents-'.uniqid();
-    mkdir($tempDir, 0755, true);
+    $assist = new class($this->roster, $this->config) extends GuidelineAssist
+    {
+        protected function discover(): array
+        {
+            return [
+                'App\Enums\FlashKey' => fixture('Enums/FlashKey.php'),
+                'App\Enums\CountryCode' => fixture('Enums/CountryCode.php'),
+            ];
+        }
+    };
 
-    $countryCodePath = $tempDir.'/CountryCode.php';
-    $flashKeyPath = $tempDir.'/FlashKey.php';
+    $contents = $assist->enumContents();
 
-    try {
-        file_put_contents($flashKeyPath, <<<'PHP'
-<?php
+    expect($contents)
+        ->toContain("case USA = 'USA';")
+        ->toContain("case Success = 'success';")
+        ->and(strpos($contents, 'enum CountryCode'))
+        ->toBeLessThan(strpos($contents, 'enum FlashKey'));
+});
 
-enum FlashKey: string
-{
-    case Success = 'success';
-}
-PHP);
+test('enumContents skips enum paths that are not files', function (): void {
+    $assist = new class($this->roster, $this->config) extends GuidelineAssist
+    {
+        protected function discover(): array
+        {
+            return [
+                'App\Enums\Deleted' => fixture('Enums'),
+                'App\Enums\FlashKey' => fixture('Enums/FlashKey.php'),
+            ];
+        }
+    };
 
-        file_put_contents($countryCodePath, <<<'PHP'
-<?php
-
-enum CountryCode: string
-{
-    case USD = 'USD';
-}
-PHP);
-
-        $assist = new GuidelineAssist($this->roster, $this->config);
-
-        $enumPathsProperty = new ReflectionProperty($assist, 'enumPaths');
-        $enumPathsProperty->setValue($assist, [
-            'App\\Enums\\FlashKey' => $flashKeyPath,
-            'App\\Enums\\CountryCode' => $countryCodePath,
-        ]);
-
-        expect($assist->enumContents())
-            ->toStartWith("<?php\n\nenum CountryCode")
-            ->toContain("case USD = 'USD';")
-            ->toContain("case Success = 'success';");
-    } finally {
-        @unlink($countryCodePath);
-        @unlink($flashKeyPath);
-        @rmdir($tempDir);
-    }
+    expect($assist->enumContents())
+        ->toStartWith('<?php')
+        ->toContain('enum FlashKey');
 });
 
 test('hasSkillsEnabled returns false when skills are disabled', function (): void {

--- a/tests/Unit/Install/GuidelineAssistTest.php
+++ b/tests/Unit/Install/GuidelineAssistTest.php
@@ -154,6 +154,51 @@ test('enumContents returns empty string when app directory does not exist', func
     expect($assist->enumContents())->toBe('');
 });
 
+test('enumContents includes all discovered enum files in stable order', function (): void {
+    $tempDir = sys_get_temp_dir().'/boost-enum-contents-'.uniqid();
+    mkdir($tempDir, 0755, true);
+
+    $countryCodePath = $tempDir.'/CountryCode.php';
+    $flashKeyPath = $tempDir.'/FlashKey.php';
+
+    try {
+        file_put_contents($flashKeyPath, <<<'PHP'
+<?php
+
+enum FlashKey: string
+{
+    case Success = 'success';
+}
+PHP);
+
+        file_put_contents($countryCodePath, <<<'PHP'
+<?php
+
+enum CountryCode: string
+{
+    case USD = 'USD';
+}
+PHP);
+
+        $assist = new GuidelineAssist($this->roster, $this->config);
+
+        $enumPathsProperty = new ReflectionProperty($assist, 'enumPaths');
+        $enumPathsProperty->setValue($assist, [
+            'App\\Enums\\FlashKey' => $flashKeyPath,
+            'App\\Enums\\CountryCode' => $countryCodePath,
+        ]);
+
+        expect($assist->enumContents())
+            ->toStartWith("<?php\n\nenum CountryCode")
+            ->toContain("case USD = 'USD';")
+            ->toContain("case Success = 'success';");
+    } finally {
+        @unlink($countryCodePath);
+        @unlink($flashKeyPath);
+        @rmdir($tempDir);
+    }
+});
+
 test('hasSkillsEnabled returns false when skills are disabled', function (): void {
     $this->config->hasSkills = false;
 


### PR DESCRIPTION
Fixes non-deterministic PHP enum guideline generation.

`GuidelineAssist::enumContents()` was only reading the first discovered enum file, so the PHP enum-naming guideline emitted by `boost:install --guidelines` depended on filesystem/Finder order and could differ across environments.

- `enumContents()` now includes **all** discovered enum files, sorted by class name, so the guideline condition no longer depends on whichever enum happens to be discovered first.
- The `php/core` guideline regex now matches uppercase enum **case declarations** (`/^\s*case\s+[A-Z][A-Z0-9_]{2,}/m`) instead of any 3+ uppercase run. Previously, a TitleCase enum with uppercase string values (`case Usd = 'USD';`) or an `API`/`URL` in a docblock would suppress the prescriptive TitleCase rule — and since the condition now scans every enum, the old loose regex would have hit far more apps.
- Tests use committed fixtures (`tests/Fixtures/Enums/`) and cover ordering, missing-file skipping, and all enum-guidance branches of the rendered guideline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)