### PR TITLE
feat: add Grok Build agent support

### DIFF
--- a/src/BoostManager.php
+++ b/src/BoostManager.php
@@ -13,6 +13,7 @@ use Laravel\Boost\Install\Agents\Codex;
 use Laravel\Boost\Install\Agents\Copilot;
 use Laravel\Boost\Install\Agents\Cursor;
 use Laravel\Boost\Install\Agents\Factory;
+use Laravel\Boost\Install\Agents\GrokBuild;
 use Laravel\Boost\Install\Agents\Junie;
 use Laravel\Boost\Install\Agents\Kiro;
 use Laravel\Boost\Install\Agents\OpenCode;
@@ -35,6 +36,7 @@ class BoostManager
         'antigravity' => Antigravity::class,
         'zed' => Zed::class,
         'pi' => Pi::class,
+        'grok_build' => GrokBuild::class,
     ];
 
     /**

--- a/src/Install/Agents/GrokBuild.php
+++ b/src/Install/Agents/GrokBuild.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install\Agents;
+
+use Laravel\Boost\Contracts\SupportsGuidelines;
+use Laravel\Boost\Contracts\SupportsMcp;
+use Laravel\Boost\Contracts\SupportsSkills;
+use Laravel\Boost\Install\Enums\McpInstallationStrategy;
+use Laravel\Boost\Install\Enums\Platform;
+
+class GrokBuild extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSkills
+{
+    public function name(): string
+    {
+        return 'grok_build';
+    }
+
+    public function displayName(): string
+    {
+        return 'Grok Build';
+    }
+
+    public function systemDetectionConfig(Platform $platform): array
+    {
+        return match ($platform) {
+            Platform::Darwin, Platform::Linux => [
+                'command' => 'command -v grok',
+                'paths' => ['~/.grok'],
+            ],
+            Platform::Windows => [
+                'command' => 'cmd /c where grok 2>nul',
+                'paths' => ['%USERPROFILE%\\.grok'],
+            ],
+        };
+    }
+
+    public function projectDetectionConfig(): array
+    {
+        return [
+            'paths' => ['.grok'],
+            'files' => ['.grok/config.toml'],
+        ];
+    }
+
+    public function guidelinesPath(): string
+    {
+        return config('boost.agents.grok_build.guidelines_path', 'AGENTS.md');
+    }
+
+    public function mcpInstallationStrategy(): McpInstallationStrategy
+    {
+        return McpInstallationStrategy::FILE;
+    }
+
+    public function mcpConfigPath(): string
+    {
+        return config('boost.agents.grok_build.mcp_config_path', '.grok/config.toml');
+    }
+
+    public function mcpConfigKey(): string
+    {
+        return 'mcp_servers';
+    }
+
+    /** {@inheritDoc} */
+    public function httpMcpServerConfig(string $url): array
+    {
+        return [
+            'url' => $url,
+        ];
+    }
+
+    /** {@inheritDoc} */
+    public function mcpServerConfig(string $command, array $args = [], array $env = []): array
+    {
+        return collect([
+            'command' => $command,
+            'args' => $args,
+            'env' => $env,
+        ])->filter(fn ($value): bool => ! in_array($value, [[], null, ''], true))
+            ->toArray();
+    }
+
+    public function skillsPath(): string
+    {
+        return config('boost.agents.grok_build.skills_path', '.grok/skills');
+    }
+}

--- a/tests/Unit/BoostManagerTest.php
+++ b/tests/Unit/BoostManagerTest.php
@@ -10,6 +10,7 @@ use Laravel\Boost\Install\Agents\Codex;
 use Laravel\Boost\Install\Agents\Copilot;
 use Laravel\Boost\Install\Agents\Cursor;
 use Laravel\Boost\Install\Agents\Factory;
+use Laravel\Boost\Install\Agents\GrokBuild;
 use Laravel\Boost\Install\Agents\Junie;
 use Laravel\Boost\Install\Agents\Kiro;
 use Laravel\Boost\Install\Agents\OpenCode;
@@ -34,6 +35,7 @@ it('returns default agents', function (): void {
         'antigravity' => Antigravity::class,
         'zed' => Zed::class,
         'pi' => Pi::class,
+        'grok_build' => GrokBuild::class,
     ]);
 });
 

--- a/tests/Unit/Install/Agents/GrokBuildTest.php
+++ b/tests/Unit/Install/Agents/GrokBuildTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Install\Agents;
+
+use Illuminate\Support\Facades\File;
+use Laravel\Boost\Install\Agents\GrokBuild;
+use Laravel\Boost\Install\Detection\DetectionStrategyFactory;
+use Laravel\Boost\Install\Enums\McpInstallationStrategy;
+use Laravel\Boost\Install\Enums\Platform;
+use Mockery;
+
+beforeEach(function (): void {
+    $this->strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
+});
+
+test('returns correct name', function (): void {
+    $agent = new GrokBuild($this->strategyFactory);
+
+    expect($agent->name())->toBe('grok_build');
+});
+
+test('returns correct display name', function (): void {
+    $agent = new GrokBuild($this->strategyFactory);
+
+    expect($agent->displayName())->toBe('Grok Build');
+});
+
+test('uses FILE-based MCP installation strategy', function (): void {
+    $agent = new GrokBuild($this->strategyFactory);
+
+    expect($agent->mcpInstallationStrategy())->toBe(McpInstallationStrategy::FILE);
+});
+
+test('returns correct MCP config path', function (): void {
+    $agent = new GrokBuild($this->strategyFactory);
+
+    expect($agent->mcpConfigPath())->toBe('.grok/config.toml');
+});
+
+test('returns configured MCP config path', function (): void {
+    config()->set('boost.agents.grok_build.mcp_config_path', '.custom/grok.toml');
+
+    $agent = new GrokBuild($this->strategyFactory);
+
+    expect($agent->mcpConfigPath())->toBe('.custom/grok.toml');
+});
+
+test('returns correct MCP config key', function (): void {
+    $agent = new GrokBuild($this->strategyFactory);
+
+    expect($agent->mcpConfigKey())->toBe('mcp_servers');
+});
+
+test('builds MCP server config without empty values', function (): void {
+    $agent = new GrokBuild($this->strategyFactory);
+
+    $config = $agent->mcpServerConfig('php', ['artisan', 'boost:mcp']);
+
+    expect($config)->toBe([
+        'command' => 'php',
+        'args' => ['artisan', 'boost:mcp'],
+    ]);
+});
+
+test('builds MCP server config with env when provided', function (): void {
+    $agent = new GrokBuild($this->strategyFactory);
+
+    $config = $agent->mcpServerConfig('php', ['artisan'], ['APP_ENV' => 'local']);
+
+    expect($config)->toBe([
+        'command' => 'php',
+        'args' => ['artisan'],
+        'env' => ['APP_ENV' => 'local'],
+    ]);
+});
+
+test('filters empty values from server config', function (): void {
+    $agent = new GrokBuild($this->strategyFactory);
+
+    $config = $agent->mcpServerConfig('php', [], []);
+
+    expect($config)->toBe([
+        'command' => 'php',
+    ]);
+});
+
+test('httpMcpServerConfig returns url-only config', function (): void {
+    $agent = new GrokBuild($this->strategyFactory);
+
+    expect($agent->httpMcpServerConfig('https://nightwatch.laravel.com/mcp'))->toBe([
+        'url' => 'https://nightwatch.laravel.com/mcp',
+    ]);
+});
+
+test('projectDetectionConfig only uses .grok dir and config.toml', function (): void {
+    $agent = new GrokBuild($this->strategyFactory);
+
+    expect($agent->projectDetectionConfig())->toBe([
+        'paths' => ['.grok'],
+        'files' => ['.grok/config.toml'],
+    ]);
+});
+
+test('detectInProject returns false when only AGENTS.md exists', function (): void {
+    $agent = new GrokBuild(new DetectionStrategyFactory(app()));
+    $tempDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'boost_grok_build_'.uniqid();
+    mkdir($tempDir);
+    touch($tempDir.DIRECTORY_SEPARATOR.'AGENTS.md');
+
+    try {
+        expect($agent->detectInProject($tempDir))->toBeFalse();
+    } finally {
+        unlink($tempDir.DIRECTORY_SEPARATOR.'AGENTS.md');
+        rmdir($tempDir);
+    }
+});
+
+test('returns correct guidelines path', function (): void {
+    $agent = new GrokBuild($this->strategyFactory);
+
+    expect($agent->guidelinesPath())->toBe('AGENTS.md');
+});
+
+test('returns configured guidelines path', function (): void {
+    config()->set('boost.agents.grok_build.guidelines_path', '.custom/AGENTS.md');
+
+    $agent = new GrokBuild($this->strategyFactory);
+
+    expect($agent->guidelinesPath())->toBe('.custom/AGENTS.md');
+});
+
+test('returns correct skills path', function (): void {
+    $agent = new GrokBuild($this->strategyFactory);
+
+    expect($agent->skillsPath())->toBe('.grok/skills');
+});
+
+test('returns configured skills path', function (): void {
+    config()->set('boost.agents.grok_build.skills_path', '.custom/skills');
+
+    $agent = new GrokBuild($this->strategyFactory);
+
+    expect($agent->skillsPath())->toBe('.custom/skills');
+});
+
+test('system detection uses command -v and ~/.grok on Darwin', function (): void {
+    $agent = new GrokBuild($this->strategyFactory);
+
+    expect($agent->systemDetectionConfig(Platform::Darwin))->toBe([
+        'command' => 'command -v grok',
+        'paths' => ['~/.grok'],
+    ]);
+});
+
+test('system detection uses command -v and ~/.grok on Linux', function (): void {
+    $agent = new GrokBuild($this->strategyFactory);
+
+    expect($agent->systemDetectionConfig(Platform::Linux))->toBe([
+        'command' => 'command -v grok',
+        'paths' => ['~/.grok'],
+    ]);
+});
+
+test('system detection uses where and USERPROFILE on Windows', function (): void {
+    $agent = new GrokBuild($this->strategyFactory);
+
+    expect($agent->systemDetectionConfig(Platform::Windows))->toBe([
+        'command' => 'cmd /c where grok 2>nul',
+        'paths' => ['%USERPROFILE%\\.grok'],
+    ]);
+});
+
+test('installMcp creates TOML config file', function (): void {
+    $agent = new GrokBuild($this->strategyFactory);
+    $capturedContent = '';
+
+    File::shouldReceive('ensureDirectoryExists')
+        ->once()
+        ->with('.grok');
+
+    File::shouldReceive('exists')
+        ->once()
+        ->with('.grok/config.toml')
+        ->andReturn(false);
+
+    File::shouldReceive('put')
+        ->once()
+        ->with(Mockery::any(), Mockery::capture($capturedContent))
+        ->andReturn(true);
+
+    $result = $agent->installMcp('laravel-boost', 'php', ['artisan', 'boost:mcp']);
+
+    expect($result)->toBeTrue()
+        ->and($capturedContent)->toContain('[mcp_servers.laravel-boost]')
+        ->and($capturedContent)->toContain('command = "php"')
+        ->and($capturedContent)->toContain('args = ["artisan", "boost:mcp"]');
+});

--- a/tests/Unit/Install/AgentsDetectorTest.php
+++ b/tests/Unit/Install/AgentsDetectorTest.php
@@ -13,6 +13,7 @@ use Laravel\Boost\Install\Agents\Codex;
 use Laravel\Boost\Install\Agents\Copilot;
 use Laravel\Boost\Install\Agents\Cursor;
 use Laravel\Boost\Install\Agents\Factory;
+use Laravel\Boost\Install\Agents\GrokBuild;
 use Laravel\Boost\Install\Agents\Junie;
 use Laravel\Boost\Install\Agents\Kiro;
 use Laravel\Boost\Install\Agents\OpenCode;
@@ -35,9 +36,9 @@ it('returns collection of all registered agents', function (): void {
     $agents = $this->detector->getAgents();
 
     expect($agents)->toBeInstanceOf(Collection::class)
-        ->and($agents->count())->toBe(12)
+        ->and($agents->count())->toBe(13)
         ->and($agents->keys()->toArray())->toBe([
-            'amp', 'junie', 'cursor', 'claude_code', 'codex', 'copilot', 'factory', 'kiro', 'opencode', 'antigravity', 'zed', 'pi',
+            'amp', 'junie', 'cursor', 'claude_code', 'codex', 'copilot', 'factory', 'kiro', 'opencode', 'antigravity', 'zed', 'pi', 'grok_build',
         ]);
 
     $agents->each(function ($agent): void {
@@ -70,6 +71,7 @@ it('returns an array of detected agents names for system discovery', function ()
     $this->container->bind(Antigravity::class, fn () => $mockOther);
     $this->container->bind(Zed::class, fn () => $mockOther);
     $this->container->bind(Pi::class, fn () => $mockOther);
+    $this->container->bind(GrokBuild::class, fn () => $mockOther);
 
     $detector = new AgentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverSystemInstalledAgents();
@@ -94,6 +96,7 @@ it('returns an empty array when no agents are detected for system discovery', fu
     $this->container->bind(Antigravity::class, fn () => $mockAgent);
     $this->container->bind(Zed::class, fn () => $mockAgent);
     $this->container->bind(Pi::class, fn () => $mockAgent);
+    $this->container->bind(GrokBuild::class, fn () => $mockAgent);
 
     $detector = new AgentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverSystemInstalledAgents();
@@ -128,6 +131,7 @@ it('returns an array of detected agent names for project discovery', function ()
     $this->container->bind(Antigravity::class, fn () => $mockOther);
     $this->container->bind(Zed::class, fn () => $mockOther);
     $this->container->bind(Pi::class, fn () => $mockOther);
+    $this->container->bind(GrokBuild::class, fn () => $mockOther);
 
     $detector = new AgentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverProjectInstalledAgents($basePath);
@@ -154,6 +158,7 @@ it('returns an empty array when no agents are detected for project discovery', f
     $this->container->bind(Antigravity::class, fn () => $mockAgent);
     $this->container->bind(Zed::class, fn () => $mockAgent);
     $this->container->bind(Pi::class, fn () => $mockAgent);
+    $this->container->bind(GrokBuild::class, fn () => $mockAgent);
 
     $detector = new AgentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverProjectInstalledAgents($basePath);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Summary

Adds [Grok Build](https://grok.com) as a first-class agent in Laravel Boost, so `php artisan boost:install` can detect it, write guidelines, install skills, and configure the Boost MCP server.

This follows the same pattern as other recent agent additions (Codex, Pi, Zed, Antigravity).

## What is configured

| Capability | Target |
|---|---|
| Guidelines | `AGENTS.md` |
| Skills | `.grok/skills` |
| MCP | `.grok/config.toml` (`[mcp_servers.*]`) |
| System detection | `command -v grok` or `~/.grok` |
| Project detection | `.grok` / `.grok/config.toml` (not bare `AGENTS.md`) |

HTTP MCP uses Grok's native `url` form rather than an `npx mcp-remote` proxy.

## Why

Grok Build is an AI coding agent that already understands Laravel Boost-style project rules (`AGENTS.md`), skills, and MCP. Without first-class support, users have to wire these up by hand. With this change, Boost can install everything through the normal installer flow, the same way it does for Cursor, Claude Code, Codex, and others.

## Compatibility

- Fully additive: no existing agents, configs, or defaults are changed
- MCP install is file-based (writes project `.grok/config.toml`), so install works even when the `grok` binary is not on `PATH` at install time
- Detection intentionally ignores a lone root `AGENTS.md` so projects that share that file with other agents are not mis-detected as Grok Build projects

## Tests

- Unit coverage for `GrokBuild` (paths, detection, MCP TOML write, HTTP config)
- `BoostManager` and `AgentsDetector` updated for the new registered agent