### PR TITLE
[2.x] Update .gitattributes export ignore entries

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,10 +9,13 @@
 /.github export-ignore
 /art export-ignore
 /tests export-ignore
+/workbench export-ignore
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 CHANGELOG.md export-ignore
 phpstan.neon.dist export-ignore
 phpunit.xml.dist export-ignore
+pint.json export-ignore
 UPGRADE.md export-ignore
+rector.php export-ignore


### PR DESCRIPTION
This ensures the `workbench` folder, `pint.json` and `rector.php` aren't exported, so they dont end up in the end users vendor. I was going through our vendor installs and noticed this. 

<img width="275" height="235" alt="image" src="https://github.com/user-attachments/assets/26936058-016d-433c-b2bb-a281d8557ea7" />


There could be more to ignore like resources, but did these for now.