### PR TITLE
Handle signaled process when detecting test enforcement

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -33,6 +33,7 @@ use Laravel\Boost\Skills\Remote\RemoteSkill;
 use Laravel\Boost\Support\Config;
 use Laravel\Prompts\Terminal;
 use RuntimeException;
+use Symfony\Component\Process\Exception\ProcessSignaledException;
 use Symfony\Component\Process\Process;
 use Throwable;
 
@@ -179,7 +180,12 @@ class InstallCommand extends Command
         }
 
         $process = new Process([PHP_BINARY, 'artisan', 'test', '--list-tests'], base_path());
-        $process->run();
+
+        try {
+            $process->run();
+        } catch (ProcessSignaledException) {
+            return false;
+        }
 
         return Str::of($process->getOutput())
             ->trim()

--- a/src/Install/Agents/Agent.php
+++ b/src/Install/Agents/Agent.php
@@ -12,6 +12,7 @@ use Laravel\Boost\Install\Enums\Platform;
 use Laravel\Boost\Install\Mcp\FileWriter;
 use Laravel\Boost\Install\Mcp\TomlFileWriter;
 use Laravel\Boost\Support\CommandNormalizer;
+use Symfony\Component\Process\Exception\ProcessSignaledException;
 
 abstract class Agent
 {
@@ -225,7 +226,11 @@ abstract class Agent
             trim($envString),
         ], $shellCommand);
 
-        $result = Process::run($command);
+        try {
+            $result = Process::run($command);
+        } catch (ProcessSignaledException) {
+            return false;
+        }
 
         if ($result->successful()) {
             return true;

--- a/src/Install/Detection/CommandDetectionStrategy.php
+++ b/src/Install/Detection/CommandDetectionStrategy.php
@@ -7,6 +7,7 @@ namespace Laravel\Boost\Install\Detection;
 use Illuminate\Support\Facades\Process;
 use Laravel\Boost\Install\Contracts\DetectionStrategy;
 use Laravel\Boost\Install\Enums\Platform;
+use Symfony\Component\Process\Exception\ProcessSignaledException;
 
 class CommandDetectionStrategy implements DetectionStrategy
 {
@@ -16,6 +17,10 @@ class CommandDetectionStrategy implements DetectionStrategy
             return false;
         }
 
-        return Process::run($config['command'])->successful();
+        try {
+            return Process::run($config['command'])->successful();
+        } catch (ProcessSignaledException) {
+            return false;
+        }
     }
 }

--- a/tests/Feature/Console/InstallCommandTestEnforcementTest.php
+++ b/tests/Feature/Console/InstallCommandTestEnforcementTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+use Laravel\Boost\Console\InstallCommand;
+
+it('does not crash when the test-listing process is signaled', function (): void {
+    $projectPath = sys_get_temp_dir().'/boost_'.uniqid();
+    File::ensureDirectoryExists($projectPath.'/vendor/bin');
+    File::put($projectPath.'/vendor/bin/phpunit', '');
+    File::put($projectPath.'/artisan', '<?php posix_kill(posix_getpid(), 5);');
+    app()->setBasePath($projectPath);
+
+    $reflection = new ReflectionClass(InstallCommand::class);
+    $command = $reflection->newInstanceWithoutConstructor();
+    $result = $reflection->getMethod('determineTestEnforcement')->invoke($command);
+
+    File::deleteDirectory($projectPath);
+
+    expect($result)->toBeFalse();
+})->skipOnWindows();

--- a/tests/Feature/Install/Detection/CommandDetectionStrategyTest.php
+++ b/tests/Feature/Install/Detection/CommandDetectionStrategyTest.php
@@ -77,3 +77,11 @@ test('works with different platforms parameter', function (): void {
 
     expect($result)->toBeTrue();
 });
+
+test('returns false when the process is signaled', function (): void {
+    $result = $this->strategy->detect([
+        'command' => 'php -r "posix_kill(posix_getpid(), 5);"',
+    ]);
+
+    expect($result)->toBeFalse();
+})->skipOnWindows();

--- a/tests/Unit/Install/Agents/AgentTest.php
+++ b/tests/Unit/Install/Agents/AgentTest.php
@@ -212,6 +212,21 @@ test('installShellMcp returns true when process fails but has already exists err
     expect($result)->toBe(true);
 });
 
+test('installShellMcp returns false when the process is signaled', function (): void {
+    $environment = Mockery::mock(TestAgent::class)->makePartial();
+    $environment->shouldAllowMockingProtectedMethods();
+
+    $environment->shouldReceive('shellMcpCommand')
+        ->andReturn('php -r "posix_kill(posix_getpid(), 5);"');
+
+    $environment->shouldReceive('mcpInstallationStrategy')
+        ->andReturn(McpInstallationStrategy::SHELL);
+
+    $result = $environment->installMcp('test-key', 'test-command');
+
+    expect($result)->toBe(false);
+})->skipOnWindows();
+
 test('installFileMcp returns false when mcpConfigPath is null', function (): void {
     $environment = new TestAgent($this->strategyFactory);
 


### PR DESCRIPTION
`determineTestEnforcement()` runs `php artisan test --list-tests` through Symfony Process to decide whether to enable the test enforcement guideline. In sandboxed or otherwise constrained environments that subprocess can be killed by a signal, and the `ProcessSignaledException` it throws is never caught, so `boost:install` and `boost:update` abort. This catches it and falls back to no enforcement, the same safe default already used when no test runner is present.

Fixes #900
