### PR TITLE
feat: add configurable browser log levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,23 +18,6 @@ Laravel Boost accelerates AI-assisted development by providing the essential con
 
 Documentation for Laravel Boost can be found on the [Laravel website](https://laravel.com/docs/boost).
 
-## Browser Log Levels
-
-Boost captures browser console output to provide debugging context. Use `BOOST_BROWSER_LOG_LEVELS` to reduce noisy logs:
-
-```env
-BOOST_BROWSER_LOG_LEVELS=warning
-```
-
-| Value | Captured browser events |
-| --- | --- |
-| `error` | `console.error()` and browser errors |
-| `warning` | warnings and errors |
-| `info` | info, warnings, and errors |
-| `debug` | `console.log()`, `console.debug()`, `console.info()`, `console.warn()`, `console.error()`, and `console.table()` |
-
-The default is `debug`, which preserves Boost's existing behavior by capturing all supported browser events. An empty value also preserves that default. To disable browser logging entirely, set `BOOST_BROWSER_LOGS_WATCHER=false`.
-
 ## Contributing
 
 Thank you for considering contributing to Boost! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@ Laravel Boost accelerates AI-assisted development by providing the essential con
 
 Documentation for Laravel Boost can be found on the [Laravel website](https://laravel.com/docs/boost).
 
+## Browser Log Levels
+
+Boost captures browser console output to provide debugging context. Use `BOOST_BROWSER_LOG_LEVELS` to reduce noisy logs:
+
+```env
+BOOST_BROWSER_LOG_LEVELS=warning
+```
+
+| Value | Captured browser events |
+| --- | --- |
+| `error` | `console.error()` and browser errors |
+| `warning` | warnings and errors |
+| `info` | info, warnings, and errors |
+| `debug` | `console.log()`, `console.debug()`, `console.info()`, `console.warn()`, `console.error()`, and `console.table()` |
+
+The default is `debug`, which preserves Boost's existing behavior by capturing all supported browser events. An empty value also preserves that default. To disable browser logging entirely, set `BOOST_BROWSER_LOGS_WATCHER=false`.
+
 ## Contributing
 
 Thank you for considering contributing to Boost! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).

--- a/config/boost.php
+++ b/config/boost.php
@@ -64,4 +64,19 @@ return [
         'current_directory' => env('BOOST_CURRENT_DIRECTORY_EXECUTABLE_PATH'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Browser Log Levels
+    |--------------------------------------------------------------------------
+    |
+    | These console log levels will be captured by Boost's browser logger.
+    | You may limit this to ['error'] if warnings or info logs are too noisy.
+    |
+    */
+
+    'browser_log_levels' => array_values(array_filter(array_map(
+        'trim',
+        explode(',', env('BOOST_BROWSER_LOG_LEVELS', 'error,warning,info,log'))
+    ))),
+
 ];

--- a/config/boost.php
+++ b/config/boost.php
@@ -69,14 +69,12 @@ return [
     | Browser Log Levels
     |--------------------------------------------------------------------------
     |
-    | These console log levels will be captured by Boost's browser logger.
-    | You may limit this to ['error'] if warnings or info logs are too noisy.
+    | This option controls which browser console log levels will be captured by
+    | Boost's browser logger. You may trim this list down to ['error'] when
+    | warnings, info, and debug messages become too noisy to be helpful.
     |
     */
 
-    'browser_log_levels' => array_values(array_filter(array_map(
-        'trim',
-        explode(',', env('BOOST_BROWSER_LOG_LEVELS', 'error,warning,info,debug'))
-    ))),
+    'browser_log_levels' => explode(',', env('BOOST_BROWSER_LOG_LEVELS', 'error,warning,info,debug')),
 
 ];

--- a/config/boost.php
+++ b/config/boost.php
@@ -76,7 +76,7 @@ return [
 
     'browser_log_levels' => array_values(array_filter(array_map(
         'trim',
-        explode(',', env('BOOST_BROWSER_LOG_LEVELS', 'error,warning,info,log'))
+        explode(',', env('BOOST_BROWSER_LOG_LEVELS', 'error,warning,info,debug'))
     ))),
 
 ];

--- a/src/Services/BrowserLogger.php
+++ b/src/Services/BrowserLogger.php
@@ -10,6 +10,22 @@ use Illuminate\View\ComponentAttributeBag;
 
 class BrowserLogger
 {
+    private const AllBrowserLogTypes = [
+        'log',
+        'debug',
+        'info',
+        'warning',
+        'error',
+        'table',
+    ];
+
+    private const BrowserLogLevelTypes = [
+        'error' => ['error'],
+        'warning' => ['warning', 'error'],
+        'info' => ['info', 'warning', 'error'],
+        'debug' => self::AllBrowserLogTypes,
+    ];
+
     public static function getScript(): string
     {
         $endpoint = Route::has('boost.browser-logs')
@@ -20,7 +36,7 @@ class BrowserLogger
             'id' => 'browser-logger-active',
         ]);
 
-        $levels = json_encode(config('boost.browser_log_levels') ?? ['debug']);
+        $captureTypes = json_encode(self::captureTypes(config('boost.browser_log_levels')), JSON_THROW_ON_ERROR);
 
         if ($nonce = Vite::cspNonce()) {
             $attributes = $attributes->merge(['nonce' => $nonce]);
@@ -32,19 +48,14 @@ class BrowserLogger
     const ENDPOINT = '{$endpoint}';
     const logQueue = [];
     let flushTimeout = null;
-    let levels = {$levels};
-    const severityMap = {
-        error: ['error'],
-        warning: ['warning', 'error'],
-        info: ['info', 'warning', 'error'],
-        debug: ['log', 'info', 'warning', 'error', 'table']
-    };
+    const captureTypes = {$captureTypes};
 
     console.log('🔍 Browser logger active (MCP server detected). Posting to: ' + ENDPOINT);
 
     // Store original console methods
     const originalConsole = {
         log: console.log,
+        debug: console.debug,
         info: console.info,
         error: console.error,
         warn: console.warn,
@@ -77,19 +88,7 @@ class BrowserLogger
 
     // Determine if a log type should be captured based on configured levels
     function shouldCapture(type) {
-        const normalizedType = normalizeType(type);
-
-        if (!Array.isArray(levels)) {
-            return false;
-        }
-
-        if (levels.length === 0) {
-            return true;
-        }
-
-        const expandedLevels = levels.flatMap(level => severityMap[level] ?? [level]);
-
-        return expandedLevels.includes(normalizedType);
+        return captureTypes.includes(normalizeType(type));
     }
 
     // Batch and send logs
@@ -118,7 +117,7 @@ class BrowserLogger
     }
 
     // Intercept console methods
-    ['log', 'info', 'error', 'warn', 'table'].forEach(method => {
+    ['log', 'debug', 'info', 'error', 'warn', 'table'].forEach(method => {
         console[method] = function(...args) {
             // Call original method
             originalConsole[method].apply(console, args);
@@ -259,5 +258,32 @@ class BrowserLogger
 })();
 </script>
 HTML;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function captureTypes(mixed $levels): array
+    {
+        if (! is_array($levels) || $levels === []) {
+            return self::AllBrowserLogTypes;
+        }
+
+        $captureTypes = [];
+
+        foreach ($levels as $level) {
+            if (! is_string($level)) {
+                continue;
+            }
+
+            $level = strtolower(trim($level));
+            $level = $level === 'warn' ? 'warning' : $level;
+
+            foreach (self::BrowserLogLevelTypes[$level] ?? [$level] as $type) {
+                $captureTypes[] = $type;
+            }
+        }
+
+        return array_values(array_unique($captureTypes));
     }
 }

--- a/src/Services/BrowserLogger.php
+++ b/src/Services/BrowserLogger.php
@@ -20,7 +20,7 @@ class BrowserLogger
             'id' => 'browser-logger-active',
         ]);
 
-        $levels = json_encode(config('boost.browser_log_levels'));
+        $levels = json_encode(config('boost.browser_log_levels') ?? ['debug']);
 
         if ($nonce = Vite::cspNonce()) {
             $attributes = $attributes->merge(['nonce' => $nonce]);
@@ -79,8 +79,12 @@ class BrowserLogger
     function shouldCapture(type) {
         const normalizedType = normalizeType(type);
 
-        if (!Array.isArray(levels) || levels.length === 0) {
+        if (!Array.isArray(levels)) {
             return false;
+        }
+
+        if (levels.length === 0) {
+            return true;
         }
 
         const expandedLevels = levels.flatMap(level => severityMap[level] ?? [level]);
@@ -150,29 +154,28 @@ class BrowserLogger
     const originalOnError = window.onerror;
     window.onerror = function boostErrorHandler(errorMsg, url, lineNumber, colNumber, error) {
         try {
-            if (!shouldCapture('error')) {
-                return false;
+            if (shouldCapture('error')) {
+                logQueue.push({
+                    type: 'uncaught_error',
+                    timestamp: new Date().toISOString(),
+                    data: [{
+                        message: errorMsg,
+                        filename: url,
+                        lineno: lineNumber,
+                        colno: colNumber,
+                        error: error ? {
+                            name: error.name,
+                            message: error.message,
+                            stack: error.stack
+                        } : null
+                    }],
+                    url: window.location.href,
+                    userAgent: navigator.userAgent
+                });
+
+                scheduleFlush();
             }
 
-            logQueue.push({
-                type: 'uncaught_error',
-                timestamp: new Date().toISOString(),
-                data: [{
-                    message: errorMsg,
-                    filename: url,
-                    lineno: lineNumber,
-                    colno: colNumber,
-                    error: error ? {
-                        name: error.name,
-                        message: error.message,
-                        stack: error.stack
-                    } : null
-                }],
-                url: window.location.href,
-                userAgent: navigator.userAgent
-            });
-
-            scheduleFlush();
         } catch (e) {
             // Fail silently
         }

--- a/src/Services/BrowserLogger.php
+++ b/src/Services/BrowserLogger.php
@@ -20,6 +20,8 @@ class BrowserLogger
             'id' => 'browser-logger-active',
         ]);
 
+        $levels = json_encode(config('boost.browser_log_levels'));
+
         if ($nonce = Vite::cspNonce()) {
             $attributes = $attributes->merge(['nonce' => $nonce]);
         }
@@ -30,6 +32,13 @@ class BrowserLogger
     const ENDPOINT = '{$endpoint}';
     const logQueue = [];
     let flushTimeout = null;
+    let levels = {$levels};
+    const severityMap = {
+        error: ['error'],
+        warning: ['warning', 'error'],
+        info: ['info', 'warning', 'error'],
+        debug: ['log', 'info', 'warning', 'error', 'table']
+    };
 
     console.log('🔍 Browser logger active (MCP server detected). Posting to: ' + ENDPOINT);
 
@@ -59,6 +68,24 @@ class BrowserLogger
             }
             return value;
         });
+    }
+
+    // Normalize log type for consistency (e.g., 'warn' to 'warning')
+    function normalizeType(type) {
+        return type === 'warn' ? 'warning' : type;
+    }
+
+    // Determine if a log type should be captured based on configured levels
+    function shouldCapture(type) {
+        const normalizedType = normalizeType(type);
+
+        if (!Array.isArray(levels) || levels.length === 0) {
+            return false;
+        }
+
+        const expandedLevels = levels.flatMap(level => severityMap[level] ?? [level]);
+
+        return expandedLevels.includes(normalizedType);
     }
 
     // Batch and send logs
@@ -94,6 +121,10 @@ class BrowserLogger
 
             // Capture log data
             try {
+                if (!shouldCapture(method)) {
+                    return;
+                }
+
                 logQueue.push({
                     type: method,
                     timestamp: new Date().toISOString(),
@@ -119,6 +150,10 @@ class BrowserLogger
     const originalOnError = window.onerror;
     window.onerror = function boostErrorHandler(errorMsg, url, lineNumber, colNumber, error) {
         try {
+            if (!shouldCapture('error')) {
+                return false;
+            }
+
             logQueue.push({
                 type: 'uncaught_error',
                 timestamp: new Date().toISOString(),
@@ -152,6 +187,10 @@ class BrowserLogger
     }
     window.addEventListener('error', (event) => {
         try {
+            if (!shouldCapture('error')) {
+                return false;
+            }
+
             logQueue.push({
                 type: 'window_error',
                 timestamp: new Date().toISOString(),
@@ -180,6 +219,10 @@ class BrowserLogger
     });
     window.addEventListener('unhandledrejection', (event) => {
         try {
+            if (!shouldCapture('error')) {
+                return false;
+            }
+
             logQueue.push({
                 type: 'error',
                 timestamp: new Date().toISOString(),

--- a/tests/Feature/Mcp/Tools/BrowserLogsTest.php
+++ b/tests/Feature/Mcp/Tools/BrowserLogsTest.php
@@ -94,10 +94,25 @@ test('browser logger script contains required functionality', function (): void 
         'browser-logger-active',
         '/_boost/browser-logs',
         'console.log',
+        'console.debug',
         'console.error',
         'window.onerror'
     );
 });
+
+test('browser logger script captures the configured log levels', function (?array $configuredLevels, array $capturedTypes): void {
+    config(['boost.browser_log_levels' => $configuredLevels]);
+
+    expect(BrowserLogger::getScript())->toContain('const captureTypes = '.json_encode($capturedTypes).';');
+})->with([
+    'error' => [['error'], ['error']],
+    'warning' => [['warning'], ['warning', 'error']],
+    'info' => [['info'], ['info', 'warning', 'error']],
+    'debug' => [['debug'], ['log', 'debug', 'info', 'warning', 'error', 'table']],
+    'warn alias' => [['warn'], ['warning', 'error']],
+    'missing configuration' => [null, ['log', 'debug', 'info', 'warning', 'error', 'table']],
+    'empty configuration' => [[], ['log', 'debug', 'info', 'warning', 'error', 'table']],
+]);
 
 test('browser logs endpoint processes logs correctly', function (): void {
     $response = $this->postJson('/_boost/browser-logs', [


### PR DESCRIPTION
## Summary

This PR adds configuration for Laravel Boost browser log levels, allowing projects to choose which browser console events should be captured by Boost.

By default, the existing behavior remains unchanged. When `boost.browser_log_levels` is configured, Boost only captures and posts the configured browser log types.

Closes #289.

## Problem

Some projects emit noisy browser warnings on every page load. Because Boost captures supported browser console output, those warnings can also be forwarded into downstream debugging tools, making real issues harder to spot.

This PR adds a way to restrict what Boost captures, for example allowing only `console.error()` logs while ignoring `console.warn()`, `console.info()`, and `console.log()`.

## What Changed

* Added a `browser_log_levels` configuration option to the Boost config
* Preserved the existing default browser logging behavior
* Applied filtering in `BrowserLogger` before browser logs are queued and posted
* Normalized warning handling so configured `warning` matches browser `console.warn()`

## Configuration Example

```env
BOOST_BROWSER_LOG_LEVELS=error,warning
```

## Behavior

Developers can control the browser log severity captured by Boost through the `.env` value:

```env
BOOST_BROWSER_LOG_LEVELS=warning
```

| .env value | Captured browser log events |
|--------|--------|
| `error` | error |
| `warning` | warning, error |
| `info` | info, warning, error |
| `debug` | log, info, warning, error, table | 

- `BOOST_BROWSER_LOG_LEVELS=error` captures only browser error-level events
- `BOOST_BROWSER_LOG_LEVELS=warning` captures browser warnings and errors
- `BOOST_BROWSER_LOG_LEVELS=info` captures browser info, warnings, and errors
- `BOOST_BROWSER_LOG_LEVELS=debug` captures all supported browser console events, including console.log(), console.info(), console.warn(), console.error(), and console.table()
- Leaving the value unset preserves the current default behavior

## Notes

* Default behavior is preserved for existing applications
* This change focuses on explicit allowed log-level filtering.
