### PR TITLE
Refactor scope methods to use #[Scope] attribute

### DIFF
--- a/.ai/laravel/skill/laravel-best-practices/rules/eloquent.md
+++ b/.ai/laravel/skill/laravel-best-practices/rules/eloquent.md
@@ -30,7 +30,8 @@ $articles = Article::whereHas('user', function ($q) {
 
 Correct:
 ```php
-public function scopeActive(Builder $query): Builder
+#[Scope]
+protected function active(Builder $query): Builder
 {
     return $query->where('verified', true)->whereNotNull('activated_at');
 }
@@ -58,7 +59,8 @@ class PublishedScope implements Scope
 
 Correct (local scope you opt into):
 ```php
-public function scopePublished(Builder $query): Builder
+#[Scope]
+protected function published(Builder $query): Builder
 {
     return $query->where('published', true);
 }


### PR DESCRIPTION
A small change to ensure boost recommends using the latest and currently recommended syntax to define [local scopes](https://laravel.com/docs/13.x/eloquent#local-scopes).