### PR TITLE
Make path-scoped guideline extraction opt-in via config

### DIFF
--- a/config/boost.php
+++ b/config/boost.php
@@ -35,14 +35,15 @@ return [
     | Boost Project Rules
     |--------------------------------------------------------------------------
     |
-    | Project rules let agents record durable decisions, non-obvious traps, and
-    | standing constraints as committed markdown in .ai/rules/. Boost also
-    | extracts path-scoped guidelines there instead of inlining them.
+    | Project rules let agents record decisions, traps, and standing constraints
+    | as committed markdown in .ai/rules/. Enabling "scoped_guidelines" also
+    | moves path-scoped guidelines to .ai/rules/boost/; it stays opt-in.
     |
     */
 
     'rules' => [
         'enabled' => env('BOOST_RULES_ENABLED', true),
+        'scoped_guidelines' => env('BOOST_RULES_SCOPED_GUIDELINES', false),
     ],
 
     /*

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -393,7 +393,7 @@ class InstallCommand extends Command
     {
         $repository = app(RuleRepository::class);
 
-        if (! config('boost.rules.enabled', true)) {
+        if (! config('boost.rules.enabled', true) || ! config('boost.rules.scoped_guidelines', false)) {
             rescue(fn () => $repository->clearManaged(), report: false);
 
             return;

--- a/src/Install/GuidelineComposer.php
+++ b/src/Install/GuidelineComposer.php
@@ -44,7 +44,9 @@ class GuidelineComposer
 
     protected function rulesExtractionEnabled(): bool
     {
-        return $this->extractRules && (bool) config('boost.rules.enabled', true);
+        return $this->extractRules
+            && (bool) config('boost.rules.enabled', true)
+            && (bool) config('boost.rules.scoped_guidelines', false);
     }
 
     protected function getProject(): ProjectManager

--- a/tests/Feature/Console/InstallCommandRulesEndToEndTest.php
+++ b/tests/Feature/Console/InstallCommandRulesEndToEndTest.php
@@ -31,6 +31,7 @@ beforeEach(function (): void {
 
     (new Config)->setAgents(['claude_code']);
     config(['boost.enforce_tests' => false]);
+    config(['boost.rules.scoped_guidelines' => true]);
     config(['boost.agents.claude_code.guidelines_path' => $this->tempBasePath.'/CLAUDE.md']);
 });
 

--- a/tests/Feature/Install/GuidelineComposerTest.php
+++ b/tests/Feature/Install/GuidelineComposerTest.php
@@ -67,7 +67,9 @@ test('includes package guidelines only for installed packages', function (): voi
         ->not->toContain('=== inertia-react/core rules ===');
 });
 
-test('excludes scoped block content from the composed blob when rules are enabled by default', function (): void {
+test('excludes scoped block content from the composed blob when scoped guidelines are enabled', function (): void {
+    config(['boost.rules.scoped_guidelines' => true]);
+
     $packages = new PackageCollection([
         rosterPackage('laravel/framework', '11.0.0'),
         rosterPackage('pestphp/pest', '3.0.0'),
@@ -78,14 +80,14 @@ test('excludes scoped block content from the composed blob when rules are enable
 
     $guidelines = $this->composer->compose();
 
-    expect(config('boost.rules.enabled'))->toBeTrue()
+    expect(config('boost.rules.scoped_guidelines'))->toBeTrue()
         ->and($guidelines)
         ->not->toContain('=== pest/core rules ===')
         ->not->toContain('=== livewire/core rules ===')
         ->toContain('=== foundation rules ===');
 });
 
-test('strips only the scoped portion of a partially-scoped guideline, keeping the rest inline', function (): void {
+test('inlines scoped block content by default since scoped guidelines are opt-in', function (): void {
     $packages = new PackageCollection([
         rosterPackage('laravel/framework', '11.0.0'),
     ]);
@@ -94,7 +96,25 @@ test('strips only the scoped portion of a partially-scoped guideline, keeping th
 
     $guidelines = $this->composer->compose();
 
-    expect(config('boost.rules.enabled'))->toBeTrue()
+    expect(config('boost.rules.scoped_guidelines'))->toBeFalse()
+        ->and($guidelines)
+        ->toContain('=== laravel/core rules ===')
+        ->toContain('URL Generation')
+        ->toContain('Model Creation');
+});
+
+test('strips only the scoped portion of a partially-scoped guideline, keeping the rest inline', function (): void {
+    config(['boost.rules.scoped_guidelines' => true]);
+
+    $packages = new PackageCollection([
+        rosterPackage('laravel/framework', '11.0.0'),
+    ]);
+
+    mockProjectPackages($this->project, $packages);
+
+    $guidelines = $this->composer->compose();
+
+    expect(config('boost.rules.scoped_guidelines'))->toBeTrue()
         ->and($guidelines)
         ->toContain('=== laravel/core rules ===')
         ->toContain('URL Generation')

--- a/tests/Feature/Install/RuleComposerTest.php
+++ b/tests/Feature/Install/RuleComposerTest.php
@@ -18,6 +18,8 @@ beforeEach(function (): void {
 
     $this->app->instance(ProjectManager::class, $this->project);
 
+    config(['boost.rules.scoped_guidelines' => true]);
+
     $this->guidelines = new GuidelineComposer($this->project, $this->herd);
 });
 


### PR DESCRIPTION
Currently the path-scoped guideline splitting from #876 is tied to `boost.rules.enabled`, so it kicks in whenever project rules are on and there's no way to keep guidelines inline without also disabling the record-rule feature. It also runs by default, which changes install output for everyone.

This PR gives the splitting its own opt-in flag, separate from the record-rule feature:

\\\php
'rules' => [
    'enabled' => env('BOOST_RULES_ENABLED', true),
    'scoped_guidelines' => env('BOOST_RULES_SCOPED_GUIDELINES', false),
],
\\\

With it off (the default), `@scoped` blocks stay inline in the composed guidelines and nothing is written to `.ai/rules/boost/`. Turn it on to move path-scoped guidelines out into managed rule files. `RecordRule` still keys off `boost.rules.enabled` and is untouched.
