### PR TITLE
Replace foundation package list with composer discovery

### DIFF
--- a/.ai/foundation.blade.php
+++ b/.ai/foundation.blade.php
@@ -6,13 +6,11 @@
 The Laravel Boost guidelines are specifically curated by Laravel maintainers for this application. These guidelines should be followed closely to ensure the best experience when building Laravel applications.
 
 ## Foundational Context
-This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
+This application is a Laravel application running on PHP {{ PHP_MAJOR_VERSION }}.{{ PHP_MINOR_VERSION }}. You are an expert with the Laravel ecosystem. Always use the APIs that match the installed major version of each package — do not assume a version.
 
-- php - {{ PHP_MAJOR_VERSION }}.{{ PHP_MINOR_VERSION }}
-@php($project = app(\Laravel\Roster\ProjectManager::class))
-@foreach ($project->php()->packages()->concat($project->js()->packages())->unique(fn ($package) => $package->name()) as $package)
-- {{ $package->name() }} ({{ \Laravel\Boost\Support\PackageRegistry::rosterName($package->name()) }}) - v{{ $package->major() }}
-@endforeach
+Before relying on a package's API, confirm its installed version:
+- PHP packages: run `composer show --direct` to list direct dependencies with versions, or `composer show <vendor/package>` for a single package.
+- JS packages: check `package.json` for the installed versions.
 
 @if (! empty(config('boost.purpose')))
 Application purpose: {!! config('boost.purpose') !!}

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "illuminate/support": "^11.45.3|^12.41.1|^13.0",
         "laravel/mcp": "^0.7.1|^0.8.0|^0.9.0",
         "laravel/prompts": "^0.3.10",
-        "laravel/roster": "^1.0"
+        "laravel/roster": "^1.0.0"
     },
     "require-dev": {
         "laravel/pint": "^1.27.0",


### PR DESCRIPTION
Instead of listing packages, foundation now tells the agent how to discover versions on demand:

```blade
{{-- before: loops the entire dependency tree --}}
@foreach ($project->php()->packages()->concat($project->js()->packages())... )
- {{ $package->name() }} (...) - v{{ $package->major() }}
@endforeach
```

```blade
{{-- after: PHP version inline, plus how to look up any package --}}
- PHP packages: run `composer show --direct`, or `composer show <vendor/package>`.
- JS packages: check `package.json`.
```

The `rosterName()` to versioned-guideline mapping is driven by the guideline composer, not this display loop, so dropping the loop doesn't change which package guidelines get injected. Existing `GuidelineComposerTest` suite (70 tests) still passes.
