### PR TITLE
Support `database-query` tool for MongoDB users.

### DIFF
--- a/.ai/boost/core.blade.php
+++ b/.ai/boost/core.blade.php
@@ -3,7 +3,7 @@
 
 ## Tools
 - Laravel Boost is an MCP server with tools designed specifically for this application. Prefer Boost tools over manual alternatives like shell commands or file reads.
-- Use `database-query` to run read-only queries against the database instead of writing raw SQL in tinker.
+- Use `database-query` to run read-only queries against the database instead of writing raw SQL or MQL in tinker.
 - Use `database-schema` to inspect table structure before writing migrations or models.
 - Use `get-absolute-url` to resolve the correct scheme, domain, and port for project URLs. Always use this before sharing a URL with the user.
 @if (config('boost.browser_logs', false) !== false || config('boost.browser_logs_watcher', true) !== false)
@@ -43,4 +43,21 @@
 @else
 - Always use single quotes to prevent shell expansion: `{{ $assist->artisanCommand("tinker --execute 'Your::code();'") }}`
   - Double quotes for PHP strings inside: `{{ $assist->artisanCommand("tinker --execute 'User::where(\"active\", true)->count();'") }}`
+ - Use the `list-artisan-commands` tool when you need to call an Artisan command to double-check the available parameters.
+
+ ## URLs
+ - Whenever you share a project URL with the user, you should use the `get-absolute-url` tool to ensure you're using the correct scheme, domain/IP, and port.
+
+ ## Tinker / Debugging
+ - You should use the `tinker` tool when you need to execute PHP to debug code or query Eloquent models directly.
+ - Use the `database-query` tool when you only need to read from the database.
+
++## Querying the Database
++- Connections can use different drivers (e.g. `mysql`, `pgsql`, `sqlite`, `mongodb`). If you don't already know the driver for the connection you're targeting, use the `database-connections` tool once to check before querying.
++- Use the `database-query` tool to read data directly. For SQL drivers, pass a read-only `query` argument. For the `mongodb` driver, pass a `command` argument instead (an MQL command document) — never SQL.
++
+ @if (config('boost.browser_logs', true) !== false || config('boost.browser_logs_watcher', true) !== false)
+ ## Reading Browser Logs With the `browser-logs` Tool
+ - You can read browser logs, errors, and exceptions using the `browser-logs` tool from Boost.
+ - Only recent browser logs will be useful - ignore old logs.
 @endif

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, fileinfo, pdo, sqlite, pdo_sqlite
+          extensions: dom, curl, libxml, mbstring, zip, fileinfo, pdo, sqlite, pdo_sqlite, mongodb
           ini-values: error_reporting=E_ALL
           tools: composer:v2.8
           coverage: none

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "laravel/pint": "^1.27.0",
         "mockery/mockery": "^1.6.12",
         "orchestra/testbench": "^9.15.0|^10.6|^11.0",
+        "mongodb/laravel-mongodb": "^5.8",
         "pestphp/pest": "^2.36.0|^3.8.4|^4.1.5",
         "phpstan/phpstan": "^2.1.27",
         "rector/rector": "^2.1"

--- a/src/Mcp/Tools/DatabaseQuery.php
+++ b/src/Mcp/Tools/DatabaseQuery.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Mcp\Tools;
 
-use Illuminate\Database\ConnectionInterface;
-use InvalidArgumentException;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Database\ConnectionInterface;
 use Illuminate\JsonSchema\Types\Type;
 use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;
 use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
-use Throwable;
 use MongoDB\Laravel\Connection as MongoDBConnection;
+use Stringable;
+use Throwable;
 
 #[IsReadOnly]
 class DatabaseQuery extends Tool
@@ -54,17 +55,17 @@ class DatabaseQuery extends Tool
                 : $this->handleSql($request->string('query'), $connection);
 
             return Response::json($result);
-        } catch (\InvalidArgumentException $e) {
+        } catch (InvalidArgumentException $e) {
             return Response::error($e->getMessage());
         } catch (Throwable $e) {
-            return Response::error('Query failed: ' . $e->getMessage());
+            return Response::error('Query failed: '.$e->getMessage());
         }
     }
 
     /**
      * @throws InvalidArgumentException
      */
-    private function handleSql(\Stringable $query, ConnectionInterface $connection): array
+    private function handleSql(Stringable $query, ConnectionInterface $connection): array
     {
         $query = trim((string) $query);
         $token = strtok(ltrim($query), " \t\n\r");
@@ -166,7 +167,7 @@ class DatabaseQuery extends Tool
     }
 
     /**
-     * @param array<string,mixed> $command
+     * @param  array<string,mixed>  $command
      *
      * @throws InvalidArgumentException
      */
@@ -181,7 +182,7 @@ class DatabaseQuery extends Tool
         $operation = array_key_first($command);
 
         if (! in_array($operation, $allowList, true)) {
-            throw new InvalidArgumentException(sprintf('Only read commands are allowed (%s).', join(', ', $allowList)));
+            throw new InvalidArgumentException(sprintf('Only read commands are allowed (%s).', implode(', ', $allowList)));
         }
 
         if ($operation === 'aggregate') {
@@ -217,31 +218,31 @@ class DatabaseQuery extends Tool
 
         // These aggregation stages may contain nested aggregation pipelines
         // and must be checked for write ops recursively.
-        $supportsNestedWrites = ["facet", "lookup", "unionWith"];
+        $supportsNestedWrites = ['facet', 'lookup', 'unionWith'];
 
         $allowList = array_merge($supportsNestedWrites, [
-            "addFields",
-            "bucket",
-            "bucketAuto",
-            "count",
-            "densify",
-            "fill",
-            "graphLookup",
-            "group",
-            "limit",
-            "match",
-            "project",
-            "redact",
-            "replaceRoot",
-            "replaceWith",
-            "sample",
-            "set",
-            "setWindowFields",
-            "skip",
-            "sort",
-            "sortByCount",
-            "unwind",
-            "unset"
+            'addFields',
+            'bucket',
+            'bucketAuto',
+            'count',
+            'densify',
+            'fill',
+            'graphLookup',
+            'group',
+            'limit',
+            'match',
+            'project',
+            'redact',
+            'replaceRoot',
+            'replaceWith',
+            'sample',
+            'set',
+            'setWindowFields',
+            'skip',
+            'sort',
+            'sortByCount',
+            'unwind',
+            'unset',
         ]);
 
         // A pipeline is a list of single-key stage documents, e.g. [['$match' => [...]], ...].
@@ -261,13 +262,16 @@ class DatabaseQuery extends Tool
             switch ($stageName) {
                 case 'facet':
                     array_walk($stageBody, fn ($pipeline) => $this->ensureNoNestedWriteInAggregation($pipeline, $level + 1));
+
                     break;
+
                 case 'lookup':
                 case 'unionWith':
                     // Both stages take an optional single sub-pipeline; unionWith may also be a plain collection name.
                     if (is_array($stageBody) && isset($stageBody['pipeline'])) {
                         $this->ensureNoNestedWriteInAggregation($stageBody['pipeline'], $level + 1);
                     }
+
                     break;
             }
         }

--- a/src/Mcp/Tools/DatabaseQuery.php
+++ b/src/Mcp/Tools/DatabaseQuery.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Mcp\Tools;
 
+use Illuminate\Database\ConnectionInterface;
+use InvalidArgumentException;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\JsonSchema\Types\Type;
 use Illuminate\Support\Facades\DB;
@@ -43,10 +45,26 @@ class DatabaseQuery extends Tool
     public function handle(Request $request): Response
     {
         $query = trim((string) $request->string('query'));
+        $connection = DB::connection($request->get('database'));
+
+        try {
+            return Response::json($this->handleSql($query, $connection));
+        } catch (\InvalidArgumentException $e) {
+            return Response::error($e->getMessage());
+        } catch (Throwable $e) {
+            return Response::error('Query failed: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    private function handleSql(string $query, ConnectionInterface $connection): array
+    {
         $token = strtok(ltrim($query), " \t\n\r");
 
         if (! $token) {
-            return Response::error('Please pass a valid query');
+            throw new InvalidArgumentException('Please pass a valid query');
         }
 
         $firstWord = strtoupper($token);
@@ -77,25 +95,16 @@ class DatabaseQuery extends Tool
         }
 
         if (! $isReadOnly) {
-            return Response::error('Only read-only queries are allowed (SELECT, SHOW, EXPLAIN, DESCRIBE, DESC, WITH … SELECT).');
+            throw new InvalidArgumentException('Only read-only queries are allowed (SELECT, SHOW, EXPLAIN, DESCRIBE, DESC, WITH … SELECT).');
         }
 
-        $connectionName = $request->get('database');
+        $prefix = $connection->getTablePrefix();
 
-        try {
-            $connection = DB::connection($connectionName);
-            $prefix = $connection->getTablePrefix();
-
-            if ($prefix) {
-                $query = $this->addPrefixToQuery($query, $prefix);
-            }
-
-            return Response::json(
-                $connection->select($query)
-            );
-        } catch (Throwable $throwable) {
-            return Response::error('Query failed: '.$throwable->getMessage());
+        if ($prefix) {
+            $query = $this->addPrefixToQuery($query, $prefix);
         }
+
+        return $connection->select($query);
     }
 
     protected function addPrefixToQuery(string $query, string $prefix): string

--- a/src/Mcp/Tools/DatabaseQuery.php
+++ b/src/Mcp/Tools/DatabaseQuery.php
@@ -14,6 +14,7 @@ use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;
 use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
 use Throwable;
+use MongoDB\Laravel\Connection as MongoDBConnection;
 
 #[IsReadOnly]
 class DatabaseQuery extends Tool
@@ -21,7 +22,7 @@ class DatabaseQuery extends Tool
     /**
      * The tool's description.
      */
-    protected string $description = 'Execute a read-only SQL query against the configured database.';
+    protected string $description = 'Execute a read-only query against the configured database. Default to an SQL query. If the database driver is `mongodb`, use MQL commands.';
 
     /**
      * Get the tool's input schema.
@@ -32,8 +33,9 @@ class DatabaseQuery extends Tool
     {
         return [
             'query' => $schema->string()
-                ->description('The SQL query to execute. Only read-only queries are allowed (i.e. SELECT, SHOW, EXPLAIN, DESCRIBE).')
-                ->required(),
+                ->description('The SQL query to execute. Only read-only operations are allowed (i.e. SELECT, SHOW, EXPLAIN, DESCRIBE)'),
+            'command' => $schema->object()
+                ->description('The MQL command to execute for MongoDB connections. Only read commands are allowed (i.e. aggregate, count, distinct, find)'),
             'database' => $schema->string()
                 ->description("Optional database connection name to use. Defaults to the application's default connection."),
         ];
@@ -44,11 +46,14 @@ class DatabaseQuery extends Tool
      */
     public function handle(Request $request): Response
     {
-        $query = trim((string) $request->string('query'));
         $connection = DB::connection($request->get('database'));
 
         try {
-            return Response::json($this->handleSql($query, $connection));
+            $result = class_exists(MongoDBConnection::class) && $connection instanceof MongoDBConnection
+                ? $this->handleMql($request->array('command'), $connection)
+                : $this->handleSql($request->string('query'), $connection);
+
+            return Response::json($result);
         } catch (\InvalidArgumentException $e) {
             return Response::error($e->getMessage());
         } catch (Throwable $e) {
@@ -59,12 +64,13 @@ class DatabaseQuery extends Tool
     /**
      * @throws InvalidArgumentException
      */
-    private function handleSql(string $query, ConnectionInterface $connection): array
+    private function handleSql(\Stringable $query, ConnectionInterface $connection): array
     {
+        $query = trim((string) $query);
         $token = strtok(ltrim($query), " \t\n\r");
 
         if (! $token) {
-            throw new InvalidArgumentException('Please pass a valid query');
+            throw new InvalidArgumentException('Please pass a valid SQL query');
         }
 
         $firstWord = strtoupper($token);
@@ -157,5 +163,113 @@ class DatabaseQuery extends Tool
         }
 
         return [];
+    }
+
+    /**
+     * @param array<string,mixed> $command
+     *
+     * @throws InvalidArgumentException
+     */
+    private function handleMql(array $command, MongoDBConnection $connection): array
+    {
+        if ($command === []) {
+            throw new InvalidArgumentException('Please pass a valid MongoDB command');
+        }
+
+        // Allowed CRUD commands (https://www.mongodb.com/docs/manual/reference/mql/crud-commands/)
+        $allowList = ['aggregate', 'count', 'distinct', 'find'];
+        $operation = array_key_first($command);
+
+        if (! in_array($operation, $allowList, true)) {
+            throw new InvalidArgumentException(sprintf('Only read commands are allowed (%s).', join(', ', $allowList)));
+        }
+
+        if ($operation === 'aggregate') {
+            // Check nested write ops recursively with conservative allow list
+            $this->ensureNoNestedWriteInAggregation($command['pipeline'] ?? []);
+        }
+
+        $cursor = $connection->getDatabase()->command($command);
+
+        return $cursor->toArray();
+    }
+
+    // BSON objects are capped at 100 nesting levels:
+    // https://www.mongodb.com/docs/manual/reference/limits/#mongodb-limit-Nested-Depth-for-BSON-Documents
+    private const MAX_NESTING_LEVEL = 100;
+
+    // Aggregation pipelines are capped at 1000 stages
+    // https://www.mongodb.com/docs/manual/core/aggregation-pipeline-limits/#number-of-stages-restrictions
+    private const MAX_STAGES_PER_PIPELINE = 1000;
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    private function ensureNoNestedWriteInAggregation(array $pipeline, int $level = 1): void
+    {
+        if ($level > self::MAX_NESTING_LEVEL) {
+            throw new InvalidArgumentException(sprintf('Aggregation nesting exceeds the maximum of %d levels.', self::MAX_NESTING_LEVEL));
+        }
+
+        if (count($pipeline) > self::MAX_STAGES_PER_PIPELINE) {
+            throw new InvalidArgumentException(sprintf('A pipeline exceeds the maximum of %d stages.', self::MAX_STAGES_PER_PIPELINE));
+        }
+
+        // These aggregation stages may contain nested aggregation pipelines
+        // and must be checked for write ops recursively.
+        $supportsNestedWrites = ["facet", "lookup", "unionWith"];
+
+        $allowList = array_merge($supportsNestedWrites, [
+            "addFields",
+            "bucket",
+            "bucketAuto",
+            "count",
+            "densify",
+            "fill",
+            "graphLookup",
+            "group",
+            "limit",
+            "match",
+            "project",
+            "redact",
+            "replaceRoot",
+            "replaceWith",
+            "sample",
+            "set",
+            "setWindowFields",
+            "skip",
+            "sort",
+            "sortByCount",
+            "unwind",
+            "unset"
+        ]);
+
+        // A pipeline is a list of single-key stage documents, e.g. [['$match' => [...]], ...].
+        foreach ($pipeline as $stage) {
+            $operator = array_key_first($stage);
+            $stageName = str_replace('$', '', (string) $operator);
+            $stageBody = $stage[$operator];
+
+            if (! in_array($stageName, $allowList, true)) {
+                throw new InvalidArgumentException(sprintf('Only read aggregation stages are allowed. Found: %s', $stageName));
+            }
+
+            if (! in_array($stageName, $supportsNestedWrites, true)) {
+                continue;
+            }
+
+            switch ($stageName) {
+                case 'facet':
+                    array_walk($stageBody, fn ($pipeline) => $this->ensureNoNestedWriteInAggregation($pipeline, $level + 1));
+                    break;
+                case 'lookup':
+                case 'unionWith':
+                    // Both stages take an optional single sub-pipeline; unionWith may also be a plain collection name.
+                    if (is_array($stageBody) && isset($stageBody['pipeline'])) {
+                        $this->ensureNoNestedWriteInAggregation($stageBody['pipeline'], $level + 1);
+                    }
+                    break;
+            }
+        }
     }
 }

--- a/tests/Feature/Mcp/Tools/DatabaseQueryTest.php
+++ b/tests/Feature/Mcp/Tools/DatabaseQueryTest.php
@@ -2,14 +2,24 @@
 
 declare(strict_types=1);
 
+use Illuminate\Database\ConnectionInterface;
 use Illuminate\Support\Facades\DB;
 use Laravel\Boost\Mcp\Tools\DatabaseQuery;
 use Laravel\Mcp\Request;
 
-function expectSelect(): void {
-    DB::shouldReceive('connection')->andReturnSelf();
-    DB::shouldReceive('select')->andReturn([]);
-    DB::shouldReceive('getTablePrefix')->andReturn('');
+function fakeConnection(): Mockery\MockInterface {
+    $connection = Mockery::mock(ConnectionInterface::class);
+    DB::shouldReceive('connection')->andReturn($connection);
+
+    return $connection;
+}
+
+function expectSelect(): Mockery\MockInterface {
+    $connection = fakeConnection();
+    $connection->shouldReceive('select')->andReturn([]);
+    $connection->shouldReceive('getTablePrefix')->andReturn('');
+
+    return $connection;
 }
 
 it('executes allowed read-only queries', function (): void {
@@ -35,7 +45,7 @@ it('executes allowed read-only queries', function (): void {
 });
 
 it('blocks destructive queries', function (): void {
-    DB::shouldReceive('select')->never();
+    fakeConnection()->shouldReceive('select')->never();
 
     $tool = new DatabaseQuery;
 
@@ -55,7 +65,7 @@ it('blocks destructive queries', function (): void {
 });
 
 it('blocks extended destructive keywords for mysql postgres and sqlite', function (): void {
-    DB::shouldReceive('select')->never();
+    fakeConnection()->shouldReceive('select')->never();
 
     $tool = new DatabaseQuery;
 
@@ -113,8 +123,8 @@ it('allows queries starting with any allowed keyword even when identifiers look 
 });
 
 it('adds table prefix to queries', function (): void {
-    DB::shouldReceive('connection')->andReturnSelf();
-    DB::shouldReceive('getTablePrefix')->andReturn('wp_');
+    $connection = fakeConnection();
+    $connection->shouldReceive('getTablePrefix')->andReturn('wp_');
 
     $testCases = [
         'SELECT * FROM users' => 'SELECT * FROM wp_users',
@@ -151,7 +161,7 @@ it('adds table prefix to queries', function (): void {
     ];
 
     foreach ($testCases as $input => $expected) {
-        DB::shouldReceive('select')->with($expected)->once()->andReturn([]);
+        $connection->shouldReceive('select')->with($expected)->once()->andReturn([]);
 
         $tool = new DatabaseQuery;
         $response = $tool->handle(new Request(['query' => $input]));
@@ -207,9 +217,9 @@ test('it rejects a with … write query', function (): void {
 });
 
 test('it reports a failure when the database call throws', function (): void {
-    DB::shouldReceive('connection')->andReturnSelf();
-    DB::shouldReceive('getTablePrefix')->andReturn('');
-    DB::shouldReceive('select')
+    $connection = fakeConnection();
+    $connection->shouldReceive('getTablePrefix')->andReturn('');
+    $connection->shouldReceive('select')
         ->once()
         ->andThrow(new RuntimeException('Simulated DB failure'));
 

--- a/tests/Feature/Mcp/Tools/DatabaseQueryTest.php
+++ b/tests/Feature/Mcp/Tools/DatabaseQueryTest.php
@@ -6,17 +6,23 @@ use Illuminate\Database\ConnectionInterface;
 use Illuminate\Support\Facades\DB;
 use Laravel\Boost\Mcp\Tools\DatabaseQuery;
 use Laravel\Mcp\Request;
+use Mockery\MockInterface;
+use MongoDB\BSON\Int64;
 use MongoDB\Database;
+use MongoDB\Driver\CursorInterface;
+use MongoDB\Driver\Server;
 use MongoDB\Laravel\Connection as MongoDBConnection;
 
-function fakeConnection(): Mockery\MockInterface {
+function fakeConnection(): MockInterface
+{
     $connection = Mockery::mock(ConnectionInterface::class);
     DB::shouldReceive('connection')->andReturn($connection);
 
     return $connection;
 }
 
-function expectSelect(): Mockery\MockInterface {
+function expectSelect(): MockInterface
+{
     $connection = fakeConnection();
     $connection->shouldReceive('select')->andReturn([]);
     $connection->shouldReceive('getTablePrefix')->andReturn('');
@@ -241,7 +247,7 @@ function fakeMongoConnection(array $documents = []): MongoDBConnection
 {
     // Mockery can't mock CursorInterface on Mockery 1.6.x / PHP 8.4 (its Iterator::current(): mixed
     // clashes with CursorInterface::current(): object|array|null), so use a concrete double.
-    $cursor = new class($documents) implements \MongoDB\Driver\CursorInterface
+    $cursor = new class($documents) implements CursorInterface
     {
         public function __construct(private array $documents) {}
 
@@ -275,14 +281,14 @@ function fakeMongoConnection(array $documents = []): MongoDBConnection
             reset($this->documents);
         }
 
-        public function getId(): \MongoDB\BSON\Int64
+        public function getId(): Int64
         {
-            throw new \LogicException('unused in tests');
+            throw new LogicException('unused in tests');
         }
 
-        public function getServer(): \MongoDB\Driver\Server
+        public function getServer(): Server
         {
-            throw new \LogicException('unused in tests');
+            throw new LogicException('unused in tests');
         }
 
         public function isDead(): bool

--- a/tests/Feature/Mcp/Tools/DatabaseQueryTest.php
+++ b/tests/Feature/Mcp/Tools/DatabaseQueryTest.php
@@ -6,11 +6,14 @@ use Illuminate\Support\Facades\DB;
 use Laravel\Boost\Mcp\Tools\DatabaseQuery;
 use Laravel\Mcp\Request;
 
-it('executes allowed read-only queries', function (): void {
+function expectSelect(): void {
     DB::shouldReceive('connection')->andReturnSelf();
     DB::shouldReceive('select')->andReturn([]);
     DB::shouldReceive('getTablePrefix')->andReturn('');
+}
 
+it('executes allowed read-only queries', function (): void {
+    expectSelect();
     $tool = new DatabaseQuery;
 
     $queries = [
@@ -84,9 +87,7 @@ it('handles empty queries gracefully', function (): void {
 });
 
 it('allows queries starting with any allowed keyword even when identifiers look like SQL keywords', function (): void {
-    DB::shouldReceive('connection')->andReturnSelf();
-    DB::shouldReceive('select')->andReturn([]);
-    DB::shouldReceive('getTablePrefix')->andReturn('');
+    expectSelect();
 
     $tool = new DatabaseQuery;
 
@@ -157,4 +158,65 @@ it('adds table prefix to queries', function (): void {
 
         expect($response)->isToolResult()->toolHasNoError();
     }
+});
+
+test('it runs a successful lowercase select query', function (): void {
+    expectSelect();
+
+    $tool = new DatabaseQuery;
+    $response = $tool->handle(new Request(['query' => 'select * from examples']));
+
+    expect($response)->isToolResult()->toolHasNoError();
+});
+
+test('it runs a successful with … select query', function (): void {
+    expectSelect();
+
+    $tool = new DatabaseQuery;
+    $response = $tool->handle(new Request([
+        'query' => 'WITH cte AS (SELECT * FROM examples) SELECT * FROM cte',
+    ]));
+
+    expect($response)->isToolResult()->toolHasNoError();
+});
+
+test('it rejects an insert query', function (): void {
+    expectSelect();
+    $tool = new DatabaseQuery;
+
+    $response = $tool->handle(new Request([
+        'query' => "INSERT INTO examples (name) VALUES ('Otwell')",
+    ]));
+
+    expect($response)->isToolResult()
+        ->toolHasError()
+        ->toolTextContains('Only read-only queries are allowed (SELECT, SHOW, EXPLAIN, DESCRIBE, DESC, WITH … SELECT).');
+});
+
+test('it rejects a with … write query', function (): void {
+    expectSelect();
+    $tool = new DatabaseQuery;
+
+    $response = $tool->handle(new Request([
+        'query' => 'WITH data AS (VALUES (1)) DELETE FROM examples',
+    ]));
+
+    expect($response)->isToolResult()
+        ->toolHasError()
+        ->toolTextContains('Only read-only queries are allowed (SELECT, SHOW, EXPLAIN, DESCRIBE, DESC, WITH … SELECT).');
+});
+
+test('it reports a failure when the database call throws', function (): void {
+    DB::shouldReceive('connection')->andReturnSelf();
+    DB::shouldReceive('getTablePrefix')->andReturn('');
+    DB::shouldReceive('select')
+        ->once()
+        ->andThrow(new RuntimeException('Simulated DB failure'));
+
+    $tool = new DatabaseQuery;
+    $response = $tool->handle(new Request(['query' => 'SELECT * FROM examples']));
+
+    expect($response)->isToolResult()
+        ->toolHasError()
+        ->toolTextContains('Query failed: Simulated DB failure');
 });

--- a/tests/Feature/Mcp/Tools/DatabaseQueryTest.php
+++ b/tests/Feature/Mcp/Tools/DatabaseQueryTest.php
@@ -6,6 +6,8 @@ use Illuminate\Database\ConnectionInterface;
 use Illuminate\Support\Facades\DB;
 use Laravel\Boost\Mcp\Tools\DatabaseQuery;
 use Laravel\Mcp\Request;
+use MongoDB\Database;
+use MongoDB\Laravel\Connection as MongoDBConnection;
 
 function fakeConnection(): Mockery\MockInterface {
     $connection = Mockery::mock(ConnectionInterface::class);
@@ -92,7 +94,7 @@ it('handles empty queries gracefully', function (): void {
         $response = $tool->handle(new Request(['query' => $query]));
         expect($response)->isToolResult()
             ->toolHasError()
-            ->toolTextContains('Please pass a valid query');
+            ->toolTextContains('Please pass a valid SQL query');
     }
 });
 
@@ -230,3 +232,191 @@ test('it reports a failure when the database call throws', function (): void {
         ->toolHasError()
         ->toolTextContains('Query failed: Simulated DB failure');
 });
+
+/**
+ * Point DB::connection() at a mocked MongoDB connection so the tool takes the MQL path.
+ * Validation-error tests never reach the driver, so getDatabase() may go unused.
+ */
+function fakeMongoConnection(array $documents = []): MongoDBConnection
+{
+    // Mockery can't mock CursorInterface on Mockery 1.6.x / PHP 8.4 (its Iterator::current(): mixed
+    // clashes with CursorInterface::current(): object|array|null), so use a concrete double.
+    $cursor = new class($documents) implements \MongoDB\Driver\CursorInterface
+    {
+        public function __construct(private array $documents) {}
+
+        public function toArray(): array
+        {
+            return $this->documents;
+        }
+
+        public function current(): array|object|null
+        {
+            return current($this->documents) ?: null;
+        }
+
+        public function key(): ?int
+        {
+            return key($this->documents);
+        }
+
+        public function next(): void
+        {
+            next($this->documents);
+        }
+
+        public function valid(): bool
+        {
+            return key($this->documents) !== null;
+        }
+
+        public function rewind(): void
+        {
+            reset($this->documents);
+        }
+
+        public function getId(): \MongoDB\BSON\Int64
+        {
+            throw new \LogicException('unused in tests');
+        }
+
+        public function getServer(): \MongoDB\Driver\Server
+        {
+            throw new \LogicException('unused in tests');
+        }
+
+        public function isDead(): bool
+        {
+            return true;
+        }
+
+        public function setTypeMap(array $typemap): void {}
+    };
+
+    $database = Mockery::mock(Database::class);
+    $database->shouldReceive('command')->andReturn($cursor);
+
+    $connection = Mockery::mock(MongoDBConnection::class);
+    $connection->shouldReceive('getDatabase')->andReturn($database);
+
+    DB::shouldReceive('connection')->with(null)->andReturn($connection);
+
+    return $connection;
+}
+
+test('it runs a successful mql find command', function (): void {
+    fakeMongoConnection([
+        ['_id' => 1, 'name' => 'Taylor'],
+    ]);
+
+    $tool = new DatabaseQuery;
+    $response = $tool->handle(new Request([
+        'command' => ['find' => 'examples', 'filter' => ['name' => 'Taylor']],
+    ]));
+
+    expect($response)->isToolResult()
+        ->toolHasNoError()
+        ->toolJsonContent(function (array $rows): void {
+            expect($rows)->toHaveCount(1)
+                ->and($rows[0]['name'])->toBe('Taylor');
+        });
+});
+
+test('it runs a successful read-only aggregation', function (array $pipeline): void {
+    fakeMongoConnection([['count' => 1]]);
+
+    $tool = new DatabaseQuery;
+    $response = $tool->handle(new Request([
+        'command' => ['aggregate' => 'examples', 'pipeline' => $pipeline],
+    ]));
+
+    expect($response)->isToolResult()->toolHasNoError();
+})->with([
+    'flat stages' => [[
+        ['$match' => ['name' => 'Taylor']],
+        ['$sort' => ['name' => 1]],
+    ]],
+    'nested read-only lookup' => [[
+        ['$lookup' => ['from' => 'others', 'pipeline' => [['$match' => ['ok' => true]]]]],
+    ]],
+    'nested read-only unionWith' => [[
+        ['$unionWith' => ['coll' => 'others', 'pipeline' => [['$match' => ['ok' => true]]]]],
+    ]],
+    'nested read-only facet' => [[
+        ['$facet' => [
+            'a' => [['$match' => ['ok' => true]]],
+            'b' => [['$count' => 'total']],
+        ]],
+    ]],
+    'deeply nested read-only pipelines' => [[
+        ['$lookup' => ['from' => 'others', 'pipeline' => [
+            ['$unionWith' => ['coll' => 'more', 'pipeline' => [['$match' => ['ok' => true]]]]],
+        ]]],
+    ]],
+]);
+
+test('it rejects an empty mql command', function (): void {
+    fakeMongoConnection();
+
+    $tool = new DatabaseQuery;
+    $response = $tool->handle(new Request(['command' => []]));
+
+    expect($response)->isToolResult()
+        ->toolHasError()
+        ->toolTextContains('Please pass a valid MongoDB command');
+});
+
+test('it rejects a write mql command', function (): void {
+    fakeMongoConnection();
+
+    $tool = new DatabaseQuery;
+    $response = $tool->handle(new Request([
+        'command' => ['insert' => 'examples', 'documents' => [['name' => 'Otwell']]],
+    ]));
+
+    expect($response)->isToolResult()
+        ->toolHasError()
+        ->toolTextContains('Only read commands are allowed (aggregate, count, distinct, find).');
+});
+
+test('it rejects a write stage nested in an aggregation', function (array $pipeline, string $writeStage): void {
+    fakeMongoConnection();
+
+    $tool = new DatabaseQuery;
+    $response = $tool->handle(new Request([
+        'command' => ['aggregate' => 'examples', 'pipeline' => $pipeline],
+    ]));
+
+    expect($response)->isToolResult()
+        ->toolHasError()
+        ->toolTextContains(sprintf('Only read aggregation stages are allowed. Found: %s', $writeStage));
+})->with([
+    'write nested in lookup' => [
+        [['$lookup' => ['from' => 'others', 'pipeline' => [
+            ['$match' => ['name' => 'Taylor']],
+            ['$merge' => 'evil'],
+        ]]]],
+        'merge',
+    ],
+    'write nested in unionWith' => [
+        [['$unionWith' => ['coll' => 'others', 'pipeline' => [
+            ['$out' => 'evil'],
+        ]]]],
+        'out',
+    ],
+    'write nested in facet' => [
+        [['$facet' => [
+            'a' => [['$match' => ['ok' => true]]],
+            'b' => [['$merge' => 'evil']],
+        ]]],
+        'merge',
+    ],
+    'write nested three levels deep' => [
+        [['$lookup' => ['from' => 'a', 'pipeline' => [
+            ['$unionWith' => ['coll' => 'b', 'pipeline' => [
+                ['$out' => 'evil'],
+            ]]],
+        ]]]],
+        'out',
+    ],
+]);


### PR DESCRIPTION
The `database-query` tool only supports SQL queries currently. For MongoDB users, the tool attempts to pass SQL (which of course fails), then may try to pass MQL in some cases, before resorting to Tinker.

This has a higher cost, especially in tool calls. This PR introduces support for running read-only MQL commands through the tool. Please see below for a comparison.

> [!NOTE]
> One caveat is that a `database-connections` call will be done if the driver isn't already in context. Assuming most Boost users are not using a `mongodb` driver, we can also opt to only do the `database-connections` call if the first (SQL) attempt fails. This means 2 extra initial tool calls for MongoDB users, but not the one extra initial tool call for most other users. Lmk if you'd like to see that change.

## Before this change:

<img width="535" height="285" alt="Screenshot 2026-07-08 at 12 19 58" src="https://github.com/user-attachments/assets/6936ad55-c88d-461b-a1f8-d09f4d5636d0" />

*Token cost:* ~0.44
 *Tool calls:* 6

## After the

<img width="727" height="450" alt="Screenshot 2026-07-08 at 12 23 10" src="https://github.com/user-attachments/assets/162613a9-1893-4eb2-8ad6-a11a3590b1c2" />
 change:

*Token cost:* ~0.40
 *Boost tool calls:* 2