### PR TITLE
Prevent script injection into partial HTML responses

### DIFF
--- a/src/Middleware/InjectBoost.php
+++ b/src/Middleware/InjectBoost.php
@@ -59,8 +59,8 @@ class InjectBoost
 
         $content = $response->getContent();
 
-        // Check if it's HTML
-        if (! str_contains($content, '<html') && ! str_contains($content, '<head')) {
+        // Check for an <html> or <head> tag without matching e.g. <header>
+        if (preg_match('/<(html|head)[\s>]/', $content) !== 1) {
             return false;
         }
 

--- a/tests/Feature/Middleware/InjectBoostTest.php
+++ b/tests/Feature/Middleware/InjectBoostTest.php
@@ -78,6 +78,11 @@ it('does not inject when conditions are not met', function ($scenario, $response
             ->withHeaders(['content-type' => 'text/html']),
         fn ($result): Expectation => expect($result->getContent())->toContain('browser-logger-active'),
     ],
+    'partial html fragment with header tag' => [
+        'scenario',
+        fn () => (new Response('<header></header>'))->withHeaders(['content-type' => 'text/html']),
+        fn ($result): Expectation => expect($result->getContent())->toBe('<header></header>'),
+    ],
 ]);
 
 it('injects script in html responses', function ($html): void {
@@ -90,6 +95,7 @@ it('injects script in html responses', function ($html): void {
 })->with([
     'with head and body tags' => '<html><head><title>Test</title></head><body></body></html>',
     'without head/body tags' => '<html>Test</html>',
+    'with head tag only' => '<head><title>Test</title></head>',
 ]);
 
 it('handles CSP nonce attribute correctly', function ($nonce, $assertions): void {


### PR DESCRIPTION
Currently `shouldInject()` checks for HTML with `str_contains($content, '<head')`, so a partial response containing a `<header>` tag is treated as a full document and gets the browser logger script appended to it, which breaks HTMX fragment swaps.

This PR requires a real tag boundary after the tag name:

```php
// before
if (! str_contains($content, '<html') && ! str_contains($content, '<head')) {

// after
if (preg_match('/<(html|head)[\s>]/', $content) !== 1) {
```

Existing behavior is preserved: `<html>Test</html>` and `<head>`-only documents still get the script, with tests added for the fragment pass-through and the head-only case.

Fixes #865
