### PR TITLE
feat: add Hermes Agent

### DIFF
--- a/src/BoostManager.php
+++ b/src/BoostManager.php
@@ -26,19 +26,19 @@ class BoostManager
     /** @var array<string, class-string<Agent>> */
     private array $agents = [
         'amp' => Amp::class,
-        'junie' => Junie::class,
-        'cursor' => Cursor::class,
+        'antigravity' => Antigravity::class,
         'claude_code' => ClaudeCode::class,
         'codex' => Codex::class,
         'copilot' => Copilot::class,
+        'cursor' => Cursor::class,
         'factory' => Factory::class,
-        'kiro' => Kiro::class,
-        'opencode' => OpenCode::class,
-        'antigravity' => Antigravity::class,
-        'zed' => Zed::class,
-        'pi' => Pi::class,
         'grok_build' => GrokBuild::class,
         'hermes_agent' => HermesAgent::class,
+        'junie' => Junie::class,
+        'kiro' => Kiro::class,
+        'opencode' => OpenCode::class,
+        'pi' => Pi::class,
+        'zed' => Zed::class,
     ];
 
     /**

--- a/src/BoostManager.php
+++ b/src/BoostManager.php
@@ -14,6 +14,7 @@ use Laravel\Boost\Install\Agents\Copilot;
 use Laravel\Boost\Install\Agents\Cursor;
 use Laravel\Boost\Install\Agents\Factory;
 use Laravel\Boost\Install\Agents\GrokBuild;
+use Laravel\Boost\Install\Agents\HermesAgent;
 use Laravel\Boost\Install\Agents\Junie;
 use Laravel\Boost\Install\Agents\Kiro;
 use Laravel\Boost\Install\Agents\OpenCode;
@@ -37,6 +38,7 @@ class BoostManager
         'zed' => Zed::class,
         'pi' => Pi::class,
         'grok_build' => GrokBuild::class,
+        'hermes_agent' => HermesAgent::class,
     ];
 
     /**

--- a/src/Install/Agents/HermesAgent.php
+++ b/src/Install/Agents/HermesAgent.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install\Agents;
+
+use Laravel\Boost\Contracts\SupportsGuidelines;
+use Laravel\Boost\Contracts\SupportsMcp;
+use Laravel\Boost\Contracts\SupportsSkills;
+use Laravel\Boost\Install\Enums\McpInstallationStrategy;
+use Laravel\Boost\Install\Enums\Platform;
+
+class HermesAgent extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSkills
+{
+    public function name(): string
+    {
+        return 'hermes_agent';
+    }
+
+    public function displayName(): string
+    {
+        return 'Hermes Agent';
+    }
+
+    public function systemDetectionConfig(Platform $platform): array
+    {
+        return match ($platform) {
+            Platform::Darwin, Platform::Linux => [
+                'command' => 'command -v hermes',
+            ],
+            Platform::Windows => [
+                'command' => 'cmd /c where hermes 2>nul',
+            ],
+        };
+    }
+
+    public function projectDetectionConfig(): array
+    {
+        return [
+            'files' => ['.hermes.md', 'HERMES.md'],
+        ];
+    }
+
+    public function mcpInstallationStrategy(): McpInstallationStrategy
+    {
+        return McpInstallationStrategy::FILE;
+    }
+
+    public function mcpConfigPath(): string
+    {
+        return config('boost.agents.hermes_agent.mcp_config_path', '.mcp.json');
+    }
+
+    public function guidelinesPath(): string
+    {
+        return config('boost.agents.hermes_agent.guidelines_path', 'HERMES.md');
+    }
+
+    public function skillsPath(): string
+    {
+        return config('boost.agents.hermes_agent.skills_path', '.hermes/skills');
+    }
+}

--- a/tests/Feature/Install/Agents/AgentPathResolutionTest.php
+++ b/tests/Feature/Install/Agents/AgentPathResolutionTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Laravel\Boost\Install\Agents\Cursor;
+use Laravel\Boost\Install\Agents\HermesAgent;
 use Laravel\Boost\Install\Agents\Junie;
 use Laravel\Boost\Install\Agents\Pi;
 use Laravel\Boost\Install\Detection\DetectionStrategyFactory;
@@ -121,4 +122,15 @@ test('Pi uses AGENTS.md and .pi/skills defaults', function (): void {
         ->and($pi->getArtisanPath())->toBe('artisan')
         ->and($pi->guidelinesPath())->toBe('AGENTS.md')
         ->and($pi->skillsPath())->toBe('.pi/skills');
+});
+
+test('Hermes Agent uses HERMES.md and .hermes/skills defaults', function (): void {
+    config(['boost.executable_paths.php' => null]);
+    $strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
+    $hermes = new HermesAgent($strategyFactory);
+
+    expect($hermes->getPhpPath())->toBe('php')
+        ->and($hermes->getArtisanPath())->toBe('artisan')
+        ->and($hermes->guidelinesPath())->toBe('HERMES.md')
+        ->and($hermes->skillsPath())->toBe('.hermes/skills');
 });

--- a/tests/Unit/BoostManagerTest.php
+++ b/tests/Unit/BoostManagerTest.php
@@ -11,6 +11,7 @@ use Laravel\Boost\Install\Agents\Copilot;
 use Laravel\Boost\Install\Agents\Cursor;
 use Laravel\Boost\Install\Agents\Factory;
 use Laravel\Boost\Install\Agents\GrokBuild;
+use Laravel\Boost\Install\Agents\HermesAgent;
 use Laravel\Boost\Install\Agents\Junie;
 use Laravel\Boost\Install\Agents\Kiro;
 use Laravel\Boost\Install\Agents\OpenCode;
@@ -36,6 +37,7 @@ it('returns default agents', function (): void {
         'zed' => Zed::class,
         'pi' => Pi::class,
         'grok_build' => GrokBuild::class,
+        'hermes_agent' => HermesAgent::class,
     ]);
 });
 

--- a/tests/Unit/Install/Agents/HermesAgentTest.php
+++ b/tests/Unit/Install/Agents/HermesAgentTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Install\Agents;
+
+use Laravel\Boost\Install\Agents\HermesAgent;
+use Laravel\Boost\Install\Detection\DetectionStrategyFactory;
+use Mockery;
+
+beforeEach(function (): void {
+    $this->strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
+});
+
+test('returns default mcp config path', function (): void {
+    $agent = new HermesAgent($this->strategyFactory);
+
+    expect($agent->mcpConfigPath())->toBe('.mcp.json');
+});
+
+test('returns configured mcp config path', function (): void {
+    config()->set('boost.agents.hermes_agent.mcp_config_path', '../.mcp.json');
+
+    $agent = new HermesAgent($this->strategyFactory);
+
+    expect($agent->mcpConfigPath())->toBe('../.mcp.json');
+});
+
+test('uses relative paths for MCP', function (): void {
+    $agent = new HermesAgent($this->strategyFactory);
+
+    expect($agent->useAbsolutePathForMcp())->toBeFalse();
+});
+
+test('returns relative PHP path', function (): void {
+    config(['boost.executable_paths.php' => null]);
+
+    $agent = new HermesAgent($this->strategyFactory);
+
+    expect($agent->getPhpPath())->toBe('php');
+});
+
+test('returns relative artisan path', function (): void {
+    $agent = new HermesAgent($this->strategyFactory);
+
+    $artisanPath = $agent->getArtisanPath();
+
+    expect($artisanPath)->toBe('artisan');
+});
+
+test('httpMcpServerConfig returns default http config', function (): void {
+    $agent = new HermesAgent($this->strategyFactory);
+
+    expect($agent->httpMcpServerConfig('https://nightwatch.laravel.com/mcp'))->toBe([
+        'type' => 'http',
+        'url' => 'https://nightwatch.laravel.com/mcp',
+    ]);
+});

--- a/tests/Unit/Install/AgentsDetectorTest.php
+++ b/tests/Unit/Install/AgentsDetectorTest.php
@@ -14,6 +14,7 @@ use Laravel\Boost\Install\Agents\Copilot;
 use Laravel\Boost\Install\Agents\Cursor;
 use Laravel\Boost\Install\Agents\Factory;
 use Laravel\Boost\Install\Agents\GrokBuild;
+use Laravel\Boost\Install\Agents\HermesAgent;
 use Laravel\Boost\Install\Agents\Junie;
 use Laravel\Boost\Install\Agents\Kiro;
 use Laravel\Boost\Install\Agents\OpenCode;
@@ -36,9 +37,9 @@ it('returns collection of all registered agents', function (): void {
     $agents = $this->detector->getAgents();
 
     expect($agents)->toBeInstanceOf(Collection::class)
-        ->and($agents->count())->toBe(13)
+        ->and($agents->count())->toBe(14)
         ->and($agents->keys()->toArray())->toBe([
-            'amp', 'junie', 'cursor', 'claude_code', 'codex', 'copilot', 'factory', 'kiro', 'opencode', 'antigravity', 'zed', 'pi', 'grok_build',
+            'amp', 'junie', 'cursor', 'claude_code', 'codex', 'copilot', 'factory', 'kiro', 'opencode', 'antigravity', 'zed', 'pi', 'grok_build', 'hermes_agent'
         ]);
 
     $agents->each(function ($agent): void {
@@ -72,6 +73,7 @@ it('returns an array of detected agents names for system discovery', function ()
     $this->container->bind(Zed::class, fn () => $mockOther);
     $this->container->bind(Pi::class, fn () => $mockOther);
     $this->container->bind(GrokBuild::class, fn () => $mockOther);
+    $this->container->bind(HermesAgent::class, fn () => $mockOther);
 
     $detector = new AgentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverSystemInstalledAgents();
@@ -97,6 +99,7 @@ it('returns an empty array when no agents are detected for system discovery', fu
     $this->container->bind(Zed::class, fn () => $mockAgent);
     $this->container->bind(Pi::class, fn () => $mockAgent);
     $this->container->bind(GrokBuild::class, fn () => $mockAgent);
+    $this->container->bind(HermesAgent::class, fn () => $mockAgent);
 
     $detector = new AgentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverSystemInstalledAgents();
@@ -132,6 +135,7 @@ it('returns an array of detected agent names for project discovery', function ()
     $this->container->bind(Zed::class, fn () => $mockOther);
     $this->container->bind(Pi::class, fn () => $mockOther);
     $this->container->bind(GrokBuild::class, fn () => $mockOther);
+    $this->container->bind(HermesAgent::class, fn () => $mockOther);
 
     $detector = new AgentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverProjectInstalledAgents($basePath);
@@ -159,6 +163,7 @@ it('returns an empty array when no agents are detected for project discovery', f
     $this->container->bind(Zed::class, fn () => $mockAgent);
     $this->container->bind(Pi::class, fn () => $mockAgent);
     $this->container->bind(GrokBuild::class, fn () => $mockAgent);
+    $this->container->bind(HermesAgent::class, fn () => $mockAgent);
 
     $detector = new AgentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverProjectInstalledAgents($basePath);


### PR DESCRIPTION
Added Hermes Agent based on https://hermes-agent.nousresearch.com/docs/user-guide/features/context-files
The exception appears to be that Hermes doesn't currently load mcp and skills from the project directory.

I have added those so that coverage is still available to other agents.

There are workarounds available, the contents of .mcp.json can be copied to the following format in the `~/.hermes/config.yaml` file.

```yaml
mcp_servers:
  laravel-boost:
    command: "path to php binary"
    args: ["<project dir>/artisan", "boost:mcp"]
```

The skills can be worked around by symlinking `~/.hermes/skills/laravel-boost` to `<project path>/.hermes/skills`

```sh
mkdir -p "<project path>/.hermes/skills"
ln -s "<project path>/.hermes/skills/" ~/.hermes/skills/laravel-boost
```