### PR TITLE
Only offer the Laravel Cloud integration when skills are being installed

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -261,7 +261,7 @@ class InstallCommand extends Command
         $integrations = collect([
             'cloud' => [
                 'label' => 'Laravel Cloud',
-                'available' => true,
+                'available' => $this->selectedBoostFeatures->contains('skills'),
                 'default' => $this->config->getCloud(),
             ],
             'nightwatch' => [
@@ -512,7 +512,9 @@ class InstallCommand extends Command
             $this->config->setSkills($this->installedSkillNames);
         }
 
-        $this->config->setCloud($this->selectedBoostFeatures->contains('cloud'));
+        if ($this->selectedBoostFeatures->contains('skills')) {
+            $this->config->setCloud($this->selectedBoostFeatures->contains('cloud'));
+        }
 
         if ($this->selectedBoostFeatures->contains('mcp')) {
             $this->config->setMcp(true);

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -276,6 +276,10 @@ class InstallCommand extends Command
             ],
         ])->filter(fn (array $integration): bool => $integration['available']);
 
+        if ($integrations->isEmpty()) {
+            return;
+        }
+
         $defaults = $integrations->filter(fn (array $integration): bool => $integration['default'])->keys()->all();
 
         if (! $this->input->isInteractive()) {

--- a/tests/Feature/Console/InstallCommandCloudSkillTest.php
+++ b/tests/Feature/Console/InstallCommandCloudSkillTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use Laravel\Boost\Support\Config;
+
+beforeEach(function (): void {
+    $this->originalBasePath = base_path();
+    $this->tempBasePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.'boost-install-cloud-skill-test-'.uniqid();
+
+    File::makeDirectory($this->tempBasePath, 0755, true);
+    $this->app->setBasePath($this->tempBasePath);
+
+    file_put_contents($this->tempBasePath.'/composer.lock', json_encode([
+        'packages' => [
+            ['name' => 'laravel/framework', 'version' => 'v11.0.0'],
+        ],
+        'packages-dev' => [],
+    ]));
+
+    config(['boost.agents.claude_code.mcp_config_path' => $this->tempBasePath.'/.mcp.json']);
+
+    (new Config)->setAgents(['claude_code']);
+});
+
+afterEach(function (): void {
+    (new Config)->flush();
+    $this->app->setBasePath($this->originalBasePath);
+    File::deleteDirectory($this->tempBasePath);
+});
+
+it('does not download the cloud skill when the skills feature is not selected', function (): void {
+    Http::fake();
+
+    (new Config)->setCloud(true);
+
+    $this->artisan('boost:install', ['--mcp' => true, '--no-interaction' => true])
+        ->assertSuccessful();
+
+    Http::assertNothingSent();
+
+    expect(is_dir($this->tempBasePath.'/.ai/skills'))->toBeFalse()
+        ->and((new Config)->getCloud())->toBeTrue();
+});
+
+it('still downloads the cloud skill when the skills feature is selected', function (): void {
+    Http::fake();
+
+    (new Config)->setCloud(true);
+
+    $this->artisan('boost:install', ['--skills' => true, '--no-interaction' => true])
+        ->assertSuccessful();
+
+    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'cloud-cli'));
+});

--- a/tests/Feature/Console/InstallCommandCloudSkillTest.php
+++ b/tests/Feature/Console/InstallCommandCloudSkillTest.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
+use Laravel\Boost\Console\InstallCommand;
 use Laravel\Boost\Support\Config;
+use Laravel\Prompts\Prompt;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
 
 beforeEach(function (): void {
     $this->originalBasePath = base_path();
@@ -39,7 +43,7 @@ it('does not download the cloud skill when the skills feature is not selected', 
     $this->artisan('boost:install', ['--mcp' => true, '--no-interaction' => true])
         ->assertSuccessful();
 
-    Http::assertNothingSent();
+    Http::assertNotSent(fn ($request): bool => str_contains((string) $request->url(), 'cloud-cli'));
 
     expect(is_dir($this->tempBasePath.'/.ai/skills'))->toBeFalse()
         ->and((new Config)->getCloud())->toBeTrue();
@@ -53,5 +57,25 @@ it('still downloads the cloud skill when the skills feature is selected', functi
     $this->artisan('boost:install', ['--skills' => true, '--no-interaction' => true])
         ->assertSuccessful();
 
-    Http::assertSent(fn ($request): bool => str_contains($request->url(), 'cloud-cli'));
+    Http::assertSent(fn ($request): bool => str_contains((string) $request->url(), 'cloud-cli'));
 });
+
+it('does not prompt for integrations when none are available', function (): void {
+    Prompt::fake();
+
+    $command = $this->app->make(InstallCommand::class);
+
+    $input = new ArrayInput([]);
+    $input->setInteractive(true);
+
+    $reflection = new ReflectionClass($command);
+    $reflection->getProperty('input')->setValue($command, $input);
+    $reflection->getProperty('output')->setValue($command, new NullOutput);
+    $reflection->getProperty('selectedBoostFeatures')->setValue($command, collect(['mcp']));
+
+    $reflection->getMethod('selectIntegrations')->invoke($command);
+
+    Prompt::assertOutputDoesntContain('Which integrations');
+
+    expect($reflection->getProperty('selectedBoostFeatures')->getValue($command)->all())->toBe(['mcp']);
+})->skipOnWindows();


### PR DESCRIPTION
The prompt in `boost:install` offers "Laravel Cloud" even when the skills feature is not used. Selecting it downloads the `deploying-laravel-cloud` skill into `.ai/skills/`, but the step that copies skills from `.ai/skills/` out to each agent only runs when the skills feature is enabled. 

So someone running `php artisan boost:install --mcp` plus a tick on "Laravel Cloud" (it's very unobvious what the option means) leaves an .ai skill on disk that is never actually used but either needs deleting or mysteriously git-ignoring.

This PR only offers the "Laravel Cloud" option when the skills feature is selected, and leaves the `cloud` value in `boost.json` alone when the option wasn't shown.

Current behaviour (including the unobvious cloud prompt - I had assumed it was an extra MCP tool) :

```sh
php artisan boost:install --mcp
...
Let\'s give Laravel a Boost

 ┌ Which integrations would you like to configure for Boost? ───┐
 │ Laravel Cloud                                                │
 └──────────────────────────────────────────────────────────────┘
...
$ ls .ai/skills/
deploying-laravel-cloud/
```
