### PR TITLE
Add Laravel Roster 1.x support

### DIFF
--- a/.ai/foundation.blade.php
+++ b/.ai/foundation.blade.php
@@ -9,8 +9,9 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
 - php - {{ PHP_MAJOR_VERSION }}.{{ PHP_MINOR_VERSION }}
-@foreach (app(\Laravel\Roster\Roster::class)->packages()->unique(fn ($package) => $package->rawName()) as $package)
-- {{ $package->rawName() }} ({{ $package->name() }}) - v{{ $package->majorVersion() }}
+@php($project = app(\Laravel\Roster\ProjectManager::class))
+@foreach ($project->php()->packages()->concat($project->js()->packages())->unique(fn ($package) => $package->name()) as $package)
+- {{ $package->name() }} ({{ \Laravel\Boost\Support\PackageRegistry::rosterName($package->name()) }}) - v{{ $package->major() }}
 @endforeach
 
 @if (! empty(config('boost.purpose')))

--- a/.ai/inertia-laravel/core.blade.php
+++ b/.ai/inertia-laravel/core.blade.php
@@ -3,11 +3,11 @@
 - Inertia creates fully client-side rendered SPAs without modern SPA complexity, leveraging existing server-side patterns.
 - Components live in `{{ $assist->inertia()->pagesDirectory() }}` (unless specified in `vite.config.js`). Use `Inertia::render()` for server-side routing instead of Blade views.
 - ALWAYS use `search-docs` tool for version-specific Inertia documentation and updated code examples.
-@if($assist->hasPackage(\Laravel\Roster\Enums\Packages::INERTIA_REACT))
+@if($assist->hasPackage(\Laravel\Boost\Support\PackageRegistry::INERTIA_REACT))
 - IMPORTANT: Activate `inertia-react-development` when working with Inertia client-side patterns.
-@elseif($assist->hasPackage(\Laravel\Roster\Enums\Packages::INERTIA_VUE))
+@elseif($assist->hasPackage(\Laravel\Boost\Support\PackageRegistry::INERTIA_VUE))
 - IMPORTANT: Activate `inertia-vue-development` when working with Inertia Vue client-side patterns.
-@elseif($assist->hasPackage(\Laravel\Roster\Enums\Packages::INERTIA_SVELTE))
+@elseif($assist->hasPackage(\Laravel\Boost\Support\PackageRegistry::INERTIA_SVELTE))
 - IMPORTANT: Activate `inertia-svelte-development` when working with Inertia Svelte client-side patterns.
 @endif
 

--- a/.ai/wayfinder/skill/wayfinder-development/SKILL.blade.php
+++ b/.ai/wayfinder/skill/wayfinder-development/SKILL.blade.php
@@ -58,22 +58,22 @@ store.form() // { action: "/posts", method: "post" }
 show(1, { query: { page: 1 } }) // "/posts/1?page=1"
 @endboostsnippet
 
-@if($assist->roster->uses(\Laravel\Roster\Enums\Packages::INERTIA_LARAVEL) || $assist->roster->uses(\Laravel\Roster\Enums\Packages::INERTIA_REACT) || $assist->roster->uses(\Laravel\Roster\Enums\Packages::INERTIA_VUE) || $assist->roster->uses(\Laravel\Roster\Enums\Packages::INERTIA_SVELTE))
+@if($assist->project->php()->uses(\Laravel\Boost\Support\PackageRegistry::INERTIA_LARAVEL) || $assist->project->js()->uses([\Laravel\Boost\Support\PackageRegistry::INERTIA_REACT, \Laravel\Boost\Support\PackageRegistry::INERTIA_VUE, \Laravel\Boost\Support\PackageRegistry::INERTIA_SVELTE]))
 ## Wayfinder + Inertia
 
 @if($assist->inertia()->hasFormComponent())
 Use Wayfinder with the `<Form>` component:
-@if($assist->roster->uses(\Laravel\Roster\Enums\Packages::INERTIA_REACT))
+@if($assist->project->js()->uses(\Laravel\Boost\Support\PackageRegistry::INERTIA_REACT))
 @boostsnippet("Wayfinder Form (React)", "typescript")
 <Form {...store.form()}><input name="title" /></Form>
 @endboostsnippet
 @endif
-@if($assist->roster->uses(\Laravel\Roster\Enums\Packages::INERTIA_VUE))
+@if($assist->project->js()->uses(\Laravel\Boost\Support\PackageRegistry::INERTIA_VUE))
 @boostsnippet("Wayfinder Form (Vue)", "vue")
 <Form v-bind="store.form()"><input name="title" /></Form>
 @endboostsnippet
 @endif
-@if($assist->roster->uses(\Laravel\Roster\Enums\Packages::INERTIA_SVELTE))
+@if($assist->project->js()->uses(\Laravel\Boost\Support\PackageRegistry::INERTIA_SVELTE))
 @boostsnippet("Wayfinder Form (Svelte)", "svelte")
 <Form {...store.form()}><input name="title" /></Form>
 @endboostsnippet

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/support": "^11.45.3|^12.41.1|^13.0",
         "laravel/mcp": "^0.7.1|^0.8.0",
         "laravel/prompts": "^0.3.10",
-        "laravel/roster": "^0.5.0"
+        "laravel/roster": "^1.0"
     },
     "require-dev": {
         "laravel/pint": "^1.27.0",

--- a/src/BoostServiceProvider.php
+++ b/src/BoostServiceProvider.php
@@ -19,7 +19,7 @@ use Laravel\Boost\Middleware\InjectBoost;
 use Laravel\Boost\Rules\RuleRepository;
 use Laravel\Boost\Services\BrowserLogger;
 use Laravel\Mcp\Facades\Mcp;
-use Laravel\Roster\Roster;
+use Laravel\Roster\ProjectManager;
 
 class BoostServiceProvider extends ServiceProvider
 {
@@ -36,14 +36,14 @@ class BoostServiceProvider extends ServiceProvider
 
         $this->app->singleton(BoostManager::class, fn (): BoostManager => new BoostManager);
 
-        $this->app->singleton(Roster::class, fn (): Roster => Roster::scan(base_path()));
+        $this->app->singleton(ProjectManager::class, fn (): ProjectManager => new ProjectManager);
 
         $this->app->singleton(GuidelineConfig::class, fn (): GuidelineConfig => new GuidelineConfig);
 
         $this->app->singleton(RuleRepository::class, fn (): RuleRepository => new RuleRepository(base_path('.ai/rules')));
 
         $this->app->singleton(GuidelineAssist::class, fn ($app): GuidelineAssist => new GuidelineAssist(
-            $app->make(Roster::class),
+            $app->make(ProjectManager::class),
             $app->make(GuidelineConfig::class)
         ));
     }

--- a/src/Install/Assists/Inertia.php
+++ b/src/Install/Assists/Inertia.php
@@ -4,31 +4,31 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Install\Assists;
 
-use Laravel\Roster\Enums\Packages;
-use Laravel\Roster\Roster;
+use Laravel\Boost\Support\PackageRegistry;
+use Laravel\Roster\ProjectManager;
 
 class Inertia
 {
-    public function __construct(private Roster $roster)
+    public function __construct(private ProjectManager $project)
     {
         //
     }
 
     public function gte(string $version): bool
     {
-        if ($this->roster->usesVersion(Packages::INERTIA_LARAVEL, $version, '>=')) {
+        if ($this->project->php()->uses(PackageRegistry::INERTIA_LARAVEL, ">={$version}")) {
             return true;
         }
 
-        if ($this->roster->usesVersion(Packages::INERTIA_REACT, $version, '>=')) {
+        if ($this->project->js()->uses(PackageRegistry::INERTIA_REACT, ">={$version}")) {
             return true;
         }
 
-        if ($this->roster->usesVersion(Packages::INERTIA_SVELTE, $version, '>=')) {
+        if ($this->project->js()->uses(PackageRegistry::INERTIA_SVELTE, ">={$version}")) {
             return true;
         }
 
-        return $this->roster->usesVersion(Packages::INERTIA_VUE, $version, '>=');
+        return $this->project->js()->uses(PackageRegistry::INERTIA_VUE, ">={$version}");
     }
 
     public function hasFormComponent(): bool

--- a/src/Install/Concerns/DiscoverPackagePaths.php
+++ b/src/Install/Concerns/DiscoverPackagePaths.php
@@ -7,9 +7,9 @@ namespace Laravel\Boost\Install\Concerns;
 use Illuminate\Support\Collection;
 use Laravel\Boost\Support\Composer;
 use Laravel\Boost\Support\Npm;
-use Laravel\Roster\Enums\Packages;
+use Laravel\Boost\Support\PackageRegistry;
 use Laravel\Roster\Package;
-use Laravel\Roster\Roster;
+use Laravel\Roster\ProjectManager;
 
 trait DiscoverPackagePaths
 {
@@ -17,25 +17,25 @@ trait DiscoverPackagePaths
      * Only include guidelines for these package names if they're a direct requirement.
      * This fixes every Boost user getting the MCP guidelines due to indirect import.
      *
-     * @var array<int, Packages>
+     * @var array<int, string>
      * */
     protected array $mustBeDirect = [
-        Packages::MCP,
-        Packages::LIVEWIRE,
+        PackageRegistry::MCP,
+        PackageRegistry::LIVEWIRE,
     ];
 
     /**
      * Packages excluded from Roster-based guideline discovery.
      * Boost is already loaded by getCoreGuidelines(); Sail requires explicit opt-in.
      *
-     * @var array<int, Packages>
+     * @var array<int, string>
      */
     protected array $excludedPackages = [
-        Packages::BOOST,
-        Packages::SAIL,
+        PackageRegistry::BOOST,
+        PackageRegistry::SAIL,
     ];
 
-    abstract protected function getRoster(): Roster;
+    abstract protected function getProject(): ProjectManager;
 
     /**
      * Package priority system to handle conflicts between packages.
@@ -44,25 +44,25 @@ trait DiscoverPackagePaths
     protected function getPackagePriorities(): array
     {
         return [
-            Packages::PEST->value => [Packages::PHPUNIT->value],
-            Packages::FLUXUI_PRO->value => [Packages::FLUXUI_FREE->value],
+            PackageRegistry::PEST => [PackageRegistry::PHPUNIT],
+            PackageRegistry::FLUXUI_PRO => [PackageRegistry::FLUXUI_FREE],
         ];
     }
 
     protected function shouldExcludePackage(Package $package): bool
     {
-        if (in_array($package->package(), $this->excludedPackages, true)) {
+        if (in_array($package->name(), $this->excludedPackages, true)) {
             return true;
         }
 
         foreach ($this->getPackagePriorities() as $priorityPackage => $excludedPackages) {
-            if (in_array($package->package()->value, $excludedPackages, true)
-                && $this->getRoster()->uses(Packages::from($priorityPackage))) {
+            if (in_array($package->name(), $excludedPackages, true)
+                && $this->usesPackage($priorityPackage)) {
                 return true;
             }
         }
 
-        return $package->indirect() && in_array($package->package(), $this->mustBeDirect, true);
+        return ! $package->isDirect() && in_array($package->name(), $this->mustBeDirect, true);
     }
 
     /**
@@ -70,7 +70,7 @@ trait DiscoverPackagePaths
      */
     protected function discoverPackagePaths(string $basePath): Collection
     {
-        $packages = $this->getRoster()->packages()
+        $packages = $this->packages()
             ->reject(fn (Package $package): bool => $this->shouldExcludePackage($package));
 
         /** @var Collection<int, array{path: string, name: string, version: string}> $result */
@@ -81,7 +81,7 @@ trait DiscoverPackagePaths
                 return [
                     'path' => $basePath.DIRECTORY_SEPARATOR.$name,
                     'name' => $name,
-                    'version' => $package->majorVersion(),
+                    'version' => (string) $package->major(),
                 ];
             })
             ->collect();
@@ -91,7 +91,22 @@ trait DiscoverPackagePaths
 
     protected function normalizePackageName(string $name): string
     {
-        return str_replace('_', '-', strtolower($name));
+        return PackageRegistry::guidelineName($name);
+    }
+
+    /** @return Collection<int, Package> */
+    protected function packages(): Collection
+    {
+        return $this->getProject()->php()->packages()->concat($this->getProject()->js()->packages());
+    }
+
+    protected function usesPackage(string $package, ?string $constraint = null): bool
+    {
+        if ($this->getProject()->php()->uses($package, $constraint)) {
+            return true;
+        }
+
+        return $this->getProject()->js()->uses($package, $constraint);
     }
 
     protected function getBoostAiPath(): string
@@ -101,7 +116,7 @@ trait DiscoverPackagePaths
 
     protected function resolveFirstPartyBoostPath(Package $package, string $subpath): ?string
     {
-        if (! Composer::isFirstPartyPackage($package->rawName()) && ! Npm::isFirstPartyPackage($package->rawName())) {
+        if (! Composer::isFirstPartyPackage($package->name()) && ! Npm::isFirstPartyPackage($package->name())) {
             return null;
         }
 

--- a/src/Install/GuidelineAssist.php
+++ b/src/Install/GuidelineAssist.php
@@ -7,9 +7,9 @@ namespace Laravel\Boost\Install;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Laravel\Boost\Install\Assists\Inertia;
-use Laravel\Roster\Enums\NodePackageManager;
-use Laravel\Roster\Enums\Packages;
-use Laravel\Roster\Roster;
+use Laravel\Boost\Support\PackageRegistry;
+use Laravel\Roster\Enums\JsPackageManager;
+use Laravel\Roster\ProjectManager;
 use Symfony\Component\Finder\Finder;
 
 class GuidelineAssist
@@ -17,7 +17,7 @@ class GuidelineAssist
     /** @var array<string, string> */
     protected array $enumPaths = [];
 
-    public function __construct(public Roster $roster, public GuidelineConfig $config, public ?Collection $skills = null)
+    public function __construct(public ProjectManager $project, public GuidelineConfig $config, public ?Collection $skills = null)
     {
         $this->skills ??= collect();
         $this->enumPaths = $this->discover();
@@ -93,24 +93,26 @@ class GuidelineAssist
 
     public function inertia(): Inertia
     {
-        return new Inertia($this->roster);
+        return new Inertia($this->project);
     }
 
     public function supportsPintAgentFormatter(): bool
     {
-        return $this->roster->usesVersion(Packages::PINT, '1.27.0', '>=');
+        return $this->project->php()->uses(PackageRegistry::PINT, '>=1.27.0');
     }
 
-    public function hasPackage(Packages $package): bool
+    public function hasPackage(string $package): bool
     {
-        return $this->roster->packages()->contains(
-            fn ($pkg): bool => $pkg->package() === $package
-        );
+        if ($this->project->php()->uses($package)) {
+            return true;
+        }
+
+        return $this->project->js()->uses($package);
     }
 
     public function nodePackageManager(): string
     {
-        return ($this->roster->nodePackageManager() ?? NodePackageManager::NPM)->value;
+        return ($this->project->js()->packageManager() ?? JsPackageManager::Npm)->value;
     }
 
     protected function detectedNodePackageManager(): string

--- a/src/Install/GuidelineComposer.php
+++ b/src/Install/GuidelineComposer.php
@@ -10,7 +10,7 @@ use Laravel\Boost\Concerns\RendersBladeGuidelines;
 use Laravel\Boost\Install\Concerns\DiscoverPackagePaths;
 use Laravel\Boost\Support\Composer;
 use Laravel\Roster\Package;
-use Laravel\Roster\Roster;
+use Laravel\Roster\ProjectManager;
 use Symfony\Component\Finder\Exception\DirectoryNotFoundException;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -27,14 +27,14 @@ class GuidelineComposer
 
     protected GuidelineConfig $config;
 
-    public function __construct(protected Roster $roster, protected Herd $herd)
+    public function __construct(protected ProjectManager $project, protected Herd $herd)
     {
         $this->config = new GuidelineConfig;
     }
 
-    protected function getRoster(): Roster
+    protected function getProject(): ProjectManager
     {
-        return $this->roster;
+        return $this->project;
     }
 
     public function config(GuidelineConfig $config): self
@@ -176,7 +176,7 @@ class GuidelineComposer
 
     protected function getPackageGuidelines(): Collection
     {
-        return $this->roster->packages()
+        return $this->packages()
             ->reject(fn (Package $package): bool => $this->shouldExcludePackage($package))
             ->flatMap(function (Package $package): Collection {
                 $guidelineDir = $this->normalizePackageName($package->name());
@@ -191,13 +191,13 @@ class GuidelineComposer
                     $guidelineDir.'/core' => $this->resolveGuideline($vendorCorePath, $guidelineDir.'/core'),
                 ]);
 
-                $packageGuidelines = $this->guidelinesDir($guidelineDir.'/'.$package->majorVersion());
+                $packageGuidelines = $this->guidelinesDir($guidelineDir.'/'.$package->major());
 
                 foreach ($packageGuidelines as $guideline) {
                     $suffix = $guideline['name'] === 'core' ? '' : '/'.$guideline['name'];
 
                     $guidelines->put(
-                        $guidelineDir.'/v'.$package->majorVersion().$suffix,
+                        $guidelineDir.'/v'.$package->major().$suffix,
                         $guideline
                     );
                 }
@@ -315,7 +315,7 @@ class GuidelineComposer
 
     protected function getGuidelineAssist(): GuidelineAssist
     {
-        return new GuidelineAssist($this->roster, $this->config);
+        return new GuidelineAssist($this->project, $this->config);
     }
 
     protected function prependPackageGuidelinePath(string $path): string

--- a/src/Install/SkillComposer.php
+++ b/src/Install/SkillComposer.php
@@ -10,7 +10,7 @@ use Laravel\Boost\Concerns\RendersBladeGuidelines;
 use Laravel\Boost\Install\Concerns\DiscoverPackagePaths;
 use Laravel\Boost\Support\Composer;
 use Laravel\Roster\Package;
-use Laravel\Roster\Roster;
+use Laravel\Roster\ProjectManager;
 use Symfony\Component\Yaml\Yaml;
 
 class SkillComposer
@@ -21,14 +21,14 @@ class SkillComposer
     /** @var Collection<string, Skill>|null */
     protected ?Collection $skills = null;
 
-    public function __construct(protected Roster $roster, protected GuidelineConfig $config = new GuidelineConfig)
+    public function __construct(protected ProjectManager $project, protected GuidelineConfig $config = new GuidelineConfig)
     {
         //
     }
 
-    protected function getRoster(): Roster
+    protected function getProject(): ProjectManager
     {
-        return $this->roster;
+        return $this->project;
     }
 
     public function config(GuidelineConfig $config): self
@@ -65,7 +65,7 @@ class SkillComposer
     protected function getBoostSkills(): Collection
     {
         /** @var Collection<string, Skill> $skills */
-        $skills = $this->getRoster()->packages()
+        $skills = $this->packages()
             ->reject(fn (Package $package): bool => $this->shouldExcludePackage($package))
             ->collect()
             ->flatMap(function (Package $package): Collection {
@@ -79,7 +79,7 @@ class SkillComposer
 
                 $aiPath = $this->getBoostAiPath().DIRECTORY_SEPARATOR.$name;
                 $aiSkills = is_dir($aiPath)
-                    ? $this->discoverSkillsFromPath($aiPath, $name, $package->majorVersion())
+                    ? $this->discoverSkillsFromPath($aiPath, $name, $package->major() === null ? null : (string) $package->major())
                     : collect();
 
                 return $aiSkills->merge($vendorSkills);
@@ -255,6 +255,6 @@ class SkillComposer
 
     protected function getGuidelineAssist(): GuidelineAssist
     {
-        return new GuidelineAssist($this->roster, $this->config);
+        return new GuidelineAssist($this->project, $this->config);
     }
 }

--- a/src/Mcp/Prompts/UpgradeInertiav3/UpgradeInertiaV3.php
+++ b/src/Mcp/Prompts/UpgradeInertiav3/UpgradeInertiaV3.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Laravel\Boost\Mcp\Prompts\UpgradeInertiav3;
 
 use Laravel\Boost\Concerns\RendersBladeGuidelines;
+use Laravel\Boost\Support\PackageRegistry;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Prompt;
-use Laravel\Roster\Enums\Packages;
-use Laravel\Roster\Roster;
+use Laravel\Roster\ProjectManager;
 
 class UpgradeInertiaV3 extends Prompt
 {
@@ -20,31 +20,31 @@ class UpgradeInertiaV3 extends Prompt
 
     protected string $description = 'Provides step-by-step guidance for upgrading from Inertia v2 to v3.';
 
-    public function shouldRegister(Roster $roster): bool
+    public function shouldRegister(ProjectManager $project): bool
     {
-        if ($roster->uses(Packages::INERTIA_LARAVEL)) {
+        if ($project->php()->uses(PackageRegistry::INERTIA_LARAVEL)) {
             return true;
         }
 
-        if ($roster->uses(Packages::INERTIA_REACT)) {
+        if ($project->js()->uses(PackageRegistry::INERTIA_REACT)) {
             return true;
         }
 
-        if ($roster->uses(Packages::INERTIA_VUE)) {
+        if ($project->js()->uses(PackageRegistry::INERTIA_VUE)) {
             return true;
         }
 
-        return $roster->uses(Packages::INERTIA_SVELTE);
+        return $project->js()->uses(PackageRegistry::INERTIA_SVELTE);
     }
 
     public function handle(): Response
     {
-        $roster = $this->getGuidelineAssist()->roster;
+        $project = $this->getGuidelineAssist()->project;
 
         $content = $this->renderBladeFile(__DIR__.'/upgrade-inertia-v3.blade.php', [
-            'usesReact' => $roster->uses(Packages::INERTIA_REACT),
-            'usesVue' => $roster->uses(Packages::INERTIA_VUE),
-            'usesSvelte' => $roster->uses(Packages::INERTIA_SVELTE),
+            'usesReact' => $project->js()->uses(PackageRegistry::INERTIA_REACT),
+            'usesVue' => $project->js()->uses(PackageRegistry::INERTIA_VUE),
+            'usesSvelte' => $project->js()->uses(PackageRegistry::INERTIA_SVELTE),
         ]);
 
         return Response::text($content);

--- a/src/Mcp/Prompts/UpgradeLaravelv13/UpgradeLaravelV13.php
+++ b/src/Mcp/Prompts/UpgradeLaravelv13/UpgradeLaravelV13.php
@@ -6,10 +6,10 @@ namespace Laravel\Boost\Mcp\Prompts\UpgradeLaravelv13;
 
 use Laravel\Boost\Concerns\RendersBladeGuidelines;
 use Laravel\Boost\Install\Herd;
+use Laravel\Boost\Support\PackageRegistry;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Prompt;
-use Laravel\Roster\Enums\Packages;
-use Laravel\Roster\Roster;
+use Laravel\Roster\ProjectManager;
 
 class UpgradeLaravelV13 extends Prompt
 {
@@ -21,10 +21,9 @@ class UpgradeLaravelV13 extends Prompt
 
     protected string $description = 'Provides step-by-step guidance for upgrading from Laravel 12.x to 13.0.';
 
-    public function shouldRegister(Roster $roster): bool
+    public function shouldRegister(ProjectManager $project): bool
     {
-        return $roster->usesVersion(Packages::LARAVEL, '12.0.0', '>=')
-            && $roster->usesVersion(Packages::LARAVEL, '13.0.0', '<');
+        return $project->php()->uses(PackageRegistry::LARAVEL, '>=12.0.0 <13.0.0');
     }
 
     public function handle(): Response

--- a/src/Mcp/Prompts/UpgradeLivewirev4/UpgradeLivewireV4.php
+++ b/src/Mcp/Prompts/UpgradeLivewirev4/UpgradeLivewireV4.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Laravel\Boost\Mcp\Prompts\UpgradeLivewirev4;
 
 use Laravel\Boost\Concerns\RendersBladeGuidelines;
+use Laravel\Boost\Support\PackageRegistry;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Prompt;
-use Laravel\Roster\Enums\Packages;
-use Laravel\Roster\Roster;
+use Laravel\Roster\ProjectManager;
 
 class UpgradeLivewireV4 extends Prompt
 {
@@ -20,9 +20,9 @@ class UpgradeLivewireV4 extends Prompt
 
     protected string $description = 'Provides step-by-step guidance for upgrading from Livewire v3 to v4.';
 
-    public function shouldRegister(Roster $roster): bool
+    public function shouldRegister(ProjectManager $project): bool
     {
-        return $roster->uses(Packages::LIVEWIRE);
+        return $project->php()->uses(PackageRegistry::LIVEWIRE);
     }
 
     public function handle(): Response

--- a/src/Mcp/Tools/ApplicationInfo.php
+++ b/src/Mcp/Tools/ApplicationInfo.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Mcp\Tools;
 
+use Laravel\Boost\Support\PackageRegistry;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;
 use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
 use Laravel\Roster\Package;
-use Laravel\Roster\Roster;
+use Laravel\Roster\ProjectManager;
 
 #[IsReadOnly]
 class ApplicationInfo extends Tool
 {
-    public function __construct(protected Roster $roster)
+    public function __construct(protected ProjectManager $project)
     {
         //
     }
@@ -33,7 +34,13 @@ class ApplicationInfo extends Tool
             'php_version' => PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION,
             'laravel_version' => app()->version(),
             'database_engine' => config('database.default'),
-            'packages' => $this->roster->packages()->map(fn (Package $package): array => ['roster_name' => $package->name(), 'version' => $package->version(), 'package_name' => $package->rawName()]),
+            'packages' => $this->project->php()->packages()
+                ->concat($this->project->js()->packages())
+                ->map(fn (Package $package): array => [
+                    'roster_name' => PackageRegistry::rosterName($package->name()),
+                    'version' => $package->version(),
+                    'package_name' => $package->name(),
+                ]),
         ]);
     }
 }

--- a/src/Mcp/Tools/SearchDocs.php
+++ b/src/Mcp/Tools/SearchDocs.php
@@ -12,14 +12,14 @@ use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;
 use Laravel\Roster\Package;
-use Laravel\Roster\Roster;
+use Laravel\Roster\ProjectManager;
 use Throwable;
 
 class SearchDocs extends Tool
 {
     use MakesHttpRequests;
 
-    public function __construct(protected Roster $roster)
+    public function __construct(protected ProjectManager $project)
     {
         //
     }
@@ -74,16 +74,16 @@ class SearchDocs extends Tool
         );
 
         try {
-            $packagesCollection = $this->roster->packages();
+            $packagesCollection = $this->project->php()->packages()->concat($this->project->js()->packages());
 
             // Only search in specific packages
             if ($packagesFilter) {
-                $packagesCollection = $packagesCollection->filter(fn (Package $package): bool => in_array($package->rawName(), $packagesFilter, true));
+                $packagesCollection = $packagesCollection->filter(fn (Package $package): bool => in_array($package->name(), $packagesFilter, true));
             }
 
             $packages = $packagesCollection->map(function (Package $package): array {
-                $name = $package->rawName();
-                $version = $package->majorVersion().'.x';
+                $name = $package->name();
+                $version = $package->major().'.x';
 
                 return [
                     'name' => $name,

--- a/src/Support/PackageRegistry.php
+++ b/src/Support/PackageRegistry.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Support;
+
+class PackageRegistry
+{
+    public const BOOST = 'laravel/boost';
+
+    public const FLUXUI_FREE = 'livewire/flux';
+
+    public const FLUXUI_PRO = 'livewire/flux-pro';
+
+    public const INERTIA_LARAVEL = 'inertiajs/inertia-laravel';
+
+    public const INERTIA_REACT = '@inertiajs/react';
+
+    public const INERTIA_SVELTE = '@inertiajs/svelte';
+
+    public const INERTIA_VUE = '@inertiajs/vue3';
+
+    public const LARAVEL = 'laravel/framework';
+
+    public const LIVEWIRE = 'livewire/livewire';
+
+    public const MCP = 'laravel/mcp';
+
+    public const PEST = 'pestphp/pest';
+
+    public const PHPUNIT = 'phpunit/phpunit';
+
+    public const PINT = 'laravel/pint';
+
+    public const SAIL = 'laravel/sail';
+
+    /** @var array<string, string> */
+    private const GUIDELINE_NAMES = [
+        '@inertiajs/react' => 'inertia-react',
+        '@inertiajs/svelte' => 'inertia-svelte',
+        '@inertiajs/vue3' => 'inertia-vue',
+        'inertiajs/inertia-laravel' => 'inertia-laravel',
+        'laravel/boost' => 'boost',
+        'laravel/folio' => 'folio',
+        'laravel/framework' => 'laravel',
+        'laravel/mcp' => 'mcp',
+        'laravel/pennant' => 'pennant',
+        'laravel/pint' => 'pint',
+        'laravel/sail' => 'sail',
+        'laravel/wayfinder' => 'wayfinder',
+        'livewire/flux' => 'fluxui-free',
+        'livewire/flux-pro' => 'fluxui-pro',
+        'livewire/livewire' => 'livewire',
+        'livewire/volt' => 'volt',
+        'pestphp/pest' => 'pest',
+        'phpunit/phpunit' => 'phpunit',
+        'tailwindcss' => 'tailwindcss',
+    ];
+
+    public static function guidelineName(string $package): string
+    {
+        return self::GUIDELINE_NAMES[$package]
+            ?? str_replace(['@', '/', '_'], ['', '-', '-'], strtolower($package));
+    }
+
+    public static function rosterName(string $package): string
+    {
+        return strtoupper(str_replace('-', '_', self::guidelineName($package)));
+    }
+}

--- a/tests/Feature/BoostServiceProviderTest.php
+++ b/tests/Feature/BoostServiceProviderTest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Config;
 use Laravel\Boost\Boost;
 use Laravel\Boost\BoostManager;
 use Laravel\Boost\BoostServiceProvider;
-use Laravel\Roster\Roster;
+use Laravel\Roster\ProjectManager;
 
 beforeEach(function (): void {
     $this->refreshApplication();
@@ -33,7 +33,7 @@ describe('boost.enabled configuration', function (): void {
         $provider->register();
         $provider->boot(app('router'));
 
-        expect(app()->bound(Roster::class))->toBeTrue()
+        expect(app()->bound(ProjectManager::class))->toBeTrue()
             ->and(config('logging.channels.browser'))->not->toBeNull();
     });
 

--- a/tests/Feature/Install/GuidelineComposerTest.php
+++ b/tests/Feature/Install/GuidelineComposerTest.php
@@ -9,38 +9,32 @@ use Laravel\Boost\Install\GuidelineConfig;
 use Laravel\Boost\Install\Herd;
 use Laravel\Boost\Support\Composer;
 use Laravel\Boost\Support\Npm;
-use Laravel\Roster\Enums\NodePackageManager;
-use Laravel\Roster\Enums\Packages;
+use Laravel\Roster\Enums\JsPackageManager;
 use Laravel\Roster\Package;
 use Laravel\Roster\PackageCollection;
-use Laravel\Roster\Roster;
+use Laravel\Roster\ProjectManager;
 
 use function Pest\testDirectory;
 
 beforeEach(function (): void {
-    $this->roster = Mockery::mock(Roster::class);
-    $this->nodePackageManager = NodePackageManager::NPM;
-    $this->roster->shouldReceive('nodePackageManager')->andReturnUsing(
-        fn (): NodePackageManager => $this->nodePackageManager
-    );
-    $this->roster->shouldReceive('usesVersion')->andReturn(false)->byDefault();
+    $this->project = Mockery::mock(ProjectManager::class);
 
     $this->herd = Mockery::mock(Herd::class);
     $this->herd->shouldReceive('isInstalled')->andReturn(false)->byDefault();
 
-    $this->app->instance(Roster::class, $this->roster);
+    $this->app->instance(ProjectManager::class, $this->project);
 
-    $this->composer = new GuidelineComposer($this->roster, $this->herd);
+    $this->composer = new GuidelineComposer($this->project, $this->herd);
 });
 
 test('includes Inertia React conditional guidelines based on version', function (string $version): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::INERTIA_REACT, 'inertiajs/inertia-react', $version),
-        new Package(Packages::INERTIA_LARAVEL, 'inertiajs/inertia-laravel', $version),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('@inertiajs/react', $version),
+        rosterPackage('inertiajs/inertia-laravel', $version),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     $guidelines = $this->composer->compose();
 
@@ -56,11 +50,11 @@ test('includes Inertia React conditional guidelines based on version', function 
 
 test('includes package guidelines only for installed packages', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::PEST, 'pestphp/pest', '3.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('pestphp/pest', '3.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     $guidelines = $this->composer->compose();
 
@@ -71,10 +65,10 @@ test('includes package guidelines only for installed packages', function (): voi
 
 test('excludes conditional guidelines when config is false', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     $config = new GuidelineConfig;
     $config->laravelStyle = false;
@@ -95,10 +89,10 @@ test('excludes conditional guidelines when config is false', function (): void {
 
 test('includes Herd guidelines only when on .test domain and Herd is installed', function (string $appUrl, bool $herdInstalled, bool $shouldInclude): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
     $this->herd->shouldReceive('isInstalled')->andReturn($herdInstalled);
 
     config(['app.url' => $appUrl]);
@@ -119,10 +113,10 @@ test('includes Herd guidelines only when on .test domain and Herd is installed',
 
 test('excludes Herd guidelines when Sail is configured', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
     $this->herd->shouldReceive('isInstalled')->andReturn(true);
 
     config(['app.url' => 'http://myapp.test']);
@@ -142,10 +136,10 @@ test('excludes Herd guidelines when Sail is configured', function (): void {
 
 test('excludes Sail guidelines when Herd is configured', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
     $this->herd->shouldReceive('isInstalled')->andReturn(true);
 
     config(['app.url' => 'http://myapp.test']);
@@ -164,10 +158,10 @@ test('excludes Sail guidelines when Herd is configured', function (): void {
 
 test('composes guidelines with proper formatting', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     $guidelines = $this->composer->compose();
 
@@ -184,36 +178,14 @@ test('composes guidelines with proper formatting', function (): void {
 
 test('handles multiple package versions correctly', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::INERTIA_REACT, 'inertiajs/inertia-react', '2.1.0'),
-        new Package(Packages::INERTIA_VUE, 'inertiajs/inertia-vue', '2.0.0'),
-        new Package(Packages::PEST, 'pestphp/pest', '3.1.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('@inertiajs/react', '2.1.0'),
+        rosterPackage('@inertiajs/vue3', '2.0.0'),
+        rosterPackage('pestphp/pest', '3.1.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
     // Mock all Inertia package version checks for this test too
-    $this->roster->shouldReceive('usesVersion')
-        ->with(Packages::INERTIA_LARAVEL, '2.1.0', '>=')
-        ->andReturn(false);
-    $this->roster->shouldReceive('usesVersion')
-        ->with(Packages::INERTIA_REACT, '2.1.0', '>=')
-        ->andReturn(true);
-    $this->roster->shouldReceive('usesVersion')
-        ->with(Packages::INERTIA_SVELTE, '2.1.0', '>=')
-        ->andReturn(false);
-    $this->roster->shouldReceive('usesVersion')
-        ->with(Packages::INERTIA_VUE, '2.1.0', '>=')
-        ->andReturn(false);
-
-    $this->roster->shouldReceive('usesVersion')
-        ->with(Packages::INERTIA_REACT, '2.1.2', '>=')
-        ->andReturn(false);
-    $this->roster->shouldReceive('usesVersion')
-        ->with(Packages::INERTIA_SVELTE, '2.1.2', '>=')
-        ->andReturn(false);
-    $this->roster->shouldReceive('usesVersion')
-        ->with(Packages::INERTIA_VUE, '2.1.2', '>=')
-        ->andReturn(false);
 
     $guidelines = $this->composer->compose();
 
@@ -225,10 +197,10 @@ test('handles multiple package versions correctly', function (): void {
 
 test('filters out empty guidelines', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     $guidelines = $this->composer->compose();
 
@@ -240,8 +212,8 @@ test('filters out empty guidelines', function (): void {
 test('includes the project rules pointer when rules are enabled and MCP is on', function (): void {
     config()->set('boost.rules.enabled', true);
 
-    $this->roster->shouldReceive('packages')->andReturn(new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+    mockProjectPackages($this->project, new PackageCollection([
+        rosterPackage('laravel/framework', '11.0.0'),
     ]));
 
     $config = new GuidelineConfig;
@@ -259,8 +231,8 @@ test('includes the project rules pointer when rules are enabled and MCP is on', 
 test('omits the project rules pointer when rules are disabled', function (): void {
     config()->set('boost.rules.enabled', false);
 
-    $this->roster->shouldReceive('packages')->andReturn(new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+    mockProjectPackages($this->project, new PackageCollection([
+        rosterPackage('laravel/framework', '11.0.0'),
     ]));
 
     $config = new GuidelineConfig;
@@ -275,11 +247,11 @@ test('omits the project rules pointer when rules are disabled', function (): voi
 
 test('returns list of used guidelines', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::PEST, 'pestphp/pest', '3.0.1', true),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('pestphp/pest', '3.0.1', true),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     $config = new GuidelineConfig;
     $config->laravelStyle = true;
@@ -302,12 +274,12 @@ test('returns list of used guidelines', function (): void {
 
 test('includes user custom guidelines from .ai/guidelines directory', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
-    $composer = Mockery::mock(GuidelineComposer::class, [$this->roster, $this->herd])->makePartial();
+    $composer = Mockery::mock(GuidelineComposer::class, [$this->project, $this->herd])->makePartial();
     $composer
         ->shouldReceive('customGuidelinePath')
         ->andReturnUsing(fn ($path = ''): string => realpath(testDirectory('Fixtures/.ai/guidelines')).'/'.ltrim((string) $path, '/'));
@@ -325,12 +297,12 @@ test('includes user custom guidelines from .ai/guidelines directory', function (
 
 test('non-empty custom guidelines override Boost guidelines', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
-    $composer = Mockery::mock(GuidelineComposer::class, [$this->roster, $this->herd])->makePartial();
+    $composer = Mockery::mock(GuidelineComposer::class, [$this->project, $this->herd])->makePartial();
     $composer
         ->shouldReceive('customGuidelinePath')
         ->andReturnUsing(fn ($path = ''): string => realpath(testDirectory('Fixtures/.ai/guidelines')).'/'.ltrim((string) $path, '/'));
@@ -351,13 +323,12 @@ test('non-empty custom guidelines override Boost guidelines', function (): void 
 
 test('excludes PHPUnit guidelines when Pest is present due to package priority', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::PEST, 'pestphp/pest', '3.0.0'),
-        new Package(Packages::PHPUNIT, 'phpunit/phpunit', '10.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('pestphp/pest', '3.0.0'),
+        rosterPackage('phpunit/phpunit', '10.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
-    $this->roster->shouldReceive('uses')->with(Packages::PEST)->andReturn(true);
+    mockProjectPackages($this->project, $packages);
 
     $guidelines = $this->composer->compose();
 
@@ -368,47 +339,44 @@ test('excludes PHPUnit guidelines when Pest is present due to package priority',
 
 test('excludes laravel/mcp guidelines when indirectly required', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        (new Package(Packages::MCP, 'laravel/mcp', '0.2.2'))->setDirect(false),
+        rosterPackage('laravel/framework', '11.0.0'),
+        (rosterPackage('laravel/mcp', '0.2.2'))->setDirect(false),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
-    $this->roster->shouldReceive('uses')->with(Packages::LARAVEL)->andReturn(true);
-    $this->roster->shouldReceive('uses')->with(Packages::MCP)->andReturn(true);
+    mockProjectPackages($this->project, $packages);
 
     expect($this->composer->compose())->not->toContain('Mcp::web');
 });
 
 test('excludes livewire guidelines when indirectly required', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        (new Package(Packages::LIVEWIRE, 'livewire/livewire', '3.0.0'))->setDirect(false),
+        rosterPackage('laravel/framework', '11.0.0'),
+        (rosterPackage('livewire/livewire', '3.0.0'))->setDirect(false),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     expect($this->composer->compose())->not->toContain('=== livewire/core rules ===');
 });
 
 test('includes livewire guidelines when directly required', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        (new Package(Packages::LIVEWIRE, 'livewire/livewire', '3.0.0'))->setDirect(true),
+        rosterPackage('laravel/framework', '11.0.0'),
+        (rosterPackage('livewire/livewire', '3.0.0'))->setDirect(true),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     expect($this->composer->compose())->toContain('=== livewire/core rules ===');
 });
 
 test('includes PHPUnit guidelines when Pest is not present', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::PHPUNIT, 'phpunit/phpunit', '10.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('phpunit/phpunit', '10.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
-    $this->roster->shouldReceive('uses')->with(Packages::PEST)->andReturn(false);
+    mockProjectPackages($this->project, $packages);
 
     $guidelines = $this->composer->compose();
 
@@ -417,12 +385,11 @@ test('includes PHPUnit guidelines when Pest is not present', function (): void {
         ->not->toContain('=== pest/core rules ===');
 });
 
-test('includes correct package manager commands in guidelines based on lockfile', function (NodePackageManager $packageManager, string $expectedCommand): void {
+test('includes correct package manager commands in guidelines based on lockfile', function (JsPackageManager $packageManager, string $expectedCommand): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
-    $this->nodePackageManager = $packageManager;
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages, $packageManager);
 
     $guidelines = $this->composer->compose();
 
@@ -430,22 +397,20 @@ test('includes correct package manager commands in guidelines based on lockfile'
         ->toContain("{$expectedCommand} run build")
         ->toContain("{$expectedCommand} run dev");
 })->with([
-    'npm' => [NodePackageManager::NPM, 'npm'],
-    'pnpm' => [NodePackageManager::PNPM, 'pnpm'],
-    'yarn' => [NodePackageManager::YARN, 'yarn'],
-    'bun' => [NodePackageManager::BUN, 'bun'],
+    'npm' => [JsPackageManager::Npm, 'npm'],
+    'pnpm' => [JsPackageManager::Pnpm, 'pnpm'],
+    'yarn' => [JsPackageManager::Yarn, 'yarn'],
+    'bun' => [JsPackageManager::Bun, 'bun'],
 ]);
 
 test('renderContent handles blade and markdown files correctly', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::VOLT, 'laravel/volt', '1.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('livewire/volt', '1.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
-    $this->nodePackageManager = NodePackageManager::NPM;
-
-    $composer = Mockery::mock(GuidelineComposer::class, [$this->roster, $this->herd])->makePartial();
+    mockProjectPackages($this->project, $packages);
+    $composer = Mockery::mock(GuidelineComposer::class, [$this->project, $this->herd])->makePartial();
     $composer
         ->shouldReceive('customGuidelinePath')
         ->andReturnUsing(fn ($path = ''): string => realpath(testDirectory('Fixtures/.ai/guidelines')).'/'.ltrim((string) $path, '/'));
@@ -489,31 +454,13 @@ test('renderContent handles blade and markdown files correctly', function (): vo
 
 test('includes wayfinder guidelines with inertia integration when both packages are present', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::WAYFINDER, 'laravel/wayfinder', '1.0.0'),
-        new Package(Packages::INERTIA_REACT, 'inertiajs/inertia-react', '2.1.2'),
-        new Package(Packages::INERTIA_LARAVEL, 'inertiajs/inertia-laravel', '2.1.2'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('laravel/wayfinder', '1.0.0'),
+        rosterPackage('@inertiajs/react', '2.1.2'),
+        rosterPackage('inertiajs/inertia-laravel', '2.1.2'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
-
-    $this->roster->shouldReceive('uses')->with(Packages::INERTIA_LARAVEL)->andReturn(true);
-    $this->roster->shouldReceive('uses')->with(Packages::INERTIA_REACT)->andReturn(true);
-    $this->roster->shouldReceive('uses')->with(Packages::INERTIA_VUE)->andReturn(false);
-    $this->roster->shouldReceive('uses')->with(Packages::INERTIA_SVELTE)->andReturn(false);
-
-    $this->roster->shouldReceive('usesVersion')
-        ->with(Packages::INERTIA_LARAVEL, Mockery::any(), '>=')
-        ->andReturn(true);
-    $this->roster->shouldReceive('usesVersion')
-        ->with(Packages::INERTIA_REACT, Mockery::any(), '>=')
-        ->andReturn(true);
-    $this->roster->shouldReceive('usesVersion')
-        ->with(Packages::INERTIA_VUE, Mockery::any(), '>=')
-        ->andReturn(false);
-    $this->roster->shouldReceive('usesVersion')
-        ->with(Packages::INERTIA_SVELTE, Mockery::any(), '>=')
-        ->andReturn(false);
+    mockProjectPackages($this->project, $packages);
 
     $guidelines = $this->composer->compose();
 
@@ -525,31 +472,13 @@ test('includes wayfinder guidelines with inertia integration when both packages 
 
 test('includes wayfinder guidelines with inertia vue integration', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::WAYFINDER, 'laravel/wayfinder', '1.0.0'),
-        new Package(Packages::INERTIA_VUE, 'inertiajs/inertia-vue', '2.1.2'),
-        new Package(Packages::INERTIA_LARAVEL, 'inertiajs/inertia-laravel', '2.1.2'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('laravel/wayfinder', '1.0.0'),
+        rosterPackage('@inertiajs/vue3', '2.1.2'),
+        rosterPackage('inertiajs/inertia-laravel', '2.1.2'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
-
-    $this->roster->shouldReceive('uses')->with(Packages::INERTIA_LARAVEL)->andReturn(true);
-    $this->roster->shouldReceive('uses')->with(Packages::INERTIA_REACT)->andReturn(false);
-    $this->roster->shouldReceive('uses')->with(Packages::INERTIA_VUE)->andReturn(true);
-    $this->roster->shouldReceive('uses')->with(Packages::INERTIA_SVELTE)->andReturn(false);
-
-    $this->roster->shouldReceive('usesVersion')
-        ->with(Packages::INERTIA_LARAVEL, Mockery::any(), '>=')
-        ->andReturn(true);
-    $this->roster->shouldReceive('usesVersion')
-        ->with(Packages::INERTIA_REACT, Mockery::any(), '>=')
-        ->andReturn(false);
-    $this->roster->shouldReceive('usesVersion')
-        ->with(Packages::INERTIA_VUE, Mockery::any(), '>=')
-        ->andReturn(true);
-    $this->roster->shouldReceive('usesVersion')
-        ->with(Packages::INERTIA_SVELTE, Mockery::any(), '>=')
-        ->andReturn(false);
+    mockProjectPackages($this->project, $packages);
 
     $guidelines = $this->composer->compose();
 
@@ -561,31 +490,13 @@ test('includes wayfinder guidelines with inertia vue integration', function (): 
 
 test('includes wayfinder guidelines with inertia svelte integration', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::WAYFINDER, 'laravel/wayfinder', '1.0.0'),
-        new Package(Packages::INERTIA_SVELTE, 'inertiajs/inertia-svelte', '2.1.2'),
-        new Package(Packages::INERTIA_LARAVEL, 'inertiajs/inertia-laravel', '2.1.2'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('laravel/wayfinder', '1.0.0'),
+        rosterPackage('@inertiajs/svelte', '2.1.2'),
+        rosterPackage('inertiajs/inertia-laravel', '2.1.2'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
-
-    $this->roster->shouldReceive('uses')->with(Packages::INERTIA_LARAVEL)->andReturn(true);
-    $this->roster->shouldReceive('uses')->with(Packages::INERTIA_REACT)->andReturn(false);
-    $this->roster->shouldReceive('uses')->with(Packages::INERTIA_VUE)->andReturn(false);
-    $this->roster->shouldReceive('uses')->with(Packages::INERTIA_SVELTE)->andReturn(true);
-
-    $this->roster->shouldReceive('usesVersion')
-        ->with(Packages::INERTIA_LARAVEL, Mockery::any(), '>=')
-        ->andReturn(true);
-    $this->roster->shouldReceive('usesVersion')
-        ->with(Packages::INERTIA_REACT, Mockery::any(), '>=')
-        ->andReturn(false);
-    $this->roster->shouldReceive('usesVersion')
-        ->with(Packages::INERTIA_VUE, Mockery::any(), '>=')
-        ->andReturn(false);
-    $this->roster->shouldReceive('usesVersion')
-        ->with(Packages::INERTIA_SVELTE, Mockery::any(), '>=')
-        ->andReturn(true);
+    mockProjectPackages($this->project, $packages);
 
     $guidelines = $this->composer->compose();
 
@@ -597,29 +508,11 @@ test('includes wayfinder guidelines with inertia svelte integration', function (
 
 test('includes wayfinder guidelines without inertia integration when inertia is not present', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::WAYFINDER, 'laravel/wayfinder', '1.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('laravel/wayfinder', '1.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
-
-    $this->roster->shouldReceive('uses')->with(Packages::INERTIA_LARAVEL)->andReturn(false);
-    $this->roster->shouldReceive('uses')->with(Packages::INERTIA_REACT)->andReturn(false);
-    $this->roster->shouldReceive('uses')->with(Packages::INERTIA_VUE)->andReturn(false);
-    $this->roster->shouldReceive('uses')->with(Packages::INERTIA_SVELTE)->andReturn(false);
-
-    $this->roster->shouldReceive('usesVersion')
-        ->with(Packages::INERTIA_LARAVEL, Mockery::any(), '>=')
-        ->andReturn(false);
-    $this->roster->shouldReceive('usesVersion')
-        ->with(Packages::INERTIA_REACT, Mockery::any(), '>=')
-        ->andReturn(false);
-    $this->roster->shouldReceive('usesVersion')
-        ->with(Packages::INERTIA_VUE, Mockery::any(), '>=')
-        ->andReturn(false);
-    $this->roster->shouldReceive('usesVersion')
-        ->with(Packages::INERTIA_SVELTE, Mockery::any(), '>=')
-        ->andReturn(false);
+    mockProjectPackages($this->project, $packages);
 
     $guidelines = $this->composer->compose();
 
@@ -630,16 +523,16 @@ test('includes wayfinder guidelines without inertia integration when inertia is 
 });
 
 test('the guidelines are in correct order', function (): void {
-    $composer = Mockery::mock(GuidelineComposer::class, [$this->roster, $this->herd])->makePartial();
+    $composer = Mockery::mock(GuidelineComposer::class, [$this->project, $this->herd])->makePartial();
     $composer
         ->shouldReceive('customGuidelinePath')
         ->andReturnUsing(fn ($path = ''): string => realpath(testDirectory('Fixtures/.ai/guidelines')).'/'.ltrim((string) $path, '/'));
 
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::PEST, 'pestphp/pest', '3.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('pestphp/pest', '3.0.0'),
     ]);
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     $config = new GuidelineConfig;
     $config->enforceTests = true;
@@ -689,13 +582,11 @@ test('composeGuidelines filters out empty guidelines', function (): void {
 
 test('correctly converts package names to hyphens in guideline paths', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::INERTIA_REACT, 'inertiajs/inertia-react', '2.1.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('@inertiajs/react', '2.1.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
-    $this->roster->shouldReceive('usesVersion')->andReturn(false);
-
+    mockProjectPackages($this->project, $packages);
     $guidelines = $this->composer->guidelines();
     $keys = $guidelines->keys()->toArray();
 
@@ -708,11 +599,11 @@ test('correctly converts package names to hyphens in guideline paths', function 
 
 test('includes enabled conditional guidelines and orders them before packages', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::PEST, 'pestphp/pest', '3.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('pestphp/pest', '3.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
     $this->herd->shouldReceive('isInstalled')->andReturn(true);
     config(['app.url' => 'http://myapp.test']);
 
@@ -739,12 +630,12 @@ test('includes enabled conditional guidelines and orders them before packages', 
 
 test('user guidelines are sorted by filename for predictable ordering', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
-    $composer = Mockery::mock(GuidelineComposer::class, [$this->roster, $this->herd])->makePartial();
+    $composer = Mockery::mock(GuidelineComposer::class, [$this->project, $this->herd])->makePartial();
     $composer
         ->shouldReceive('customGuidelinePath')
         ->andReturnUsing(fn ($path = ''): string => realpath(testDirectory('Fixtures/.ai/sorted-guidelines')).'/'.ltrim((string) $path, '/'));
@@ -762,11 +653,11 @@ test('user guidelines are sorted by filename for predictable ordering', function
 
 test('excludes boost package from Roster discovery to prevent duplicate core guidelines', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::BOOST, 'laravel/boost', '2.1.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('laravel/boost', '2.1.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     $guidelines = $this->composer->guidelines();
     $keys = $guidelines->keys();
@@ -777,10 +668,10 @@ test('excludes boost package from Roster discovery to prevent duplicate core gui
 
 test('excludes Skills Activation section when skills are disabled', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     $config = new GuidelineConfig;
     $config->hasSkills = false;
@@ -796,10 +687,10 @@ test('excludes Skills Activation section when skills are disabled', function ():
 
 test('includes Skills Activation section when skills are enabled', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     $config = new GuidelineConfig;
     $config->hasSkills = true;
@@ -815,10 +706,10 @@ test('includes Skills Activation section when skills are enabled', function (): 
 
 test('excludes guidelines listed in config exclude list', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
     $this->herd->shouldReceive('isInstalled')->andReturn(true);
 
     config(['app.url' => 'http://myapp.test']);
@@ -839,10 +730,10 @@ test('excludes guidelines listed in config exclude list', function (): void {
 
 test('excludes core guidelines when listed in exclude config', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     config(['boost.guidelines.exclude' => ['php']]);
 
@@ -856,11 +747,11 @@ test('excludes core guidelines when listed in exclude config', function (): void
 
 test('excludes package guidelines when listed in exclude config', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::PEST, 'pestphp/pest', '3.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('pestphp/pest', '3.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     config(['boost.guidelines.exclude' => ['pest/core']]);
 
@@ -873,10 +764,10 @@ test('excludes package guidelines when listed in exclude config', function (): v
 
 test('excludes deployment guidelines when listed in exclude config', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     config(['boost.guidelines.exclude' => ['deployments']]);
 
@@ -890,10 +781,10 @@ test('excludes deployment guidelines when listed in exclude config', function ()
 
 test('excludes versioned package guidelines when listed in exclude config', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '12.0.0'),
+        rosterPackage('laravel/framework', '12.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     config(['boost.guidelines.exclude' => ['laravel/v12']]);
 
@@ -907,12 +798,12 @@ test('excludes versioned package guidelines when listed in exclude config', func
 
 test('does not exclude user guidelines via config', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
-    $composer = Mockery::mock(GuidelineComposer::class, [$this->roster, $this->herd])->makePartial();
+    $composer = Mockery::mock(GuidelineComposer::class, [$this->project, $this->herd])->makePartial();
     $composer
         ->shouldReceive('customGuidelinePath')
         ->andReturnUsing(fn ($path = ''): string => realpath(testDirectory('Fixtures/.ai/guidelines')).'/'.ltrim((string) $path, '/'));
@@ -925,10 +816,10 @@ test('does not exclude user guidelines via config', function (): void {
 
 test('ignores non-existent keys in guidelines exclude list', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     config(['boost.guidelines.exclude' => ['nonexistent']]);
 
@@ -942,11 +833,11 @@ test('ignores non-existent keys in guidelines exclude list', function (): void {
 
 test('excludes guidelines from used() list', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::PEST, 'pestphp/pest', '3.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('pestphp/pest', '3.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     config(['boost.guidelines.exclude' => ['pest/core']]);
 
@@ -959,10 +850,10 @@ test('excludes guidelines from used() list', function (): void {
 
 test('excludes MCP Tools and Searching Documentation sections when hasMcp is false', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     $config = new GuidelineConfig;
     $config->hasMcp = false;
@@ -981,10 +872,10 @@ test('excludes MCP Tools and Searching Documentation sections when hasMcp is fal
 
 test('includes MCP Tools and Searching Documentation sections when hasMcp is true', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     $config = new GuidelineConfig;
     $config->hasMcp = true;
@@ -1003,19 +894,19 @@ test('includes MCP Tools and Searching Documentation sections when hasMcp is tru
 
 test('loads vendor core guideline when available', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::PEST, 'pestphp/pest', '3.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('pestphp/pest', '3.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     $vendorFixture = realpath(testDirectory('Fixtures/vendor-guidelines/core-only'));
 
-    $composer = Mockery::mock(GuidelineComposer::class, [$this->roster, $this->herd])
+    $composer = Mockery::mock(GuidelineComposer::class, [$this->project, $this->herd])
         ->makePartial()
         ->shouldAllowMockingProtectedMethods();
     $composer->shouldReceive('resolveFirstPartyBoostPath')
-        ->andReturnUsing(fn (Package $package, string $subpath): ?string => $package->rawName() === 'pestphp/pest' ? $vendorFixture : null);
+        ->andReturnUsing(fn (Package $package, string $subpath): ?string => $package->name() === 'pestphp/pest' ? $vendorFixture : null);
 
     $guidelines = $composer->compose();
 
@@ -1026,13 +917,13 @@ test('loads vendor core guideline when available', function (): void {
 
 test('falls back to .ai/ when vendor guideline path does not exist', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::PEST, 'pestphp/pest', '3.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('pestphp/pest', '3.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
-    $composer = Mockery::mock(GuidelineComposer::class, [$this->roster, $this->herd])
+    $composer = Mockery::mock(GuidelineComposer::class, [$this->project, $this->herd])
         ->makePartial()
         ->shouldAllowMockingProtectedMethods();
     $composer->shouldReceive('resolveFirstPartyBoostPath')->andReturn(null);
@@ -1044,19 +935,19 @@ test('falls back to .ai/ when vendor guideline path does not exist', function ()
 
 test('guideline key is unchanged regardless of vendor or .ai/ source', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::PEST, 'pestphp/pest', '3.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('pestphp/pest', '3.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     $vendorFixture = realpath(testDirectory('Fixtures/vendor-guidelines/core-only'));
 
-    $composer = Mockery::mock(GuidelineComposer::class, [$this->roster, $this->herd])
+    $composer = Mockery::mock(GuidelineComposer::class, [$this->project, $this->herd])
         ->makePartial()
         ->shouldAllowMockingProtectedMethods();
     $composer->shouldReceive('resolveFirstPartyBoostPath')
-        ->andReturnUsing(fn (Package $package, string $subpath): ?string => $package->rawName() === 'pestphp/pest' ? $vendorFixture : null);
+        ->andReturnUsing(fn (Package $package, string $subpath): ?string => $package->name() === 'pestphp/pest' ? $vendorFixture : null);
 
     $keys = $composer->used();
 
@@ -1065,20 +956,20 @@ test('guideline key is unchanged regardless of vendor or .ai/ source', function 
 
 test('user override works with vendor-sourced guideline', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     $vendorFixture = realpath(testDirectory('Fixtures/vendor-guidelines/core-only'));
 
-    $composer = Mockery::mock(GuidelineComposer::class, [$this->roster, $this->herd])
+    $composer = Mockery::mock(GuidelineComposer::class, [$this->project, $this->herd])
         ->makePartial()
         ->shouldAllowMockingProtectedMethods();
     $composer->shouldReceive('customGuidelinePath')
         ->andReturnUsing(fn ($path = ''): string => realpath(testDirectory('Fixtures/.ai/guidelines')).'/'.ltrim((string) $path, '/'));
     $composer->shouldReceive('resolveFirstPartyBoostPath')
-        ->andReturnUsing(fn (Package $package, string $subpath): ?string => $package->rawName() === 'laravel/framework' ? $vendorFixture : null);
+        ->andReturnUsing(fn (Package $package, string $subpath): ?string => $package->name() === 'laravel/framework' ? $vendorFixture : null);
 
     $guidelines = $composer->guidelines();
     $laravelCore = $guidelines->get('laravel/core');
@@ -1105,19 +996,19 @@ test('isFirstPartyPackage identifies scoped npm packages', function (): void {
 
 test('loads node_modules core guideline for npm first-party packages', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::INERTIA_REACT, '@inertiajs/react', '2.1.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('@inertiajs/react', '2.1.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     $vendorFixture = realpath(testDirectory('Fixtures/vendor-guidelines/core-only'));
 
-    $composer = Mockery::mock(GuidelineComposer::class, [$this->roster, $this->herd])
+    $composer = Mockery::mock(GuidelineComposer::class, [$this->project, $this->herd])
         ->makePartial()
         ->shouldAllowMockingProtectedMethods();
     $composer->shouldReceive('resolveFirstPartyBoostPath')
-        ->andReturnUsing(fn (Package $package, string $subpath): ?string => $package->rawName() === '@inertiajs/react' ? $vendorFixture : null);
+        ->andReturnUsing(fn (Package $package, string $subpath): ?string => $package->name() === '@inertiajs/react' ? $vendorFixture : null);
 
     $guidelines = $composer->compose();
 
@@ -1128,13 +1019,13 @@ test('loads node_modules core guideline for npm first-party packages', function 
 
 test('falls back to .ai/ when node_modules guideline path does not exist for npm package', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::INERTIA_REACT, '@inertiajs/react', '2.1.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('@inertiajs/react', '2.1.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
-    $composer = Mockery::mock(GuidelineComposer::class, [$this->roster, $this->herd])
+    $composer = Mockery::mock(GuidelineComposer::class, [$this->project, $this->herd])
         ->makePartial()
         ->shouldAllowMockingProtectedMethods();
     $composer->shouldReceive('resolveFirstPartyBoostPath')->andReturn(null);
@@ -1146,11 +1037,11 @@ test('falls back to .ai/ when node_modules guideline path does not exist for npm
 
 test('user override resolves .md files for vendor-sourced guidelines', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::PEST, 'pestphp/pest', '3.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('pestphp/pest', '3.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     $vendorFixture = realpath(testDirectory('Fixtures/vendor-guidelines/core-only'));
 
@@ -1158,11 +1049,11 @@ test('user override resolves .md files for vendor-sourced guidelines', function 
     @mkdir($mdOverrideDir.'/pest', 0755, true);
     file_put_contents($mdOverrideDir.'/pest/core.md', '# Pest Markdown Override');
 
-    $composer = Mockery::mock(GuidelineComposer::class, [$this->roster, $this->herd])
+    $composer = Mockery::mock(GuidelineComposer::class, [$this->project, $this->herd])
         ->makePartial()
         ->shouldAllowMockingProtectedMethods();
     $composer->shouldReceive('resolveFirstPartyBoostPath')
-        ->andReturnUsing(fn (Package $package, string $subpath): ?string => $package->rawName() === 'pestphp/pest' ? $vendorFixture : null);
+        ->andReturnUsing(fn (Package $package, string $subpath): ?string => $package->name() === 'pestphp/pest' ? $vendorFixture : null);
     $composer->shouldReceive('customGuidelinePath')
         ->andReturnUsing(fn ($path = ''): string => $mdOverrideDir.'/'.ltrim((string) $path, '/'));
 
@@ -1180,10 +1071,10 @@ test('user override resolves .md files for vendor-sourced guidelines', function 
 
 test('symlinked custom guidelines directory does not produce duplicates', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     $realGuidelinesDir = realpath(testDirectory('Fixtures/.ai/guidelines'));
     $symlinkDir = testDirectory('Fixtures/.ai/symlinked-guidelines');
@@ -1192,7 +1083,7 @@ test('symlinked custom guidelines directory does not produce duplicates', functi
     symlink($realGuidelinesDir, $symlinkDir);
 
     try {
-        $composer = Mockery::mock(GuidelineComposer::class, [$this->roster, $this->herd])->makePartial();
+        $composer = Mockery::mock(GuidelineComposer::class, [$this->project, $this->herd])->makePartial();
         $composer
             ->shouldReceive('customGuidelinePath')
             ->andReturnUsing(fn ($path = ''): string => $symlinkDir.'/'.ltrim((string) $path, '/'));
@@ -1208,10 +1099,10 @@ test('symlinked custom guidelines directory does not produce duplicates', functi
 
 test('symlinked custom guideline file does not produce duplicates', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     $customDir = testDirectory('Fixtures/.ai/symlinked-file-guidelines');
     $externalFile = realpath(testDirectory('Fixtures/.ai/guidelines/laravel/core.blade.php'));
@@ -1222,7 +1113,7 @@ test('symlinked custom guideline file does not produce duplicates', function ():
     symlink($externalFile, $customDir.'/laravel/core.blade.php');
 
     try {
-        $composer = Mockery::mock(GuidelineComposer::class, [$this->roster, $this->herd])->makePartial();
+        $composer = Mockery::mock(GuidelineComposer::class, [$this->project, $this->herd])->makePartial();
         $composer
             ->shouldReceive('customGuidelinePath')
             ->andReturnUsing(fn ($path = ''): string => $customDir.'/'.ltrim((string) $path, '/'));

--- a/tests/Feature/Install/SkillComposerTest.php
+++ b/tests/Feature/Install/SkillComposerTest.php
@@ -6,29 +6,25 @@ use Illuminate\Support\Collection;
 use Laravel\Boost\Install\GuidelineConfig;
 use Laravel\Boost\Install\Skill;
 use Laravel\Boost\Install\SkillComposer;
-use Laravel\Roster\Enums\NodePackageManager;
-use Laravel\Roster\Enums\Packages;
 use Laravel\Roster\Package;
 use Laravel\Roster\PackageCollection;
-use Laravel\Roster\Roster;
+use Laravel\Roster\ProjectManager;
 
 beforeEach(function (): void {
-    $this->roster = Mockery::mock(Roster::class);
-    $this->roster->shouldReceive('nodePackageManager')->andReturn(NodePackageManager::NPM);
-    $this->roster->shouldReceive('usesVersion')->andReturn(false);
+    $this->project = Mockery::mock(ProjectManager::class);
 
-    $this->app->instance(Roster::class, $this->roster);
+    $this->app->instance(ProjectManager::class, $this->project);
 });
 
 test('skills return a collection keyed by skill name', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        (new Package(Packages::LIVEWIRE, 'livewire/livewire', '3.0.0'))->setDirect(true),
+        rosterPackage('laravel/framework', '11.0.0'),
+        (rosterPackage('livewire/livewire', '3.0.0'))->setDirect(true),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
-    $skills = (new SkillComposer($this->roster))->skills();
+    $skills = (new SkillComposer($this->project))->skills();
 
     expect($skills)
         ->toBeInstanceOf(Collection::class)
@@ -37,38 +33,38 @@ test('skills return a collection keyed by skill name', function (): void {
 
 test('skills are discovered from Boost built-in .ai directory', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        (new Package(Packages::LIVEWIRE, 'livewire/livewire', '3.0.0'))->setDirect(true),
+        rosterPackage('laravel/framework', '11.0.0'),
+        (rosterPackage('livewire/livewire', '3.0.0'))->setDirect(true),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
-    $skills = (new SkillComposer($this->roster))->skills();
+    $skills = (new SkillComposer($this->project))->skills();
 
     expect($skills->has('livewire-development'))->toBeTrue();
 });
 
 test('skills only includes skills for installed packages', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
-    $skills = (new SkillComposer($this->roster))->skills();
+    $skills = (new SkillComposer($this->project))->skills();
 
     expect($skills->has('livewire-development'))->toBeFalse();
 });
 
 test('skill has name, description, path, and package', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        (new Package(Packages::LIVEWIRE, 'livewire/livewire', '3.0.0'))->setDirect(true),
+        rosterPackage('laravel/framework', '11.0.0'),
+        (rosterPackage('livewire/livewire', '3.0.0'))->setDirect(true),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
-    $skill = (new SkillComposer($this->roster))->skills()->get('livewire-development');
+    $skill = (new SkillComposer($this->project))->skills()->get('livewire-development');
 
     expect($skill)
         ->name->toBe('livewire-development')
@@ -79,24 +75,24 @@ test('skill has name, description, path, and package', function (): void {
 
 test('skills result is cached', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
-    $composer = new SkillComposer($this->roster);
+    $composer = new SkillComposer($this->project);
 
     expect($composer->skills())->toBe($composer->skills());
 });
 
 test('config change clears skills cache', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
-    $composer = new SkillComposer($this->roster);
+    $composer = new SkillComposer($this->project);
     $first = $composer->skills();
 
     $composer->config(new GuidelineConfig);
@@ -106,76 +102,76 @@ test('config change clears skills cache', function (): void {
 
 test('excludes livewire skills when indirectly required', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        (new Package(Packages::LIVEWIRE, 'livewire/livewire', '3.0.0'))->setDirect(false),
+        rosterPackage('laravel/framework', '11.0.0'),
+        (rosterPackage('livewire/livewire', '3.0.0'))->setDirect(false),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
-    $skills = (new SkillComposer($this->roster))->skills();
+    $skills = (new SkillComposer($this->project))->skills();
 
     expect($skills->has('livewire-development'))->toBeFalse();
 });
 
 test('excludes skills listed in config exclude list', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        (new Package(Packages::LIVEWIRE, 'livewire/livewire', '3.0.0'))->setDirect(true),
+        rosterPackage('laravel/framework', '11.0.0'),
+        (rosterPackage('livewire/livewire', '3.0.0'))->setDirect(true),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     config(['boost.skills.exclude' => ['livewire-development']]);
 
-    $skills = (new SkillComposer($this->roster))->skills();
+    $skills = (new SkillComposer($this->project))->skills();
 
     expect($skills->has('livewire-development'))->toBeFalse();
 });
 
 test('ignores non-existent skill names in exclude list', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        (new Package(Packages::LIVEWIRE, 'livewire/livewire', '3.0.0'))->setDirect(true),
+        rosterPackage('laravel/framework', '11.0.0'),
+        (rosterPackage('livewire/livewire', '3.0.0'))->setDirect(true),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     config(['boost.skills.exclude' => ['nonexistent']]);
 
-    $skills = (new SkillComposer($this->roster))->skills();
+    $skills = (new SkillComposer($this->project))->skills();
 
     expect($skills->has('livewire-development'))->toBeTrue();
 });
 
 test('includes livewire skills when directly required', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        (new Package(Packages::LIVEWIRE, 'livewire/livewire', '3.0.0'))->setDirect(true),
+        rosterPackage('laravel/framework', '11.0.0'),
+        (rosterPackage('livewire/livewire', '3.0.0'))->setDirect(true),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
-    $skills = (new SkillComposer($this->roster))->skills();
+    $skills = (new SkillComposer($this->project))->skills();
 
     expect($skills->has('livewire-development'))->toBeTrue();
 });
 
 test('vendor skills override .ai/ skills with the same name', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        (new Package(Packages::LIVEWIRE, 'livewire/livewire', '3.0.0'))->setDirect(true),
+        rosterPackage('laravel/framework', '11.0.0'),
+        (rosterPackage('livewire/livewire', '3.0.0'))->setDirect(true),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     $vendorFixture = realpath(\Pest\testDirectory('Fixtures/vendor-skills'));
     expect($vendorFixture)->not->toBeFalse();
 
-    $composer = Mockery::mock(SkillComposer::class, [$this->roster])
+    $composer = Mockery::mock(SkillComposer::class, [$this->project])
         ->makePartial()
         ->shouldAllowMockingProtectedMethods();
     $composer->shouldReceive('resolveFirstPartyBoostPath')
-        ->andReturnUsing(fn (Package $package, string $subpath): ?string => $package->rawName() === 'livewire/livewire' ? $vendorFixture : null);
+        ->andReturnUsing(fn (Package $package, string $subpath): ?string => $package->name() === 'livewire/livewire' ? $vendorFixture : null);
 
     $skills = $composer->skills();
 
@@ -185,13 +181,13 @@ test('vendor skills override .ai/ skills with the same name', function (): void 
 
 test('falls back to .ai/ skills when vendor has none', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        (new Package(Packages::LIVEWIRE, 'livewire/livewire', '3.0.0'))->setDirect(true),
+        rosterPackage('laravel/framework', '11.0.0'),
+        (rosterPackage('livewire/livewire', '3.0.0'))->setDirect(true),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
-    $composer = Mockery::mock(SkillComposer::class, [$this->roster])
+    $composer = Mockery::mock(SkillComposer::class, [$this->project])
         ->makePartial()
         ->shouldAllowMockingProtectedMethods();
     $composer->shouldReceive('resolveFirstPartyBoostPath')->andReturn(null);
@@ -203,20 +199,20 @@ test('falls back to .ai/ skills when vendor has none', function (): void {
 
 test('node_modules skills override .ai/ skills for npm first-party packages', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::INERTIA_REACT, '@inertiajs/react', '2.1.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('@inertiajs/react', '2.1.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     $vendorFixture = realpath(\Pest\testDirectory('Fixtures/vendor-skills'));
     expect($vendorFixture)->not->toBeFalse();
 
-    $composer = Mockery::mock(SkillComposer::class, [$this->roster])
+    $composer = Mockery::mock(SkillComposer::class, [$this->project])
         ->makePartial()
         ->shouldAllowMockingProtectedMethods();
     $composer->shouldReceive('resolveFirstPartyBoostPath')
-        ->andReturnUsing(fn (Package $package, string $subpath): ?string => $package->rawName() === '@inertiajs/react' ? $vendorFixture : null);
+        ->andReturnUsing(fn (Package $package, string $subpath): ?string => $package->name() === '@inertiajs/react' ? $vendorFixture : null);
 
     $skills = $composer->skills();
 
@@ -226,13 +222,13 @@ test('node_modules skills override .ai/ skills for npm first-party packages', fu
 
 test('falls back to .ai/ skills when node_modules has none for npm package', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::INERTIA_REACT, '@inertiajs/react', '2.1.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('@inertiajs/react', '2.1.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
-    $composer = Mockery::mock(SkillComposer::class, [$this->roster])
+    $composer = Mockery::mock(SkillComposer::class, [$this->project])
         ->makePartial()
         ->shouldAllowMockingProtectedMethods();
     $composer->shouldReceive('resolveFirstPartyBoostPath')->andReturn(null);
@@ -243,7 +239,7 @@ test('falls back to .ai/ skills when node_modules has none for npm package', fun
 });
 
 test('returns all third-party skills when aiGuidelines is uninitialized', function (): void {
-    $this->roster->shouldReceive('packages')->andReturn(new PackageCollection([]));
+    mockProjectPackages($this->project, new PackageCollection([]));
 
     $skillDir = base_path('vendor/some/third-party/resources/boost/skills/third-party-skill');
     @mkdir($skillDir, 0755, true);
@@ -251,7 +247,7 @@ test('returns all third-party skills when aiGuidelines is uninitialized', functi
     file_put_contents(base_path('composer.json'), json_encode(['require' => ['some/third-party' => '^1.0']]));
 
     try {
-        $skills = (new SkillComposer($this->roster))->skills();
+        $skills = (new SkillComposer($this->project))->skills();
 
         expect($skills->has('third-party-skill'))->toBeTrue();
     } finally {
@@ -268,7 +264,7 @@ test('returns all third-party skills when aiGuidelines is uninitialized', functi
 });
 
 test('filters third-party skills to matching packages when aiGuidelines is set', function (): void {
-    $this->roster->shouldReceive('packages')->andReturn(new PackageCollection([]));
+    mockProjectPackages($this->project, new PackageCollection([]));
 
     $skillDir = base_path('vendor/some/third-party/resources/boost/skills/third-party-skill');
     @mkdir($skillDir, 0755, true);
@@ -279,7 +275,7 @@ test('filters third-party skills to matching packages when aiGuidelines is set',
         $config = new GuidelineConfig;
         $config->aiGuidelines = ['some/third-party'];
 
-        $skills = (new SkillComposer($this->roster))->config($config)->skills();
+        $skills = (new SkillComposer($this->project))->config($config)->skills();
 
         expect($skills->has('third-party-skill'))->toBeTrue();
     } finally {
@@ -296,7 +292,7 @@ test('filters third-party skills to matching packages when aiGuidelines is set',
 });
 
 test('excludes third-party skills for packages not in aiGuidelines', function (): void {
-    $this->roster->shouldReceive('packages')->andReturn(new PackageCollection([]));
+    mockProjectPackages($this->project, new PackageCollection([]));
 
     $skillDir = base_path('vendor/some/third-party/resources/boost/skills/third-party-skill');
     @mkdir($skillDir, 0755, true);
@@ -307,7 +303,7 @@ test('excludes third-party skills for packages not in aiGuidelines', function ()
         $config = new GuidelineConfig;
         $config->aiGuidelines = ['other/package'];
 
-        $skills = (new SkillComposer($this->roster))->config($config)->skills();
+        $skills = (new SkillComposer($this->project))->config($config)->skills();
 
         expect($skills->has('third-party-skill'))->toBeFalse();
     } finally {
@@ -325,10 +321,10 @@ test('excludes third-party skills for packages not in aiGuidelines', function ()
 
 test('blade skills with code before frontmatter are parsed correctly', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
     $skillDir = base_path('.ai/skills/blade-frontmatter-test');
     @mkdir($skillDir, 0755, true);
@@ -348,7 +344,7 @@ test('blade skills with code before frontmatter are parsed correctly', function 
         BLADE);
 
     try {
-        $skills = (new SkillComposer($this->roster))->skills();
+        $skills = (new SkillComposer($this->project))->skills();
 
         expect($skills->has('blade-frontmatter-test'))->toBeTrue()
             ->and($skills->get('blade-frontmatter-test')->description)
@@ -361,12 +357,12 @@ test('blade skills with code before frontmatter are parsed correctly', function 
 
 test('frontmatter parsing ignores HTML comments injected by third-party packages', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $this->roster->shouldReceive('packages')->andReturn($packages);
+    mockProjectPackages($this->project, $packages);
 
-    $composer = new SkillComposer($this->roster);
+    $composer = new SkillComposer($this->project);
     $method = new ReflectionMethod($composer, 'parseSkillFrontmatter');
 
     $content = <<<'HTML'

--- a/tests/Feature/Mcp/Prompts/UpgradeInertiav3Test.php
+++ b/tests/Feature/Mcp/Prompts/UpgradeInertiav3Test.php
@@ -4,25 +4,25 @@ declare(strict_types=1);
 
 use Laravel\Boost\Install\GuidelineAssist;
 use Laravel\Boost\Mcp\Prompts\UpgradeInertiav3\UpgradeInertiaV3;
-use Laravel\Roster\Enums\Packages;
-use Laravel\Roster\Roster;
+use Laravel\Roster\PackageCollection;
+use Laravel\Roster\ProjectManager;
 
 beforeEach(function (): void {
     $this->prompt = new UpgradeInertiaV3;
 });
 
-function mockRosterWithFrameworks(bool $react = false, bool $vue = false, bool $svelte = false): Roster
+function mockProjectWithFrameworks(bool $react = false, bool $vue = false, bool $svelte = false): ProjectManager
 {
-    $roster = Mockery::mock(Roster::class);
-    $roster->shouldReceive('uses')->with(Packages::INERTIA_REACT)->andReturn($react);
-    $roster->shouldReceive('uses')->with(Packages::INERTIA_VUE)->andReturn($vue);
-    $roster->shouldReceive('uses')->with(Packages::INERTIA_SVELTE)->andReturn($svelte);
-    $roster->shouldReceive('uses')->with(Packages::INERTIA_LARAVEL)->andReturn(true);
-    $roster->shouldReceive('usesVersion')->andReturn(false);
-    $roster->shouldReceive('packages')->andReturn(collect());
-    $roster->shouldReceive('nodePackageManager')->andReturn(null);
+    $project = Mockery::mock(ProjectManager::class);
+    $packages = new PackageCollection([
+        rosterPackage('inertiajs/inertia-laravel', '2.0.0'),
+        ...($react ? [rosterPackage('@inertiajs/react', '2.0.0')] : []),
+        ...($vue ? [rosterPackage('@inertiajs/vue3', '2.0.0')] : []),
+        ...($svelte ? [rosterPackage('@inertiajs/svelte', '2.0.0')] : []),
+    ]);
+    mockProjectPackages($project, $packages);
 
-    return $roster;
+    return $project;
 }
 
 test('it has the correct name', function (): void {
@@ -88,7 +88,7 @@ test('it avoids the outdated migration guidance from the original draft', functi
 });
 
 test('it shows react-specific content when react adapter is installed', function (): void {
-    $assist = app(GuidelineAssist::class, ['roster' => mockRosterWithFrameworks(react: true)]);
+    $assist = app(GuidelineAssist::class, ['project' => mockProjectWithFrameworks(react: true)]);
     $this->app->instance(GuidelineAssist::class, $assist);
 
     $text = (string) $this->prompt->handle()->content();
@@ -104,7 +104,7 @@ test('it shows react-specific content when react adapter is installed', function
 });
 
 test('it shows vue-specific content when vue adapter is installed', function (): void {
-    $assist = app(GuidelineAssist::class, ['roster' => mockRosterWithFrameworks(vue: true)]);
+    $assist = app(GuidelineAssist::class, ['project' => mockProjectWithFrameworks(vue: true)]);
     $this->app->instance(GuidelineAssist::class, $assist);
 
     $text = (string) $this->prompt->handle()->content();
@@ -119,7 +119,7 @@ test('it shows vue-specific content when vue adapter is installed', function ():
 });
 
 test('it shows svelte-specific content when svelte adapter is installed', function (): void {
-    $assist = app(GuidelineAssist::class, ['roster' => mockRosterWithFrameworks(svelte: true)]);
+    $assist = app(GuidelineAssist::class, ['project' => mockProjectWithFrameworks(svelte: true)]);
     $this->app->instance(GuidelineAssist::class, $assist);
 
     $text = (string) $this->prompt->handle()->content();

--- a/tests/Feature/Mcp/Tools/ApplicationInfoTest.php
+++ b/tests/Feature/Mcp/Tools/ApplicationInfoTest.php
@@ -4,21 +4,19 @@ declare(strict_types=1);
 
 use Laravel\Boost\Mcp\Tools\ApplicationInfo;
 use Laravel\Mcp\Request;
-use Laravel\Roster\Enums\Packages;
-use Laravel\Roster\Package;
 use Laravel\Roster\PackageCollection;
-use Laravel\Roster\Roster;
+use Laravel\Roster\ProjectManager;
 
 test('it returns application info with packages', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::PEST, 'pestphp/pest', '2.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('pestphp/pest', '2.0.0'),
     ]);
 
-    $roster = Mockery::mock(Roster::class);
-    $roster->shouldReceive('packages')->andReturn($packages);
+    $project = Mockery::mock(ProjectManager::class);
+    mockProjectPackages($project, $packages);
 
-    $tool = new ApplicationInfo($roster);
+    $tool = new ApplicationInfo($project);
     $response = $tool->handle(new Request([]));
 
     expect($response)->isToolResult()
@@ -43,10 +41,10 @@ test('it returns application info with packages', function (): void {
 });
 
 test('it returns application info with no packages', function (): void {
-    $roster = Mockery::mock(Roster::class);
-    $roster->shouldReceive('packages')->andReturn(new PackageCollection([]));
+    $project = Mockery::mock(ProjectManager::class);
+    mockProjectPackages($project, new PackageCollection([]));
 
-    $tool = new ApplicationInfo($roster);
+    $tool = new ApplicationInfo($project);
     $response = $tool->handle(new Request([]));
 
     expect($response)->isToolResult()
@@ -61,12 +59,12 @@ test('it returns application info with no packages', function (): void {
 
 it('returns updated package versions when roster binding changes in container', function (): void {
     $initialPackages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $roster = Mockery::mock(Roster::class);
-    $roster->shouldReceive('packages')->andReturn($initialPackages);
-    $this->app->instance(Roster::class, $roster);
+    $project = Mockery::mock(ProjectManager::class);
+    mockProjectPackages($project, $initialPackages);
+    $this->app->instance(ProjectManager::class, $project);
 
     $tool = app(ApplicationInfo::class);
     $response = $tool->handle(new Request([]));
@@ -80,13 +78,13 @@ it('returns updated package versions when roster binding changes in container', 
     });
 
     $updatedPackages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '12.0.0'),
-        new Package(Packages::PEST, 'pestphp/pest', '3.0.0'),
+        rosterPackage('laravel/framework', '12.0.0'),
+        rosterPackage('pestphp/pest', '3.0.0'),
     ]);
 
-    $updatedRoster = Mockery::mock(Roster::class);
-    $updatedRoster->shouldReceive('packages')->andReturn($updatedPackages);
-    $this->app->instance(Roster::class, $updatedRoster);
+    $updatedProject = Mockery::mock(ProjectManager::class);
+    mockProjectPackages($updatedProject, $updatedPackages);
+    $this->app->instance(ProjectManager::class, $updatedProject);
 
     $tool = app(ApplicationInfo::class);
     $response = $tool->handle(new Request([]));

--- a/tests/Feature/Mcp/Tools/SearchDocsTest.php
+++ b/tests/Feature/Mcp/Tools/SearchDocsTest.php
@@ -5,25 +5,23 @@ declare(strict_types=1);
 use Illuminate\Support\Facades\Http;
 use Laravel\Boost\Mcp\Tools\SearchDocs;
 use Laravel\Mcp\Request;
-use Laravel\Roster\Enums\Packages;
-use Laravel\Roster\Package;
 use Laravel\Roster\PackageCollection;
-use Laravel\Roster\Roster;
+use Laravel\Roster\ProjectManager;
 
 test('it searches documentation successfully', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::PEST, 'pestphp/pest', '2.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('pestphp/pest', '2.0.0'),
     ]);
 
-    $roster = Mockery::mock(Roster::class);
-    $roster->shouldReceive('packages')->andReturn($packages);
+    $project = Mockery::mock(ProjectManager::class);
+    mockProjectPackages($project, $packages);
 
     Http::fake([
         'https://boost.laravel.com/api/docs' => Http::response('Documentation search results', 200),
     ]);
 
-    $tool = new SearchDocs($roster);
+    $tool = new SearchDocs($project);
     $response = $tool->handle(new Request(['queries' => ['authentication', 'testing']]));
 
     expect($response)->isToolResult()
@@ -42,17 +40,17 @@ test('it searches documentation successfully', function (): void {
 
 test('it handles API error response', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $roster = Mockery::mock(Roster::class);
-    $roster->shouldReceive('packages')->andReturn($packages);
+    $project = Mockery::mock(ProjectManager::class);
+    mockProjectPackages($project, $packages);
 
     Http::fake([
         'https://boost.laravel.com/api/docs' => Http::response('API Error', 500),
     ]);
 
-    $tool = new SearchDocs($roster);
+    $tool = new SearchDocs($project);
     $response = $tool->handle(new Request(['queries' => ['authentication']]));
 
     expect($response)->isToolResult()
@@ -63,14 +61,14 @@ test('it handles API error response', function (): void {
 test('it filters empty queries', function (): void {
     $packages = new PackageCollection([]);
 
-    $roster = Mockery::mock(Roster::class);
-    $roster->shouldReceive('packages')->andReturn($packages);
+    $project = Mockery::mock(ProjectManager::class);
+    mockProjectPackages($project, $packages);
 
     Http::fake([
         'https://boost.laravel.com/api/docs' => Http::response('Empty results', 200),
     ]);
 
-    $tool = new SearchDocs($roster);
+    $tool = new SearchDocs($project);
     $response = $tool->handle(new Request(['queries' => ['test', '  ', '*', ' ']]));
 
     expect($response)->isToolResult()
@@ -84,18 +82,18 @@ test('it filters empty queries', function (): void {
 
 test('it formats package data correctly', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::LIVEWIRE, 'livewire/livewire', '3.5.1'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('livewire/livewire', '3.5.1'),
     ]);
 
-    $roster = Mockery::mock(Roster::class);
-    $roster->shouldReceive('packages')->andReturn($packages);
+    $project = Mockery::mock(ProjectManager::class);
+    mockProjectPackages($project, $packages);
 
     Http::fake([
         'https://boost.laravel.com/api/docs' => Http::response('Package data results', 200),
     ]);
 
-    $tool = new SearchDocs($roster);
+    $tool = new SearchDocs($project);
     $response = $tool->handle(new Request(['queries' => ['test']]));
 
     expect($response)->isToolResult()
@@ -110,14 +108,14 @@ test('it formats package data correctly', function (): void {
 test('it handles empty results', function (): void {
     $packages = new PackageCollection([]);
 
-    $roster = Mockery::mock(Roster::class);
-    $roster->shouldReceive('packages')->andReturn($packages);
+    $project = Mockery::mock(ProjectManager::class);
+    mockProjectPackages($project, $packages);
 
     Http::fake([
         'https://boost.laravel.com/api/docs' => Http::response('Empty response', 200),
     ]);
 
-    $tool = new SearchDocs($roster);
+    $tool = new SearchDocs($project);
     $response = $tool->handle(new Request(['queries' => ['nonexistent']]));
 
     expect($response)->isToolResult()
@@ -128,14 +126,14 @@ test('it handles empty results', function (): void {
 test('it uses custom token_limit when provided', function (): void {
     $packages = new PackageCollection([]);
 
-    $roster = Mockery::mock(Roster::class);
-    $roster->shouldReceive('packages')->andReturn($packages);
+    $project = Mockery::mock(ProjectManager::class);
+    mockProjectPackages($project, $packages);
 
     Http::fake([
         'https://boost.laravel.com/api/docs' => Http::response('Custom token limit results', 200),
     ]);
 
-    $tool = new SearchDocs($roster);
+    $tool = new SearchDocs($project);
     $response = $tool->handle(new Request(['queries' => ['test'], 'token_limit' => 5000]));
 
     expect($response)->isToolResult()->toolHasNoError();
@@ -145,17 +143,17 @@ test('it uses custom token_limit when provided', function (): void {
 
 test('it handles queries passed as a JSON-encoded string', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
+        rosterPackage('laravel/framework', '11.0.0'),
     ]);
 
-    $roster = Mockery::mock(Roster::class);
-    $roster->shouldReceive('packages')->andReturn($packages);
+    $project = Mockery::mock(ProjectManager::class);
+    mockProjectPackages($project, $packages);
 
     Http::fake([
         'https://boost.laravel.com/api/docs' => Http::response('Documentation search results', 200),
     ]);
 
-    $tool = new SearchDocs($roster);
+    $tool = new SearchDocs($project);
     $response = $tool->handle(new Request(['queries' => '["authentication","testing"]']));
 
     expect($response)->isToolResult()
@@ -167,18 +165,18 @@ test('it handles queries passed as a JSON-encoded string', function (): void {
 
 test('it handles packages passed as a JSON-encoded string', function (): void {
     $packages = new PackageCollection([
-        new Package(Packages::LARAVEL, 'laravel/framework', '11.0.0'),
-        new Package(Packages::LIVEWIRE, 'livewire/livewire', '3.5.1'),
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('livewire/livewire', '3.5.1'),
     ]);
 
-    $roster = Mockery::mock(Roster::class);
-    $roster->shouldReceive('packages')->andReturn($packages);
+    $project = Mockery::mock(ProjectManager::class);
+    mockProjectPackages($project, $packages);
 
     Http::fake([
         'https://boost.laravel.com/api/docs' => Http::response('Filtered results', 200),
     ]);
 
-    $tool = new SearchDocs($roster);
+    $tool = new SearchDocs($project);
     $response = $tool->handle(new Request([
         'queries' => ['test'],
         'packages' => '["livewire/livewire"]',
@@ -192,27 +190,27 @@ test('it handles packages passed as a JSON-encoded string', function (): void {
 });
 
 test('it returns error for malformed JSON in queries string', function (): void {
-    $roster = Mockery::mock(Roster::class);
+    $project = Mockery::mock(ProjectManager::class);
 
-    $tool = new SearchDocs($roster);
+    $tool = new SearchDocs($project);
     $response = $tool->handle(new Request(['queries' => '["authentication","testing"']));
 
     expect($response)->isToolResult()->toolHasError();
 });
 
 test('it returns error for non-array JSON in queries string', function (): void {
-    $roster = Mockery::mock(Roster::class);
+    $project = Mockery::mock(ProjectManager::class);
 
-    $tool = new SearchDocs($roster);
+    $tool = new SearchDocs($project);
     $response = $tool->handle(new Request(['queries' => '"authentication"']));
 
     expect($response)->isToolResult()->toolHasError();
 });
 
 test('it returns error for malformed JSON in packages string', function (): void {
-    $roster = Mockery::mock(Roster::class);
+    $project = Mockery::mock(ProjectManager::class);
 
-    $tool = new SearchDocs($roster);
+    $tool = new SearchDocs($project);
     $response = $tool->handle(new Request([
         'queries' => ['test'],
         'packages' => '["livewire/livewire"',
@@ -222,9 +220,9 @@ test('it returns error for malformed JSON in packages string', function (): void
 });
 
 test('it returns error for non-array JSON in packages string', function (): void {
-    $roster = Mockery::mock(Roster::class);
+    $project = Mockery::mock(ProjectManager::class);
 
-    $tool = new SearchDocs($roster);
+    $tool = new SearchDocs($project);
     $response = $tool->handle(new Request([
         'queries' => ['test'],
         'packages' => '"livewire/livewire"',
@@ -234,18 +232,18 @@ test('it returns error for non-array JSON in packages string', function (): void
 });
 
 test('it returns error for JSON object string in queries', function (): void {
-    $roster = Mockery::mock(Roster::class);
+    $project = Mockery::mock(ProjectManager::class);
 
-    $tool = new SearchDocs($roster);
+    $tool = new SearchDocs($project);
     $response = $tool->handle(new Request(['queries' => '{"q":"authentication"}']));
 
     expect($response)->isToolResult()->toolHasError();
 });
 
 test('it returns error for JSON object string in packages', function (): void {
-    $roster = Mockery::mock(Roster::class);
+    $project = Mockery::mock(ProjectManager::class);
 
-    $tool = new SearchDocs($roster);
+    $tool = new SearchDocs($project);
     $response = $tool->handle(new Request([
         'queries' => ['test'],
         'packages' => '{"pkg":"laravel/framework"}',
@@ -257,14 +255,14 @@ test('it returns error for JSON object string in packages', function (): void {
 test('it caps token_limit at maximum of 1000000', function (): void {
     $packages = new PackageCollection([]);
 
-    $roster = Mockery::mock(Roster::class);
-    $roster->shouldReceive('packages')->andReturn($packages);
+    $project = Mockery::mock(ProjectManager::class);
+    mockProjectPackages($project, $packages);
 
     Http::fake([
         'https://boost.laravel.com/api/docs' => Http::response('Capped token limit results', 200),
     ]);
 
-    $tool = new SearchDocs($roster);
+    $tool = new SearchDocs($project);
     $response = $tool->handle(new Request(['queries' => ['test'], 'token_limit' => 2000000]));
 
     expect($response)->isToolResult()->toolHasNoError();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -14,6 +14,13 @@ declare(strict_types=1);
 */
 
 use Laravel\Mcp\Response;
+use Laravel\Roster\Ecosystems\Ecosystem;
+use Laravel\Roster\Ecosystems\JsEcosystem;
+use Laravel\Roster\Enums\JsPackageManager;
+use Laravel\Roster\Enums\PackageSource;
+use Laravel\Roster\Package;
+use Laravel\Roster\PackageCollection;
+use Laravel\Roster\ProjectManager;
 use Tests\TestCase;
 
 use function Pest\testDirectory;
@@ -76,4 +83,34 @@ if (! function_exists('fixture')) {
 function fixtureContent(string $name): string
 {
     return file_get_contents(fixture($name));
+}
+
+function rosterPackage(string $name, string $version, bool $dev = false, ?string $path = null): Package
+{
+    $source = str_starts_with($name, '@') || ! str_contains($name, '/')
+        ? PackageSource::Npm
+        : PackageSource::Composer;
+
+    return new class($name, $version, $source, $dev, false, '', $path) extends Package
+    {
+        public function setDirect(bool $direct = true): self
+        {
+            $this->direct = $direct;
+
+            return $this;
+        }
+    };
+}
+
+function mockProjectPackages(ProjectManager $project, PackageCollection $packages, ?JsPackageManager $packageManager = null): void
+{
+    $php = new PackageCollection($packages->filter(
+        fn (Package $package): bool => $package->source() === PackageSource::Composer,
+    )->values()->all());
+    $js = new PackageCollection($packages->filter(
+        fn (Package $package): bool => $package->source() === PackageSource::Npm,
+    )->values()->all());
+
+    $project->shouldReceive('php')->andReturn(new Ecosystem($php));
+    $project->shouldReceive('js')->andReturn(new JsEcosystem($js, $packageManager));
 }

--- a/tests/Unit/Install/Assists/InertiaTest.php
+++ b/tests/Unit/Install/Assists/InertiaTest.php
@@ -3,13 +3,12 @@
 declare(strict_types=1);
 
 use Laravel\Boost\Install\Assists\Inertia;
-use Laravel\Roster\Roster;
+use Laravel\Roster\ProjectManager;
 
 beforeEach(function (): void {
-    $this->roster = Mockery::mock(Roster::class);
-    $this->roster->shouldReceive('usesVersion')->andReturn(false);
+    $this->project = Mockery::mock(ProjectManager::class);
 
-    $this->inertia = new Inertia($this->roster);
+    $this->inertia = new Inertia($this->project);
 });
 
 afterEach(function (): void {

--- a/tests/Unit/Install/GuidelineAssistTest.php
+++ b/tests/Unit/Install/GuidelineAssistTest.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 use Laravel\Boost\Install\GuidelineAssist;
 use Laravel\Boost\Install\GuidelineConfig;
 use Laravel\Boost\Install\Sail;
-use Laravel\Roster\Roster;
+use Laravel\Roster\PackageCollection;
+use Laravel\Roster\ProjectManager;
 
 beforeEach(function (): void {
-    $this->roster = Mockery::mock(Roster::class);
-    $this->roster->shouldReceive('nodePackageManager')->andReturn(null);
-    $this->roster->shouldReceive('usesVersion')->andReturn(false);
+    $this->project = Mockery::mock(ProjectManager::class);
+    mockProjectPackages($this->project, new PackageCollection([]));
 
     $this->config = new GuidelineConfig;
 });
@@ -19,7 +19,7 @@ test('php executable falls back to Sail when no config is set', function (): voi
     config(['boost.executable_paths.php' => null]);
     $this->config->usesSail = true;
 
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
+    $assist = Mockery::mock(GuidelineAssist::class, [$this->project, $this->config])->makePartial();
     $assist->shouldAllowMockingProtectedMethods();
     $assist->shouldReceive('discover')->andReturn([]);
 
@@ -30,7 +30,7 @@ test('php executable config takes precedence over Sail', function (): void {
     config(['boost.executable_paths.php' => '/usr/local/bin/php8.3']);
     $this->config->usesSail = true;
 
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
+    $assist = Mockery::mock(GuidelineAssist::class, [$this->project, $this->config])->makePartial();
     $assist->shouldAllowMockingProtectedMethods();
     $assist->shouldReceive('discover')->andReturn([]);
 
@@ -41,7 +41,7 @@ test('composer executable falls back to Sail when no config is set', function ()
     config(['boost.executable_paths.composer' => null]);
     $this->config->usesSail = true;
 
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
+    $assist = Mockery::mock(GuidelineAssist::class, [$this->project, $this->config])->makePartial();
     $assist->shouldAllowMockingProtectedMethods();
     $assist->shouldReceive('discover')->andReturn([]);
 
@@ -54,7 +54,7 @@ test('composer executable config takes precedence over Sail', function (): void 
     config(['boost.executable_paths.composer' => '/usr/local/bin/composer2']);
     $this->config->usesSail = true;
 
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
+    $assist = Mockery::mock(GuidelineAssist::class, [$this->project, $this->config])->makePartial();
     $assist->shouldAllowMockingProtectedMethods();
     $assist->shouldReceive('discover')->andReturn([]);
 
@@ -65,7 +65,7 @@ test('npm executable falls back to Sail when no config is set', function (): voi
     config(['boost.executable_paths.npm' => null]);
     $this->config->usesSail = true;
 
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
+    $assist = Mockery::mock(GuidelineAssist::class, [$this->project, $this->config])->makePartial();
     $assist->shouldAllowMockingProtectedMethods();
     $assist->shouldReceive('discover')->andReturn([]);
 
@@ -78,7 +78,7 @@ test('npm executable config takes precedence over Sail', function (): void {
     config(['boost.executable_paths.npm' => '/usr/local/bin/yarn']);
     $this->config->usesSail = true;
 
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
+    $assist = Mockery::mock(GuidelineAssist::class, [$this->project, $this->config])->makePartial();
     $assist->shouldAllowMockingProtectedMethods();
     $assist->shouldReceive('discover')->andReturn([]);
 
@@ -89,7 +89,7 @@ test('npm executable falls back to npm when no config and no Sail', function ():
     config(['boost.executable_paths.npm' => null]);
     $this->config->usesSail = false;
 
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
+    $assist = Mockery::mock(GuidelineAssist::class, [$this->project, $this->config])->makePartial();
     $assist->shouldAllowMockingProtectedMethods();
     $assist->shouldReceive('discover')->andReturn([]);
 
@@ -100,7 +100,7 @@ test('vendor bin prefix falls back to Sail when no config is set', function (): 
     config(['boost.executable_paths.vendor_bin' => null]);
     $this->config->usesSail = true;
 
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
+    $assist = Mockery::mock(GuidelineAssist::class, [$this->project, $this->config])->makePartial();
     $assist->shouldAllowMockingProtectedMethods();
     $assist->shouldReceive('discover')->andReturn([]);
 
@@ -113,7 +113,7 @@ test('vendor bin prefix config takes precedence over Sail', function (): void {
     config(['boost.executable_paths.vendor_bin' => '/custom/path/']);
     $this->config->usesSail = true;
 
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
+    $assist = Mockery::mock(GuidelineAssist::class, [$this->project, $this->config])->makePartial();
     $assist->shouldAllowMockingProtectedMethods();
     $assist->shouldReceive('discover')->andReturn([]);
 
@@ -124,7 +124,7 @@ test('vendor bin prefix falls back to vendor/bin when no config and no Sail', fu
     config(['boost.executable_paths.vendor_bin' => null]);
     $this->config->usesSail = false;
 
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
+    $assist = Mockery::mock(GuidelineAssist::class, [$this->project, $this->config])->makePartial();
     $assist->shouldAllowMockingProtectedMethods();
     $assist->shouldReceive('discover')->andReturn([]);
 
@@ -147,7 +147,7 @@ test('hasSkills property can be set to true', function (): void {
 test('enumContents returns empty string when app directory does not exist', function (): void {
     $sentinel = ['app-path-isnt-a-directory' => sys_get_temp_dir()];
 
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
+    $assist = Mockery::mock(GuidelineAssist::class, [$this->project, $this->config])->makePartial();
     $assist->shouldAllowMockingProtectedMethods();
     $assist->shouldReceive('discover')->andReturn($sentinel);
 
@@ -155,7 +155,7 @@ test('enumContents returns empty string when app directory does not exist', func
 });
 
 test('enumContents includes all discovered enum files in stable order', function (): void {
-    $assist = new class($this->roster, $this->config) extends GuidelineAssist
+    $assist = new class($this->project, $this->config) extends GuidelineAssist
     {
         protected function discover(): array
         {
@@ -176,7 +176,7 @@ test('enumContents includes all discovered enum files in stable order', function
 });
 
 test('enumContents skips enum paths that are not files', function (): void {
-    $assist = new class($this->roster, $this->config) extends GuidelineAssist
+    $assist = new class($this->project, $this->config) extends GuidelineAssist
     {
         protected function discover(): array
         {
@@ -195,7 +195,7 @@ test('enumContents skips enum paths that are not files', function (): void {
 test('hasSkillsEnabled returns false when skills are disabled', function (): void {
     $this->config->hasSkills = false;
 
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
+    $assist = Mockery::mock(GuidelineAssist::class, [$this->project, $this->config])->makePartial();
     $assist->shouldAllowMockingProtectedMethods();
     $assist->shouldReceive('discover')->andReturn([]);
 
@@ -205,7 +205,7 @@ test('hasSkillsEnabled returns false when skills are disabled', function (): voi
 test('hasSkillsEnabled returns true when skills are enabled', function (): void {
     $this->config->hasSkills = true;
 
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
+    $assist = Mockery::mock(GuidelineAssist::class, [$this->project, $this->config])->makePartial();
     $assist->shouldAllowMockingProtectedMethods();
     $assist->shouldReceive('discover')->andReturn([]);
 
@@ -215,7 +215,7 @@ test('hasSkillsEnabled returns true when skills are enabled', function (): void 
 test('hasMcpEnabled returns false when MCP is disabled', function (): void {
     $this->config->hasMcp = false;
 
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
+    $assist = Mockery::mock(GuidelineAssist::class, [$this->project, $this->config])->makePartial();
     $assist->shouldAllowMockingProtectedMethods();
     $assist->shouldReceive('discover')->andReturn([]);
 
@@ -225,7 +225,7 @@ test('hasMcpEnabled returns false when MCP is disabled', function (): void {
 test('hasMcpEnabled returns true when MCP is enabled', function (): void {
     $this->config->hasMcp = true;
 
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
+    $assist = Mockery::mock(GuidelineAssist::class, [$this->project, $this->config])->makePartial();
     $assist->shouldAllowMockingProtectedMethods();
     $assist->shouldReceive('discover')->andReturn([]);
 
@@ -233,7 +233,7 @@ test('hasMcpEnabled returns true when MCP is enabled', function (): void {
 });
 
 test('appPath returns default app path', function (): void {
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
+    $assist = Mockery::mock(GuidelineAssist::class, [$this->project, $this->config])->makePartial();
     $assist->shouldAllowMockingProtectedMethods();
     $assist->shouldReceive('discover')->andReturn([]);
 
@@ -242,7 +242,7 @@ test('appPath returns default app path', function (): void {
 });
 
 test('appPath returns customized path', function (): void {
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
+    $assist = Mockery::mock(GuidelineAssist::class, [$this->project, $this->config])->makePartial();
     $assist->shouldAllowMockingProtectedMethods();
     $assist->shouldReceive('discover')->andReturn([]);
 
@@ -253,7 +253,7 @@ test('appPath returns customized path', function (): void {
 })->after(fn () => app()->useAppPath('app'));
 
 test('appPath normalizes separators to forward slashes', function (): void {
-    $assist = Mockery::mock(GuidelineAssist::class, [$this->roster, $this->config])->makePartial();
+    $assist = Mockery::mock(GuidelineAssist::class, [$this->project, $this->config])->makePartial();
     $assist->shouldAllowMockingProtectedMethods();
     $assist->shouldReceive('discover')->andReturn([]);
 


### PR DESCRIPTION
Boost currently depends on Roster 0.x and uses APIs removed in 1.x, so upgrading Roster breaks package detection, generated guidelines, prompts, and tools.

This migrates checks from:

```php
$roster->usesVersion(Packages::PINT, '1.27.0', '>=');
```

to:

```php
$project->php()->uses('laravel/pint', '>=1.27.0');
```

PHP and JavaScript packages now come from their respective ecosystems. Boost keeps its own package-name mapping so existing `.ai` guideline and skill paths, along with `roster_name` output, remain stable.

Tests were updated for Roster 1.x. The focused suite, PHPStan, Pint, and Rector pass.