### PR TITLE
Add missing existing keys to config file

### DIFF
--- a/config/boost.php
+++ b/config/boost.php
@@ -55,7 +55,7 @@ return [
     |
     | Any skills listed here will not be installed or synced to your agents
     | by boost:install and boost:update, e.g. "fluxui-development". Your
-    | own skills within your .ai/skills directory are never excluded.
+    | own skills within the ".ai/skills" directory are never excluded.
     |
     */
 

--- a/config/boost.php
+++ b/config/boost.php
@@ -35,6 +35,36 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Excluded Guidelines
+    |--------------------------------------------------------------------------
+    |
+    | Any guidelines listed here will be excluded whenever Boost composes your
+    | AI guidelines during boost:install or boost:update. Entries match the
+    | names shown within the boost:install summary, e.g. "livewire/core".
+    |
+    */
+
+    'guidelines' => [
+        'exclude' => [],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Excluded Skills
+    |--------------------------------------------------------------------------
+    |
+    | Any skills listed here will not be installed or synced to your agents
+    | by boost:install and boost:update, e.g. "fluxui-development". Your
+    | own skills within your .ai/skills directory are never excluded.
+    |
+    */
+
+    'skills' => [
+        'exclude' => [],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Boost Executables Paths
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
Sorry - me again :-)

Currently `boost.guidelines.exclude` and `boost.skills.exclude` are read when boost builds its guidelines and skills, but those aren't in the default `config/boost.php`. So it's very unclear how to entirely exclude individual items.: Eg, the `livewire/core` guideline, or the `fluxui-development` skill. 

This PR adds both keys to `config/boost.php` with some helpful doc-blocks. Both default to an empty list so shouldn't break any existing setups.