### PR TITLE
Prevent `boost:update` from failing when there is nothing to update

### DIFF
--- a/src/Console/UpdateCommand.php
+++ b/src/Console/UpdateCommand.php
@@ -23,14 +23,10 @@ class UpdateCommand extends Command
 
     public function handle(Config $config): int
     {
-        if (! $config->isValid() || empty($config->getAgents())) {
+        if (! $config->isValid()) {
             $this->error('Please set up Boost with [php artisan boost:install] first.');
 
             return self::FAILURE;
-        }
-
-        if (! $this->option('no-discover')) {
-            $this->discoverNewContent($config);
         }
 
         $guidelines = $config->getGuidelines();
@@ -38,6 +34,16 @@ class UpdateCommand extends Command
 
         if (! $guidelines && ! $hasSkills) {
             return self::SUCCESS;
+        }
+
+        if (empty($config->getAgents())) {
+            $this->error('Please set up Boost with [php artisan boost:install] first.');
+
+            return self::FAILURE;
+        }
+
+        if (! $this->option('no-discover')) {
+            $this->discoverNewContent($config);
         }
 
         $this->callSilently(InstallCommand::class, [

--- a/tests/Feature/Console/UpdateCommandTest.php
+++ b/tests/Feature/Console/UpdateCommandTest.php
@@ -67,6 +67,15 @@ it('exits silently when no guidelines and no skills are configured', function ()
         ->assertSuccessful();
 });
 
+it('exits silently when only mcp is configured and no agents are stored', function (): void {
+    $config = new Config;
+    $config->setMcp(true);
+
+    $this->artisan('boost:update')
+        ->doesntExpectOutputToContain('Please set up Boost with [php artisan boost:install] first.')
+        ->assertSuccessful();
+});
+
 it('calls install command with a guidelines flag when guidelines are enabled', function (): void {
     $config = new Config;
     $config->setAgents(['claude_code']);


### PR DESCRIPTION
Currently `boost:update` needs configured agents before it checks whether there is anything to update, so an MCP-only setup (`php artisan boost:install --mcp`) gets `Please set up Boost with [php artisan boost:install] first.` and a non-zero exit code.

This PR reorders the checks in `handle()` so that when guidelines or skills aren't configured the command exits successfully before requiring the agents part.

Example run that shows the current behaviour in a new project that this PR (seems to!) fix:

```sh
$ composer require --dev laravel/boost
... <all fine>

$ php artisan boost:install --mcp
... <all looks ok>

$ php artisan boost:update
Please set up Boost with [php artisan boost:install] first.
```

