### PR TITLE
Support `extra.laravel-boost` package discovery in `composer.json`

### DIFF
--- a/src/Install/Concerns/DiscoverPackagePaths.php
+++ b/src/Install/Concerns/DiscoverPackagePaths.php
@@ -62,7 +62,9 @@ trait DiscoverPackagePaths
             }
         }
 
-        return ! $package->isDirect() && in_array($package->name(), $this->mustBeDirect, true);
+        return ! $package->isDirect()
+            && in_array($package->name(), $this->mustBeDirect, true)
+            && ! in_array($package->name(), Composer::extraPackageNames(), true);
     }
 
     /**

--- a/src/Support/Composer.php
+++ b/src/Support/Composer.php
@@ -34,32 +34,122 @@ class Composer
     public static function packagesDirectories(): array
     {
         return collect(static::packages())
-            ->mapWithKeys(fn (string $key, string $package): array => [$package => implode(DIRECTORY_SEPARATOR, [
-                base_path('vendor'),
-                str_replace('/', DIRECTORY_SEPARATOR, $package),
-            ])])
+            ->mapWithKeys(fn (string $key, string $package): array => [$package => self::vendorPath($package)])
             ->filter(fn (string $path): bool => is_dir($path))
             ->toArray();
     }
 
     public static function packages(): array
     {
-        $composerJsonPath = base_path('composer.json');
+        $composerData = self::readComposerJson(base_path('composer.json'));
 
-        if (! file_exists($composerJsonPath)) {
+        return collect(self::extraPackages($composerData))
+            ->merge(self::requiresOf($composerData, 'require'))
+            ->merge(self::requiresOf($composerData, 'require-dev'))
+            ->mapWithKeys(fn (string $key, string $package): array => [$package => $key])
+            ->toArray();
+    }
+
+    /**
+     * Packages opted in through `extra.laravel-boost` in the application's composer.json.
+     *
+     * @return array<int, string>
+     */
+    public static function extraPackageNames(): array
+    {
+        $composerData = self::readComposerJson(base_path('composer.json'));
+        $extraPackages = self::extraPackages($composerData);
+
+        return array_keys($extraPackages);
+    }
+
+    /**
+     * @param  array<string, mixed>  $composerData
+     * @return array<string, string>
+     */
+    private static function extraPackages(array $composerData): array
+    {
+        $config = $composerData['extra']['laravel-boost'] ?? [];
+
+        if (! is_array($config)) {
             return [];
         }
 
-        $composerData = json_decode(file_get_contents($composerJsonPath), true);
+        $packages = collect(self::stringList($config, 'packages'))
+            ->reject(fn (string $package): bool => self::isPlatformRequirement($package))
+            ->mapWithKeys(fn (string $package): array => [$package => '*']);
+
+        foreach (self::stringList($config, 'include-packages-from') as $sourcePackage) {
+            $packages = $packages->merge(
+                self::requiresOf(self::readComposerJson(self::vendorPath($sourcePackage).DIRECTORY_SEPARATOR.'composer.json'), 'require')
+            );
+        }
+
+        return $packages->all();
+    }
+
+    /**
+     * @param  array<string, mixed>  $composerData
+     * @return array<string, string>
+     */
+    private static function requiresOf(array $composerData, string $key): array
+    {
+        $requires = $composerData[$key] ?? [];
+
+        if (! is_array($requires)) {
+            return [];
+        }
+
+        return collect($requires)
+            ->reject(fn (mixed $constraint, string $name): bool => self::isPlatformRequirement($name))
+            ->filter(fn (mixed $constraint): bool => is_string($constraint))
+            ->all();
+    }
+
+    private static function isPlatformRequirement(string $name): bool
+    {
+        return ! str_contains($name, '/');
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     * @return array<int, string>
+     */
+    private static function stringList(array $config, string $key): array
+    {
+        $values = $config[$key] ?? [];
+
+        if (! is_array($values)) {
+            return [];
+        }
+
+        return array_values(array_filter($values, 'is_string'));
+    }
+
+    private static function vendorPath(string $package): string
+    {
+        return implode(DIRECTORY_SEPARATOR, [
+            base_path('vendor'),
+            str_replace('/', DIRECTORY_SEPARATOR, $package),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function readComposerJson(string $path): array
+    {
+        if (! file_exists($path)) {
+            return [];
+        }
+
+        $composerData = json_decode(file_get_contents($path), true);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             return [];
         }
 
-        return collect($composerData['require'] ?? [])
-            ->merge($composerData['require-dev'] ?? [])
-            ->mapWithKeys(fn (string $key, string $package): array => [$package => $key])
-            ->toArray();
+        return is_array($composerData) ? $composerData : [];
     }
 
     public static function packagesDirectoriesWithBoostGuidelines(): array

--- a/tests/Feature/Install/GuidelineComposerTest.php
+++ b/tests/Feature/Install/GuidelineComposerTest.php
@@ -456,6 +456,31 @@ test('excludes livewire guidelines when indirectly required', function (): void 
     expect($this->composer->compose())->not->toContain('=== livewire/core rules ===');
 });
 
+test('includes livewire guidelines when indirectly required but opted in through extra laravel-boost', function (): void {
+    file_put_contents(base_path('composer.json'), json_encode([
+        'extra' => [
+            'laravel-boost' => [
+                'packages' => [
+                    'livewire/livewire',
+                ],
+            ],
+        ],
+    ]));
+
+    $packages = new PackageCollection([
+        rosterPackage('laravel/framework', '11.0.0'),
+        (rosterPackage('livewire/livewire', '3.0.0'))->setDirect(false),
+    ]);
+
+    mockProjectPackages($this->project, $packages);
+
+    expect($this->composer->compose())->toContain('=== livewire/core rules ===');
+})->after(function (): void {
+    if (file_exists(base_path('composer.json'))) {
+        unlink(base_path('composer.json'));
+    }
+});
+
 test('includes livewire guidelines when directly required', function (): void {
     config(['boost.rules.enabled' => false]);
 
@@ -466,7 +491,10 @@ test('includes livewire guidelines when directly required', function (): void {
 
     mockProjectPackages($this->project, $packages);
 
-    expect($this->composer->compose())->toContain('=== livewire/core rules ===');
+    $guidelines = $this->composer->compose();
+
+    expect($guidelines)
+        ->toContain('=== livewire/core rules ===');
 });
 
 test('includes PHPUnit guidelines when Pest is not present', function (): void {

--- a/tests/Unit/Support/ComposerTest.php
+++ b/tests/Unit/Support/ComposerTest.php
@@ -13,15 +13,38 @@ afterEach(function (): void {
     File::deleteDirectory(base_path('vendor'));
 });
 
+/**
+ * @param  array<string, mixed>  $data
+ */
+function writeAppComposerJson(array $data): void
+{
+    file_put_contents(base_path('composer.json'), json_encode($data));
+}
+
+/**
+ * @param  array<string, mixed>|string  $data
+ */
+function writeVendorComposerJson(string $package, array|string $data): void
+{
+    $directory = base_path('vendor'.DIRECTORY_SEPARATOR.str_replace('/', DIRECTORY_SEPARATOR, $package));
+
+    File::ensureDirectoryExists($directory);
+
+    file_put_contents(
+        $directory.DIRECTORY_SEPARATOR.'composer.json',
+        is_string($data) ? $data : json_encode($data),
+    );
+}
+
 it('reads require and require-dev from composer.json', function (): void {
-    file_put_contents(base_path('composer.json'), json_encode([
+    writeAppComposerJson([
         'require' => [
             'laravel/framework' => '^11.0',
         ],
         'require-dev' => [
             'pestphp/pest' => '^3.0',
         ],
-    ]));
+    ]);
 
     $packages = Composer::packages();
 
@@ -31,12 +54,12 @@ it('reads require and require-dev from composer.json', function (): void {
 });
 
 it('returns package directories that exist in vendor', function (): void {
-    file_put_contents(base_path('composer.json'), json_encode([
+    writeAppComposerJson([
         'require' => [
             'laravel/framework' => '^11.0',
             'nonexistent/pkg' => '^1.0.0',
         ],
-    ]));
+    ]);
 
     $dir = base_path('vendor'.DIRECTORY_SEPARATOR.'laravel'.DIRECTORY_SEPARATOR.'framework');
     File::ensureDirectoryExists($dir);
@@ -49,12 +72,12 @@ it('returns package directories that exist in vendor', function (): void {
 });
 
 it('returns packages directories with boost guidelines', function (): void {
-    file_put_contents(base_path('composer.json'), json_encode([
+    writeAppComposerJson([
         'require' => [
             'laravel/framework' => '^11.0',
             'laravel/horizon' => '^5.0',
         ],
-    ]));
+    ]);
 
     $withGuidelines = base_path(implode(DIRECTORY_SEPARATOR, [
         'vendor', 'laravel', 'framework', 'resources', 'boost', 'guidelines',
@@ -71,6 +94,308 @@ it('returns packages directories with boost guidelines', function (): void {
     expect($result)
         ->toHaveKey('laravel/framework')
         ->not->toHaveKey('laravel/horizon');
+});
+
+it('includes packages listed in the extra laravel-boost config', function (): void {
+    writeAppComposerJson([
+        'require' => [
+            'laravel/framework' => '^11.0',
+        ],
+        'extra' => [
+            'laravel-boost' => [
+                'packages' => [
+                    'acme/first',
+                    'acme/second',
+                ],
+            ],
+        ],
+    ]);
+
+    $packages = Composer::packages();
+
+    expect($packages)
+        ->toHaveKey('laravel/framework')
+        ->toHaveKey('acme/first')
+        ->toHaveKey('acme/second');
+});
+
+it('includes the requirements of packages listed in include-packages-from', function (): void {
+    writeAppComposerJson([
+        'require' => [
+            'acme/bundle' => '^1.0',
+        ],
+        'extra' => [
+            'laravel-boost' => [
+                'include-packages-from' => [
+                    'acme/bundle',
+                ],
+            ],
+        ],
+    ]);
+
+    writeVendorComposerJson('acme/bundle', [
+        'require' => [
+            'spatie/laravel-permission' => '^6.0',
+            'livewire/livewire' => '^3.0',
+        ],
+    ]);
+
+    $packages = Composer::packages();
+
+    expect($packages)
+        ->toHaveKey('acme/bundle')
+        ->toHaveKey('spatie/laravel-permission')
+        ->toHaveKey('livewire/livewire');
+});
+
+it('ignores platform requirements when including packages from another package', function (): void {
+    writeAppComposerJson([
+        'extra' => [
+            'laravel-boost' => [
+                'include-packages-from' => [
+                    'acme/bundle',
+                ],
+            ],
+        ],
+    ]);
+
+    writeVendorComposerJson('acme/bundle', [
+        'require' => [
+            'php' => '^8.4',
+            'ext-json' => '*',
+            'spatie/laravel-permission' => '^6.0',
+        ],
+    ]);
+
+    $packages = Composer::packages();
+
+    expect($packages)
+        ->toHaveKey('spatie/laravel-permission')
+        ->not->toHaveKey('php')
+        ->not->toHaveKey('ext-json');
+});
+
+it('ignores include-packages-from entries that are not installed', function (): void {
+    writeAppComposerJson([
+        'require' => [
+            'laravel/framework' => '^11.0',
+        ],
+        'extra' => [
+            'laravel-boost' => [
+                'include-packages-from' => [
+                    'acme/not-installed',
+                ],
+            ],
+        ],
+    ]);
+
+    $packages = Composer::packages();
+
+    expect($packages)
+        ->toHaveKey('laravel/framework')
+        ->not->toHaveKey('acme/not-installed');
+});
+
+it('ignores platform requirements listed in the extra laravel-boost packages', function (): void {
+    writeAppComposerJson([
+        'extra' => [
+            'laravel-boost' => [
+                'packages' => [
+                    'php',
+                    'ext-json',
+                    'acme/first',
+                ],
+            ],
+        ],
+    ]);
+
+    $packages = Composer::packages();
+
+    expect($packages)
+        ->toHaveKey('acme/first')
+        ->not->toHaveKey('php')
+        ->not->toHaveKey('ext-json');
+});
+
+it('keeps the real constraint when a package is also listed in the extra laravel-boost config', function (): void {
+    writeAppComposerJson([
+        'require' => [
+            'spatie/laravel-permission' => '^6.0',
+        ],
+        'extra' => [
+            'laravel-boost' => [
+                'packages' => [
+                    'spatie/laravel-permission',
+                ],
+            ],
+        ],
+    ]);
+
+    expect(Composer::packages())->toMatchArray(['spatie/laravel-permission' => '^6.0']);
+});
+
+it('ignores a malformed extra laravel-boost config', function (): void {
+    writeAppComposerJson([
+        'require' => [
+            'laravel/framework' => '^11.0',
+        ],
+        'extra' => [
+            'laravel-boost' => 'nope',
+        ],
+    ]);
+
+    expect(Composer::packages())->toHaveKey('laravel/framework');
+});
+
+it('ignores malformed extra laravel-boost package lists', function (): void {
+    writeAppComposerJson([
+        'require' => [
+            'laravel/framework' => '^11.0',
+        ],
+        'extra' => [
+            'laravel-boost' => [
+                'packages' => 'acme/first',
+                'include-packages-from' => 'acme/bundle',
+            ],
+        ],
+    ]);
+
+    expect(Composer::packages())
+        ->toHaveKey('laravel/framework')
+        ->not->toHaveKey('acme/first');
+});
+
+it('ignores a composer.json that does not decode to an object', function (): void {
+    writeAppComposerJson([
+        'require' => [
+            'laravel/framework' => '^11.0',
+        ],
+        'extra' => [
+            'laravel-boost' => [
+                'include-packages-from' => [
+                    'acme/scalar',
+                ],
+            ],
+        ],
+    ]);
+
+    writeVendorComposerJson('acme/scalar', '"not an object"');
+
+    expect(Composer::packages())
+        ->toHaveKey('laravel/framework')
+        ->not->toHaveKey('acme/scalar');
+});
+
+it('ignores an include-packages-from source with a non-array require', function (): void {
+    writeAppComposerJson([
+        'require' => [
+            'laravel/framework' => '^11.0',
+        ],
+        'extra' => [
+            'laravel-boost' => [
+                'include-packages-from' => [
+                    'acme/bundle',
+                ],
+            ],
+        ],
+    ]);
+
+    writeVendorComposerJson('acme/bundle', ['require' => 'spatie/laravel-permission']);
+
+    expect(Composer::packages())
+        ->toHaveKey('laravel/framework')
+        ->not->toHaveKey('spatie/laravel-permission');
+});
+
+it('exposes the names of packages opted in through the extra laravel-boost config', function (): void {
+    writeAppComposerJson([
+        'require' => [
+            'laravel/framework' => '^11.0',
+        ],
+        'extra' => [
+            'laravel-boost' => [
+                'packages' => [
+                    'acme/explicit',
+                ],
+                'include-packages-from' => [
+                    'acme/bundle',
+                ],
+            ],
+        ],
+    ]);
+
+    writeVendorComposerJson('acme/bundle', [
+        'require' => [
+            'livewire/livewire' => '^3.0',
+        ],
+    ]);
+
+    expect(Composer::extraPackageNames())
+        ->toContain('acme/explicit')
+        ->toContain('livewire/livewire')
+        ->not->toContain('laravel/framework');
+});
+
+it('ignores include-packages-from entries with a malformed composer.json', function (): void {
+    writeAppComposerJson([
+        'require' => [
+            'laravel/framework' => '^11.0',
+        ],
+        'extra' => [
+            'laravel-boost' => [
+                'include-packages-from' => [
+                    'acme/broken',
+                ],
+            ],
+        ],
+    ]);
+
+    writeVendorComposerJson('acme/broken', '{"require": {');
+
+    $packages = Composer::packages();
+
+    expect($packages)
+        ->toHaveKey('laravel/framework')
+        ->not->toHaveKey('acme/broken');
+});
+
+it('merges packages from every extra laravel-boost source', function (): void {
+    writeAppComposerJson([
+        'require' => [
+            'laravel/framework' => '^11.0',
+        ],
+        'extra' => [
+            'laravel-boost' => [
+                'packages' => [
+                    'acme/explicit',
+                ],
+                'include-packages-from' => [
+                    'acme/first-bundle',
+                    'acme/second-bundle',
+                ],
+            ],
+        ],
+    ]);
+
+    writeVendorComposerJson('acme/first-bundle', [
+        'require' => [
+            'spatie/laravel-permission' => '^6.0',
+        ],
+    ]);
+
+    writeVendorComposerJson('acme/second-bundle', [
+        'require' => [
+            'livewire/livewire' => '^3.0',
+        ],
+    ]);
+
+    $packages = Composer::packages();
+
+    expect($packages)
+        ->toHaveKey('laravel/framework')
+        ->toHaveKey('acme/explicit')
+        ->toHaveKey('spatie/laravel-permission')
+        ->toHaveKey('livewire/livewire');
 });
 
 it('identifies scoped first party packages', function (): void {


### PR DESCRIPTION
# Support `extra.laravel-boost` package discovery in composer.json

Boost discovers guidelines by reading `require` and `require-dev` from the application's `composer.json`. Applications that pull packages in through an internal meta-package get nothing, because those packages never appear as a direct requirement.

This PR adds two opt-in keys under `extra.laravel-boost` so an application can tell Boost about packages it can't see.

## Why

We currently maintain multiple applications that share a common package containing about 90% of their functionality. As a result, each application typically requires only templating work and the implementation of a small number of custom features.

This shared package depends on several other packages, many of which provide their own guidelines and/or skills. At present, we must either publish these skills manually or duplicate the relevant requirements in each application’s composer.json file.

These changes allow us to just add the shared package to the `include-packages-from` list to have all related guidelines and/or skills discovered. It also supports adding additional packages explicitly without having to keep the version in sync.

## `packages` — list packages explicitly

```json
{
    "extra": {
        "laravel-boost": {
            "packages": [
                "spatie/laravel-permission",
                "livewire/livewire"
            ]
        }
    }
}
```

Both packages are now treated as if they were listed in `require`, so their guidelines and skills are discovered.

## `include-packages-from` — inherit a package's requirements

Given an internal meta-package that every project in the org requires:

```json
{
    "require": {
        "acme/bundle": "^1.0"
    },
    "extra": {
        "laravel-boost": {
            "include-packages-from": [
                "acme/bundle"
            ]
        }
    }
}
```

And `vendor/acme/bundle/composer.json`:

```json
{
    "require": {
        "php": "^8.4",
        "spatie/laravel-permission": "^6.0",
        "livewire/livewire": "^3.0"
    }
}
```

Boost now sees `spatie/laravel-permission` and `livewire/livewire`. Platform requirements (`php`, `ext-*`, `lib-*`, `composer-*`) are skipped.

Both keys can be used together, and `include-packages-from` accepts multiple sources.

## Indirect first-party packages

`livewire/livewire` and `laravel/mcp` are normally only given guidelines when required directly — this stops every Boost user picking up MCP guidelines because something else pulled it in. Listing one of them under `extra.laravel-boost` is an explicit opt-in, so it now overrides that rule and the guidelines are included even though the package is indirect.

## Error handling

Sources that don't resolve are ignored rather than fatal:

- `include-packages-from` entry not installed in `vendor/`
- source `composer.json` that is missing, malformed, or doesn't decode to an object
- non-array `extra.laravel-boost`, `packages`, `include-packages-from`, or `require`