### PR TITLE
Fix read-only bypass in `DatabaseQuery` via CTE bodies, `EXPLAIN ANALYZE`, and `INTO`

### DIFF
--- a/src/Mcp/Tools/DatabaseQuery.php
+++ b/src/Mcp/Tools/DatabaseQuery.php
@@ -43,40 +43,12 @@ class DatabaseQuery extends Tool
     public function handle(Request $request): Response
     {
         $query = trim((string) $request->string('query'));
-        $token = strtok(ltrim($query), " \t\n\r");
 
-        if (! $token) {
+        if ($query === '') {
             return Response::error('Please pass a valid query');
         }
 
-        $firstWord = strtoupper($token);
-
-        // Allowed read-only commands.
-        $allowList = [
-            'SELECT',
-            'SHOW',
-            'EXPLAIN',
-            'DESCRIBE',
-            'DESC',
-            'WITH',        // SELECT must follow Common-table expressions
-            'VALUES',      // Returns literal values
-            'TABLE',       // PostgresSQL shorthand for SELECT *
-        ];
-
-        $isReadOnly = in_array($firstWord, $allowList, true);
-
-        // Additional validation for WITH … SELECT.
-        if ($firstWord === 'WITH') {
-            if (! preg_match('/\)\s*SELECT\b/i', $query)) {
-                $isReadOnly = false;
-            }
-
-            if (preg_match('/\)\s*(DELETE|UPDATE|INSERT|DROP|ALTER|TRUNCATE|REPLACE|RENAME|CREATE)\b/i', $query)) {
-                $isReadOnly = false;
-            }
-        }
-
-        if (! $isReadOnly) {
+        if (! $this->isReadOnlyQuery($query)) {
             return Response::error('Only read-only queries are allowed (SELECT, SHOW, EXPLAIN, DESCRIBE, DESC, WITH … SELECT).');
         }
 
@@ -96,6 +68,90 @@ class DatabaseQuery extends Tool
         } catch (Throwable $throwable) {
             return Response::error('Query failed: '.$throwable->getMessage());
         }
+    }
+
+    /**
+     * Determine if the given query only reads data.
+     */
+    protected function isReadOnlyQuery(string $query): bool
+    {
+        // MySQL executes version-gated "/*! ... */" comments, so they cannot be treated as comments.
+        if (str_contains($query, '/*!')) {
+            return false;
+        }
+
+        $structure = $this->withoutLiteralsAndComments($query);
+
+        // Reject stacked statements, but allow a single trailing semicolon.
+        if (preg_match('/;\s*\S/', $structure)) {
+            return false;
+        }
+
+        $token = strtok($structure, " \t\n\r");
+
+        if ($token === false) {
+            return false;
+        }
+
+        $firstWord = strtoupper($token);
+
+        // Allowed read-only commands.
+        $allowList = [
+            'SELECT',
+            'SHOW',
+            'EXPLAIN',
+            'DESCRIBE',
+            'DESC',
+            'WITH',        // SELECT must follow Common-table expressions
+            'VALUES',      // Returns literal values
+            'TABLE',       // PostgresSQL shorthand for SELECT *
+        ];
+
+        if (! in_array($firstWord, $allowList, true)) {
+            return false;
+        }
+
+        // Additional validation for WITH … SELECT.
+        if ($firstWord === 'WITH' && ! preg_match('/\)\s*SELECT\b/i', $structure)) {
+            return false;
+        }
+
+        // Block write statements wherever a statement can start: at the beginning, after an
+        // opening parenthesis (data-modifying CTE bodies), after a closing parenthesis
+        // (statements following CTEs), or after a semicolon. INSERT and REPLACE also exist
+        // as string functions, so their function-call form remains allowed.
+        if (preg_match('/(^|[();])\s*(?:(?:DELETE|UPDATE|DROP|ALTER|TRUNCATE|RENAME|CREATE|MERGE)\b|(?:INSERT|REPLACE)\b(?!\s*\())/i', $structure)) {
+            return false;
+        }
+
+        // EXPLAIN ANALYZE executes the statement it explains, so EXPLAIN may only target reads.
+        if ($firstWord === 'EXPLAIN' && preg_match('/^\s*EXPLAIN\s+(?:\([^)]*\)\s*|(?:ANALYZE|VERBOSE|QUERY\s+PLAN|FORMAT\s*=?\s*\w+)\s+)*(?:DELETE|UPDATE|INSERT|REPLACE|MERGE|DROP|ALTER|TRUNCATE|RENAME|CREATE)\b/i', $structure)) {
+            return false;
+        }
+
+        // INTO always writes: SELECT … INTO, INTO OUTFILE, and INTO DUMPFILE.
+        if (preg_match('/\bINTO\b/i', $structure)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Strip string literals, quoted identifiers, and comments so keyword
+     * checks only run against the structural parts of the query.
+     */
+    protected function withoutLiteralsAndComments(string $query): string
+    {
+        $patterns = [
+            "/'(?:[^'\\\\]|\\\\.|'')*'/s",  // single-quoted strings
+            '/"(?:[^"\\\\]|\\\\.|"")*"/s',  // double-quoted strings and identifiers
+            '/`(?:[^`]|``)*`/s',            // backtick-quoted identifiers
+            '/--[^\n]*/',                   // line comments
+            '#/\*.*?\*/#s',                 // block comments
+        ];
+
+        return preg_replace($patterns, ' ', $query) ?? $query;
     }
 
     protected function addPrefixToQuery(string $query, string $prefix): string

--- a/src/Mcp/Tools/DatabaseQuery.php
+++ b/src/Mcp/Tools/DatabaseQuery.php
@@ -17,6 +17,11 @@ use Throwable;
 class DatabaseQuery extends Tool
 {
     /**
+     * Statement-starting keywords that write data.
+     */
+    private const WRITE_KEYWORDS = 'DELETE|UPDATE|DROP|ALTER|TRUNCATE|RENAME|CREATE|MERGE';
+
+    /**
      * The tool's description.
      */
     protected string $description = 'Execute a read-only SQL query against the configured database.';
@@ -75,12 +80,12 @@ class DatabaseQuery extends Tool
      */
     protected function isReadOnlyQuery(string $query): bool
     {
+        ['structure' => $structure, 'hasVersionComment' => $hasVersionComment] = $this->withoutLiteralsAndComments($query);
+
         // MySQL executes version-gated "/*! ... */" comments, so they cannot be treated as comments.
-        if (str_contains($query, '/*!')) {
+        if ($hasVersionComment) {
             return false;
         }
-
-        $structure = $this->withoutLiteralsAndComments($query);
 
         // Reject stacked statements, but allow a single trailing semicolon.
         if (preg_match('/;\s*\S/', $structure)) {
@@ -116,16 +121,13 @@ class DatabaseQuery extends Tool
             return false;
         }
 
-        // Block write statements wherever a statement can start: at the beginning, after an
-        // opening parenthesis (data-modifying CTE bodies), after a closing parenthesis
-        // (statements following CTEs), or after a semicolon. INSERT and REPLACE also exist
-        // as string functions, so their function-call form remains allowed.
-        if (preg_match('/(^|[();])\s*(?:(?:DELETE|UPDATE|DROP|ALTER|TRUNCATE|RENAME|CREATE|MERGE)\b|(?:INSERT|REPLACE)\b(?!\s*\())/i', $structure)) {
+        // Blocks write keywords at every statement boundary (^, after (, ), or ;); REPLACE(...)/INSERT(...) function calls stay allowed.
+        if (preg_match('/(^|[();])\s*(?:(?:'.self::WRITE_KEYWORDS.')\b|(?:INSERT|REPLACE)\b(?!\s*\())/i', $structure)) {
             return false;
         }
 
         // EXPLAIN ANALYZE executes the statement it explains, so EXPLAIN may only target reads.
-        if ($firstWord === 'EXPLAIN' && preg_match('/^\s*EXPLAIN\s+(?:\([^)]*\)\s*|(?:ANALYZE|VERBOSE|QUERY\s+PLAN|FORMAT\s*=?\s*\w+)\s+)*(?:DELETE|UPDATE|INSERT|REPLACE|MERGE|DROP|ALTER|TRUNCATE|RENAME|CREATE)\b/i', $structure)) {
+        if ($firstWord === 'EXPLAIN' && preg_match('/^\s*EXPLAIN\s+(?:\([^)]*\)\s*|(?:ANALYZE|VERBOSE|QUERY\s+PLAN|FORMAT\s*=?\s*\w+)\s+)*(?:'.self::WRITE_KEYWORDS.'|INSERT|REPLACE)\b/i', $structure)) {
             return false;
         }
 
@@ -138,20 +140,72 @@ class DatabaseQuery extends Tool
     }
 
     /**
-     * Strip string literals, quoted identifiers, and comments so keyword
-     * checks only run against the structural parts of the query.
+     * @return array{structure: string, hasVersionComment: bool}
      */
-    protected function withoutLiteralsAndComments(string $query): string
+    protected function withoutLiteralsAndComments(string $query): array
     {
-        $patterns = [
-            "/'(?:[^'\\\\]|\\\\.|'')*'/s",  // single-quoted strings
-            '/"(?:[^"\\\\]|\\\\.|"")*"/s',  // double-quoted strings and identifiers
-            '/`(?:[^`]|``)*`/s',            // backtick-quoted identifiers
-            '/--[^\n]*/',                   // line comments
-            '#/\*.*?\*/#s',                 // block comments
-        ];
+        $structure = '';
+        $state = 'none';
+        $hasVersionComment = false;
+        $length = strlen($query);
 
-        return preg_replace($patterns, ' ', $query) ?? $query;
+        for ($i = 0; $i < $length; $i++) {
+            $char = $query[$i];
+            $next = $query[$i + 1] ?? '';
+
+            if ($state === 'none') {
+                if ($char === "'" || $char === '"' || $char === '`') {
+                    $state = match ($char) {
+                        "'" => 'single',
+                        '"' => 'double',
+                        default => 'backtick',
+                    };
+                    $structure .= ' ';
+                } elseif ($char === '-' && $next === '-') {
+                    $state = 'line_comment';
+                    $structure .= ' ';
+                    $i++;
+                } elseif ($char === '/' && $next === '*') {
+                    if (($query[$i + 2] ?? '') === '!') {
+                        // MySQL executes version-gated "/*! ... */" comments, so they cannot be treated as comments.
+                        $hasVersionComment = true;
+                        $structure .= $char;
+                    } else {
+                        $state = 'block_comment';
+                        $structure .= ' ';
+                        $i++;
+                    }
+                } else {
+                    $structure .= $char;
+                }
+            } elseif ($state === 'line_comment') {
+                if ($char === "\n") {
+                    $state = 'none';
+                    $structure .= $char;
+                }
+            } elseif ($state === 'block_comment') {
+                if ($char === '*' && $next === '/') {
+                    $state = 'none';
+                    $i++;
+                }
+            } else {
+                $quote = match ($state) {
+                    'single' => "'",
+                    'double' => '"',
+                    default => '`',
+                };
+
+                if ($char === $quote) {
+                    if ($next === $quote) {
+                        $i++; // doubled quote escapes itself; literal continues
+                    } else {
+                        $state = 'none';
+                    }
+                }
+            }
+        }
+
+        return ['structure' => $structure, 'hasVersionComment' => $hasVersionComment];
     }
 
     protected function addPrefixToQuery(string $query, string $prefix): string

--- a/tests/Feature/Mcp/Tools/DatabaseQueryTest.php
+++ b/tests/Feature/Mcp/Tools/DatabaseQueryTest.php
@@ -111,6 +111,64 @@ it('allows queries starting with any allowed keyword even when identifiers look 
     }
 });
 
+it('blocks write operations disguised as read-only queries', function (): void {
+    DB::shouldReceive('select')->never();
+
+    $tool = new DatabaseQuery;
+
+    $queries = [
+        'WITH t AS (DELETE FROM users RETURNING *) SELECT * FROM t',
+        'WITH t AS (UPDATE users SET admin = 1 RETURNING *) SELECT * FROM t',
+        'WITH t AS (INSERT INTO logs VALUES (1) RETURNING *) SELECT * FROM t',
+        "WITH t AS (\n    -- a comment\n    DELETE FROM users RETURNING *\n) SELECT * FROM t",
+        'WITH t AS (/* a comment */ DELETE FROM users RETURNING *) SELECT * FROM t',
+        'EXPLAIN ANALYZE DELETE FROM users',
+        'EXPLAIN (ANALYZE, BUFFERS) UPDATE users SET admin = 1',
+        'EXPLAIN FORMAT=TREE DELETE FROM users',
+        'SELECT * INTO users_copy FROM users',
+        "SELECT id FROM users INTO OUTFILE '/tmp/users.csv'",
+        'SELECT 1; DELETE FROM users',
+        'SELECT /*!50000 1 */ FROM users',
+    ];
+
+    foreach ($queries as $query) {
+        $response = $tool->handle(new Request(['query' => $query]));
+
+        expect($response)->isToolResult()
+            ->toolHasError()
+            ->toolTextContains('Only read-only queries are allowed');
+    }
+});
+
+it('allows read-only queries containing write keyword look-alikes', function (): void {
+    DB::shouldReceive('connection')->andReturnSelf();
+    DB::shouldReceive('select')->andReturn([]);
+    DB::shouldReceive('getTablePrefix')->andReturn('');
+
+    $tool = new DatabaseQuery;
+
+    $queries = [
+        "SELECT REPLACE(name, 'a', 'b') FROM users",
+        "SELECT (REPLACE(name, 'a', 'b')) FROM users",
+        "SELECT INSERT('hello', 1, 2, 'x')",
+        "SELECT * FROM users WHERE action = 'DELETE FROM users'",
+        'SELECT `delete` FROM `updates`',
+        "SELECT * FROM users -- DELETE FROM users\nWHERE id = 1",
+        'SELECT * FROM users;',
+        'SHOW CREATE TABLE users',
+        'EXPLAIN ANALYZE SELECT * FROM users',
+        'EXPLAIN (ANALYZE) SELECT * FROM users',
+        'EXPLAIN users',
+    ];
+
+    foreach ($queries as $query) {
+        $response = $tool->handle(new Request(['query' => $query]));
+
+        expect($response)->isToolResult()
+            ->toolHasNoError();
+    }
+});
+
 it('adds table prefix to queries', function (): void {
     DB::shouldReceive('connection')->andReturnSelf();
     DB::shouldReceive('getTablePrefix')->andReturn('wp_');

--- a/tests/Feature/Mcp/Tools/DatabaseQueryTest.php
+++ b/tests/Feature/Mcp/Tools/DatabaseQueryTest.php
@@ -129,6 +129,8 @@ it('blocks write operations disguised as read-only queries', function (): void {
         "SELECT id FROM users INTO OUTFILE '/tmp/users.csv'",
         'SELECT 1; DELETE FROM users',
         'SELECT /*!50000 1 */ FROM users',
+        "SELECT 1 /* don't */; DELETE FROM users WHERE name = 'x'",
+        "SELECT 'a\\'; DELETE FROM users; --'",
     ];
 
     foreach ($queries as $query) {


### PR DESCRIPTION
Fixes #892.

**The problem**

`DatabaseQuery` is annotated `#[IsReadOnly]` and tells the client "Only read-only queries are allowed", but validation is essentially first-token based, so several write paths reach `DB::select()`:

1. `WITH t AS (DELETE FROM users RETURNING *) SELECT * FROM t`. The first token is `WITH`, the outer `)\s*SELECT` check matches, and the write check only looks for a write keyword after a closing paren, so the CTE-internal `DELETE` is ignored. It runs on Postgres.
2. `EXPLAIN ANALYZE DELETE FROM users`. The first token is `EXPLAIN`, and Postgres executes the statement under `ANALYZE`.
3. `SELECT * INTO users_copy FROM users` creates a table, and `SELECT id FROM users INTO OUTFILE '/tmp/users.csv'` writes to the filesystem on MySQL with `FILE` privilege.

PR #588 closed the outer `WITH ... ) DELETE` form, but not these.

**The fix**

Validation moves into an `isReadOnlyQuery()` method that checks the query's structure rather than just its first token:

- String literals, quoted identifiers, and comments are stripped before keyword matching, so `SELECT REPLACE(name, 'a', 'b')` and `WHERE action = 'DELETE FROM users'` still pass while a `DELETE` hidden behind a comment inside a CTE does not.
- Write keywords are rejected wherever a statement can begin: at the start, after `(`, after `)`, or after `;`. `INSERT` and `REPLACE` are also string functions, so their function-call form stays allowed.
- `EXPLAIN` may only target a read, which blocks `EXPLAIN ANALYZE DELETE ...` and the `EXPLAIN (ANALYZE, BUFFERS) ...` and `EXPLAIN FORMAT=TREE ...` variants.
- `INTO` is rejected, covering `SELECT ... INTO`, `INTO OUTFILE`, and `INTO DUMPFILE`.
- Stacked statements are rejected, though a single trailing semicolon is still fine.
- MySQL executes version-gated `/*! ... */` comments, so queries containing them are rejected rather than treated as commented out.

**Tests**

Two cases added to `DatabaseQueryTest`: one asserting the bypasses above are blocked, and one asserting legitimate reads that merely contain write keywords are still allowed. The full suite passes (860 tests), along with Pint and PHPStan.

This tightens the static gate rather than making the tool a true read-only sandbox. A read-only connection or database role would be the stronger guarantee, but that is a larger change and a config concern, so this keeps to closing the documented bypasses.