### PR TITLE
Skip vendor guidelines that fail to render instead of crashing

### DIFF
--- a/.ai/inertia-laravel/core.blade.php
+++ b/.ai/inertia-laravel/core.blade.php
@@ -12,7 +12,21 @@
 - IMPORTANT: Activate `inertia-svelte-development` when working with Inertia Svelte client-side patterns.
 @endif
 
-@if($assist->inertia()->gte('2.0.0'))
+@if($assist->inertia()->gte('3.0.0'))
+# Inertia v3
+
+- Use all Inertia features from v1, v2, and v3. Check the documentation before making changes to ensure the correct approach.
+- New v3 features: standalone HTTP requests (`useHttp` hook), optimistic updates with automatic rollback, layout props (`useLayoutProps` hook), instant visits, simplified SSR via `@inertiajs/vite` plugin, custom exception handling for error pages.
+- Carried over from v2: deferred props, infinite scroll, merging props, polling, prefetching, once props, flash data.
+- When using deferred props, add an empty state with a pulsing or animated skeleton.
+- Axios has been removed. Use the built-in XHR client with interceptors, or install Axios separately if needed.
+- `Inertia::lazy()` / `LazyProp` has been removed. Use `Inertia::optional()` instead.
+- Prop types (`Inertia::optional()`, `Inertia::defer()`, `Inertia::merge()`) work inside nested arrays with dot-notation paths.
+- SSR works automatically in Vite dev mode with `@inertiajs/vite` - no separate Node.js server needed during development.
+- Event renames: `invalid` is now `httpException`, `exception` is now `networkError`.
+- `router.cancel()` replaced by `router.cancelAll()`.
+- The `future` configuration namespace has been removed - all v2 future options are now always enabled.
+@elseif($assist->inertia()->gte('2.0.0'))
 # Inertia v2
 
 - Use all Inertia features from v1 and v2. Check the documentation before making changes to ensure the correct approach.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,7 +6,9 @@
 
 PR Link: https://github.com/laravel/boost/pull/891
 
-Likelihood Of Impact: Low (only applies if you ship your own Blade guidelines or skills)
+Likelihood Of Impact: Low
+
+This only applies if you ship your own Blade guidelines or skills, either in your application's `.ai` directory or in a package's `resources/boost` directory.
 
 Boost now runs on Laravel Roster 1.x, which removed the `Laravel\Roster\Enums\Packages` enum. Package names are now string constants on `Laravel\Boost\Support\PackageRegistry`, and `$assist->roster` has become `$assist->project`, a `Laravel\Roster\ProjectManager` that splits packages into `php()` and `js()`:
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,7 +6,7 @@
 
 PR Link: https://github.com/laravel/boost/pull/891
 
-Likelihood Of Impact: High (only applies if you ship your own Blade guidelines or skills)
+Likelihood Of Impact: Low (only applies if you ship your own Blade guidelines or skills)
 
 Boost now runs on Laravel Roster 1.x, which removed the `Laravel\Roster\Enums\Packages` enum. Package names are now string constants on `Laravel\Boost\Support\PackageRegistry`, and `$assist->roster` has become `$assist->project`, a `Laravel\Roster\ProjectManager` that splits packages into `php()` and `js()`:
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,7 +8,7 @@ PR Link: https://github.com/laravel/boost/pull/891
 
 Likelihood Of Impact: Low
 
-This applies if you write your own Blade guidelines or skills, either in your application's `.ai` directory or in a package's `resources/boost` directory. You can also run into it without writing any yourself, because installed packages ship their own guidelines and skills that Boost renders during `boost:install`. If a package has not been updated for this API yet, update the package once it has, and use the table below if you maintain it.
+`boost:install` renders every Blade guideline and skill, whether you wrote it in your application's `.ai` directory or a package ships it in `resources/boost`. So you can hit this even if you never wrote one. Use the table below for files you maintain, and update any package that has not migrated yet.
 
 Boost now runs on Laravel Roster 1.x, which removed the `Laravel\Roster\Enums\Packages` enum. Package names are now string constants on `Laravel\Boost\Support\PackageRegistry`, and `$assist->roster` has become `$assist->project`, a `Laravel\Roster\ProjectManager` that splits packages into `php()` and `js()`:
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -8,7 +8,7 @@ PR Link: https://github.com/laravel/boost/pull/891
 
 Likelihood Of Impact: Low
 
-This only applies if you ship your own Blade guidelines or skills, either in your application's `.ai` directory or in a package's `resources/boost` directory.
+This applies if you write your own Blade guidelines or skills, either in your application's `.ai` directory or in a package's `resources/boost` directory. You can also run into it without writing any yourself, because installed packages ship their own guidelines and skills that Boost renders during `boost:install`. If a package has not been updated for this API yet, update the package once it has, and use the table below if you maintain it.
 
 Boost now runs on Laravel Roster 1.x, which removed the `Laravel\Roster\Enums\Packages` enum. Package names are now string constants on `Laravel\Boost\Support\PackageRegistry`, and `$assist->roster` has become `$assist->project`, a `Laravel\Roster\ProjectManager` that splits packages into `php()` and `js()`:
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,48 @@
 # Upgrade Guide
 
+## Upgrading To 2.5 From 2.4
+
+### Guideline And Skill Authoring API
+
+PR Link: https://github.com/laravel/boost/pull/891
+
+Likelihood Of Impact: High (only applies if you ship your own Blade guidelines or skills)
+
+Boost now runs on Laravel Roster 1.x, which removed the `Laravel\Roster\Enums\Packages` enum. Package names are now string constants on `Laravel\Boost\Support\PackageRegistry`, and `$assist->roster` has become `$assist->project`, a `Laravel\Roster\ProjectManager` that splits packages into `php()` and `js()`:
+
+| Before                                                    | After                                                       |
+|-----------------------------------------------------------|-------------------------------------------------------------|
+| `\Laravel\Roster\Enums\Packages::INERTIA_REACT`           | `\Laravel\Boost\Support\PackageRegistry::INERTIA_REACT`     |
+| `$assist->roster`                                         | `$assist->project`                                          |
+| `$assist->roster->uses(Packages::X)`                      | `$assist->project->php()->uses(PackageRegistry::X)`         |
+| `$assist->roster->usesVersion(Packages::X, '1.0.0', '>=')` | `$assist->project->php()->uses(PackageRegistry::X, '>=1.0.0')` |
+| `$assist->roster->nodePackageManager()`                   | `$assist->project->js()->packageManager()`                  |
+| `NodePackageManager::NPM`                                 | `JsPackageManager::Npm`                                     |
+
+Before:
+
+```blade
+@if($assist->hasPackage(\Laravel\Roster\Enums\Packages::INERTIA_REACT))
+@if($assist->roster->uses(\Laravel\Roster\Enums\Packages::INERTIA_LARAVEL))
+```
+
+After:
+
+```blade
+@if($assist->hasPackage(\Laravel\Boost\Support\PackageRegistry::INERTIA_REACT))
+@if($assist->project->php()->uses(\Laravel\Boost\Support\PackageRegistry::INERTIA_LARAVEL))
+```
+
+`hasPackage()` still checks both PHP and JS packages, so reach for it when you do not care which side a package came from. `js()->uses()` also accepts an array to test several packages at once.
+
+Guidelines and skills that still use the old API will fail to render. Boost skips those files, falls back to its own bundled copy of the guideline when it has one, and lists the packages to update once `boost:install` finishes, so a stale package no longer aborts the install. If your package needs to support both, constrain it in your `composer.json`:
+
+```json
+"conflict": {
+    "laravel/boost": "<2.5.0"
+}
+```
+
 ## Upgrading To 2.x From 1.x
 
 > Note: If you are not using custom agents or overriding Boost in any way, you should experience minimal issues while upgrading. Simply run `php artisan boost:install` after upgrading to Boost 2.x and the migration will be handled automatically.

--- a/src/BoostServiceProvider.php
+++ b/src/BoostServiceProvider.php
@@ -18,6 +18,7 @@ use Laravel\Boost\Mcp\Boost;
 use Laravel\Boost\Middleware\InjectBoost;
 use Laravel\Boost\Rules\RuleRepository;
 use Laravel\Boost\Services\BrowserLogger;
+use Laravel\Boost\Support\RenderFailures;
 use Laravel\Mcp\Facades\Mcp;
 use Laravel\Roster\ProjectManager;
 
@@ -29,6 +30,8 @@ class BoostServiceProvider extends ServiceProvider
             __DIR__.'/../config/boost.php',
             'boost'
         );
+
+        $this->app->singleton(RenderFailures::class, fn (): RenderFailures => new RenderFailures);
 
         if (! $this->shouldRun()) {
             return;

--- a/src/Concerns/RendersBladeGuidelines.php
+++ b/src/Concerns/RendersBladeGuidelines.php
@@ -6,6 +6,7 @@ namespace Laravel\Boost\Concerns;
 
 use Illuminate\Support\Facades\Blade;
 use Laravel\Boost\Install\GuidelineAssist;
+use Laravel\Boost\Support\RenderFailures;
 
 trait RendersBladeGuidelines
 {
@@ -35,12 +36,22 @@ trait RendersBladeGuidelines
         ];
 
         $content = str_replace(array_keys($placeholders), array_values($placeholders), $content);
-        $rendered = Blade::render($content, [
-            'assist' => $this->getGuidelineAssist(),
-            ...$data,
-        ]);
 
-        $rendered = html_entity_decode((string) $rendered, ENT_QUOTES | ENT_HTML5);
+        $rendered = rescue(
+            fn (): string => Blade::render($content, [
+                'assist' => $this->getGuidelineAssist(),
+                ...$data,
+            ]),
+            report: false,
+        );
+
+        if ($rendered === null) {
+            app(RenderFailures::class)->record($path);
+
+            return '';
+        }
+
+        $rendered = html_entity_decode($rendered, ENT_QUOTES | ENT_HTML5);
 
         return str_replace(array_values($placeholders), array_keys($placeholders), $rendered);
     }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -31,6 +31,7 @@ use Laravel\Boost\Skills\Remote\GitHubRepository;
 use Laravel\Boost\Skills\Remote\GitHubSkillProvider;
 use Laravel\Boost\Skills\Remote\RemoteSkill;
 use Laravel\Boost\Support\Config;
+use Laravel\Boost\Support\RenderFailures;
 use Laravel\Prompts\Terminal;
 use RuntimeException;
 use Symfony\Component\Process\Process;
@@ -94,6 +95,8 @@ class InstallCommand extends Command
         $this->collectInstallationPreferences();
         $this->performInstallation();
 
+        $this->reportRenderFailures();
+
         $this->noteInferConventions();
 
         $this->outro();
@@ -146,6 +149,29 @@ class InstallCommand extends Command
         }
 
         $this->storeConfig();
+    }
+
+    protected function reportRenderFailures(): void
+    {
+        $renderFailures = app(RenderFailures::class);
+
+        if ($renderFailures->isEmpty()) {
+            return;
+        }
+
+        $paths = $renderFailures->paths();
+        $packages = $renderFailures->packages();
+
+        $this->newLine();
+        $this->warn(sprintf('Skipped %d %s that could not be rendered:', count($paths), Str::plural('file', $paths)));
+
+        foreach ($paths as $path) {
+            $this->line('  - '.str_replace(base_path().DIRECTORY_SEPARATOR, '', $path));
+        }
+
+        if ($packages !== []) {
+            $this->warn('These ship Boost files built for an older Boost version, so Boost used its own where it had them. Update them with: composer update '.implode(' ', $packages));
+        }
     }
 
     protected function noteInferConventions(): void

--- a/src/Install/GuidelineComposer.php
+++ b/src/Install/GuidelineComposer.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Str;
 use Laravel\Boost\Concerns\RendersBladeGuidelines;
 use Laravel\Boost\Install\Concerns\DiscoverPackagePaths;
 use Laravel\Boost\Support\Composer;
+use Laravel\Boost\Support\RenderFailures;
 use Laravel\Roster\Package;
 use Laravel\Roster\ProjectManager;
 use Symfony\Component\Finder\Exception\DirectoryNotFoundException;
@@ -239,9 +240,18 @@ class GuidelineComposer
     {
         if ($vendorPath !== null) {
             foreach (['.blade.php', '.md'] as $ext) {
-                if (file_exists($vendorPath.$ext)) {
-                    return $this->guideline($vendorPath.$ext, false, $guidelineKey);
+                if (! file_exists($vendorPath.$ext)) {
+                    continue;
                 }
+
+                $guideline = $this->guideline($vendorPath.$ext, false, $guidelineKey);
+
+                // A vendor guideline written for an older Boost/Roster API fails to render; use ours instead.
+                if (! app(RenderFailures::class)->failedFor($guideline['path'] ?? $vendorPath.$ext)) {
+                    return $guideline;
+                }
+
+                break;
             }
         }
 

--- a/src/Support/RenderFailures.php
+++ b/src/Support/RenderFailures.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Support;
+
+use Illuminate\Support\Str;
+
+class RenderFailures
+{
+    /** @var array<string, ?string> */
+    protected array $failures = [];
+
+    public function record(string $path): void
+    {
+        $this->failures[$path] = $this->packageFromPath($path);
+    }
+
+    public function failedFor(string $path): bool
+    {
+        return array_key_exists($path, $this->failures);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function paths(): array
+    {
+        return array_keys($this->failures);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function packages(): array
+    {
+        return collect($this->failures)
+            ->filter()
+            ->unique()
+            ->sort()
+            ->values()
+            ->all();
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->failures === [];
+    }
+
+    public function flush(): void
+    {
+        $this->failures = [];
+    }
+
+    private function packageFromPath(string $path): ?string
+    {
+        $normalized = str_replace('\\', '/', $path);
+
+        if (! str_contains($normalized, '/vendor/')) {
+            return null;
+        }
+
+        $segments = explode('/', Str::afterLast($normalized, '/vendor/'));
+
+        return count($segments) >= 3 ? $segments[0].'/'.$segments[1] : null;
+    }
+}

--- a/tests/Feature/Console/InstallCommandRenderFailuresTest.php
+++ b/tests/Feature/Console/InstallCommandRenderFailuresTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Console\Enums\Theme;
+use Laravel\Boost\Console\InstallCommand;
+use Laravel\Boost\Install\AgentsDetector;
+use Laravel\Boost\Install\Cloud;
+use Laravel\Boost\Install\Nightwatch;
+use Laravel\Boost\Install\Sail;
+use Laravel\Boost\Support\Config;
+use Laravel\Boost\Support\RenderFailures;
+use Laravel\Prompts\Terminal;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+beforeEach(function (): void {
+    (new Config)->flush();
+    config(['boost.enforce_tests' => false]);
+});
+
+afterEach(function (): void {
+    (new Config)->flush();
+    Mockery::close();
+});
+
+function runInstallCommandWithFailures(array $failedPaths): string
+{
+    $nightwatch = Mockery::mock(Nightwatch::class);
+    $nightwatch->shouldReceive('isInstalled')->andReturn(false);
+
+    $sail = Mockery::mock(Sail::class);
+    $sail->shouldReceive('isInstalled')->andReturn(false);
+    $sail->shouldReceive('isActive')->andReturn(false);
+
+    $terminal = Mockery::mock(Terminal::class);
+    $terminal->shouldReceive('initDimensions');
+
+    $detector = Mockery::mock(AgentsDetector::class);
+    $detector->shouldReceive('getAgents')->andReturn(app(AgentsDetector::class)->getAgents());
+    $detector->shouldReceive('discoverSystemInstalledAgents')->andReturn([]);
+    $detector->shouldReceive('discoverProjectInstalledAgents')->andReturn([]);
+
+    $command = new class($detector, Mockery::mock(Cloud::class), new Config, $nightwatch, $sail, $terminal) extends InstallCommand
+    {
+        public array $failedPaths = [];
+
+        protected function displayBoostHeader(string $featureName, string $projectName, ?Theme $theme = null): void {}
+
+        protected function performInstallation(): void
+        {
+            foreach ($this->failedPaths as $path) {
+                app(RenderFailures::class)->record($path);
+            }
+        }
+
+        protected function outro(): void {}
+    };
+
+    $command->failedPaths = $failedPaths;
+    $command->setLaravel(app());
+
+    $input = new ArrayInput(['--guidelines' => true], $command->getDefinition());
+    $input->setInteractive(false);
+
+    $output = new BufferedOutput;
+    $command->run($input, $output);
+
+    return $output->fetch();
+}
+
+it('tells the user which packages to update when their guidelines could not be rendered', function (): void {
+    $output = runInstallCommandWithFailures([
+        base_path('vendor/inertiajs/inertia-laravel/resources/boost/guidelines/core.blade.php'),
+        base_path('vendor/laravel/wayfinder/resources/boost/guidelines/core.blade.php'),
+    ]);
+
+    expect($output)
+        ->toContain('Skipped 2 files that could not be rendered')
+        ->toContain('vendor/inertiajs/inertia-laravel/resources/boost/guidelines/core.blade.php')
+        ->toContain('composer update inertiajs/inertia-laravel laravel/wayfinder');
+})->skipOnWindows();
+
+it('does not suggest a package update for files outside the vendor directory', function (): void {
+    $output = runInstallCommandWithFailures(['/app/.ai/guidelines/custom.blade.php']);
+
+    expect($output)
+        ->toContain('Skipped 1 file that could not be rendered')
+        ->toContain('.ai/guidelines/custom.blade.php')
+        ->not->toContain('composer update');
+})->skipOnWindows();
+
+it('stays quiet when everything rendered', function (): void {
+    expect(runInstallCommandWithFailures([]))->not->toContain('could not be rendered');
+})->skipOnWindows();

--- a/tests/Feature/Install/GuidelineComposerTest.php
+++ b/tests/Feature/Install/GuidelineComposerTest.php
@@ -9,6 +9,7 @@ use Laravel\Boost\Install\GuidelineConfig;
 use Laravel\Boost\Install\Herd;
 use Laravel\Boost\Support\Composer;
 use Laravel\Boost\Support\Npm;
+use Laravel\Boost\Support\RenderFailures;
 use Laravel\Roster\Enums\JsPackageManager;
 use Laravel\Roster\Package;
 use Laravel\Roster\PackageCollection;
@@ -1265,4 +1266,52 @@ test('php core guideline adapts enum naming guidance to the application enums', 
     'TitleCase keys' => [['App\Enums\FlashKey' => 'FlashKey.php'], 'Enums/FlashKey.php', 'Use TitleCase for Enum keys', 'Follow existing application Enum naming conventions'],
     'TitleCase keys with uppercase values' => [['App\Enums\Currency' => 'Currency.php'], 'Enums/Currency.php', 'Use TitleCase for Enum keys', 'Follow existing application Enum naming conventions'],
     'uppercase keys' => [['App\Enums\CountryCode' => 'CountryCode.php'], 'Enums/CountryCode.php', 'Follow existing application Enum naming conventions', 'Use TitleCase for Enum keys'],
+]);
+
+test('does not fail when a vendor guideline targets an API that no longer exists', function (): void {
+    config(['boost.rules.enabled' => false]);
+
+    $packages = new PackageCollection([
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('pestphp/pest', '3.0.0'),
+    ]);
+
+    mockProjectPackages($this->project, $packages);
+
+    $vendorFixture = realpath(fixture('vendor-guidelines/incompatible'));
+
+    $composer = Mockery::mock(GuidelineComposer::class, [$this->project, $this->herd])
+        ->makePartial()
+        ->shouldAllowMockingProtectedMethods();
+    $composer->shouldReceive('resolveFirstPartyBoostPath')
+        ->andReturnUsing(fn (Package $package, string $subpath): ?string => $package->name() === 'pestphp/pest' ? $vendorFixture : null);
+
+    $guidelines = $composer->compose();
+
+    expect($guidelines)
+        ->toContain('=== pest/core rules ===')
+        ->not->toContain('Vendor Core Guideline');
+
+    expect(app(RenderFailures::class)->paths())->toBe([$vendorFixture.DIRECTORY_SEPARATOR.'core.blade.php']);
+});
+
+test('inertia core guideline matches the installed major version', function (string $version, string $expected, string $notExpected): void {
+    config(['boost.rules.enabled' => false]);
+
+    $packages = new PackageCollection([
+        rosterPackage('laravel/framework', '11.0.0'),
+        rosterPackage('inertiajs/inertia-laravel', $version),
+    ]);
+
+    mockProjectPackages($this->project, $packages);
+
+    $guidelines = $this->composer->compose();
+
+    expect($guidelines)
+        ->toContain($expected)
+        ->not->toContain($notExpected);
+})->with([
+    'v1' => ['1.3.0', '# Inertia v1', '# Inertia v2'],
+    'v2' => ['2.1.0', '# Inertia v2', '# Inertia v3'],
+    'v3' => ['3.1.1', '# Inertia v3', '# Inertia v2'],
 ]);

--- a/tests/Fixtures/vendor-guidelines/incompatible/core.blade.php
+++ b/tests/Fixtures/vendor-guidelines/incompatible/core.blade.php
@@ -1,0 +1,5 @@
+# Vendor Core Guideline
+
+@if($assist->hasPackage(\Laravel\Roster\Enums\Packages::INERTIA_REACT))
+- This vendor guideline targets an API that no longer exists.
+@endif

--- a/tests/Unit/Support/RenderFailuresTest.php
+++ b/tests/Unit/Support/RenderFailuresTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Boost\Support\RenderFailures;
+
+test('records a failure against the vendor package that shipped the file', function (): void {
+    $failures = new RenderFailures;
+    $path = '/app/vendor/inertiajs/inertia-laravel/resources/boost/guidelines/core.blade.php';
+
+    $failures->record($path);
+
+    expect($failures->isEmpty())->toBeFalse()
+        ->and($failures->failedFor($path))->toBeTrue()
+        ->and($failures->failedFor('/app/vendor/laravel/wayfinder/resources/boost/guidelines/core.blade.php'))->toBeFalse()
+        ->and($failures->packages())->toBe(['inertiajs/inertia-laravel']);
+});
+
+test('does not attribute a package to files outside the vendor directory', function (): void {
+    $failures = new RenderFailures;
+
+    $failures->record('/app/.ai/guidelines/custom.blade.php');
+
+    expect($failures->packages())->toBe([])
+        ->and($failures->paths())->toBe(['/app/.ai/guidelines/custom.blade.php']);
+});
+
+test('records each file once and reports every failing package', function (): void {
+    $failures = new RenderFailures;
+    $path = '/app/vendor/laravel/wayfinder/resources/boost/guidelines/core.blade.php';
+
+    $failures->record($path);
+    $failures->record($path);
+    $failures->record('/app/vendor/inertiajs/inertia-laravel/resources/boost/guidelines/core.blade.php');
+
+    expect($failures->paths())->toHaveCount(2)
+        ->and($failures->packages())->toBe(['inertiajs/inertia-laravel', 'laravel/wayfinder']);
+
+    $failures->flush();
+
+    expect($failures->isEmpty())->toBeTrue()
+        ->and($failures->paths())->toBe([]);
+});
+
+test('handles windows separators when attributing a package', function (): void {
+    $failures = new RenderFailures;
+
+    $failures->record('C:\\app\\vendor\\laravel\\wayfinder\\resources\\boost\\guidelines\\core.blade.php');
+
+    expect($failures->packages())->toBe(['laravel/wayfinder']);
+});


### PR DESCRIPTION
Packages ship their own guidelines and skills under `resources/boost`, and Boost renders those Blade files at install time. If one of them targets an API that Boost has since changed, the whole install dies:

```
Illuminate\View\ViewException
Class "Laravel\Roster\Enums\Packages" not found (View: .../storage/framework/views/32976a5f.php)
at storage/framework/views/9a6ce17d.php:6
```

`inertiajs/inertia-laravel` and `laravel/wayfinder` both still call the Roster enum that #891 moved to `PackageRegistry` (wayfinder's skill also uses `$assist->roster`, now `$assist->project`). Upstream main isn't fixed yet, so `composer update` doesn't help. Either way, one stale vendor file taking down the entire install feels wrong.

Now a file that fails to render is skipped, Boost falls back to its own bundled copy of that guideline when it has one, and the user gets told at the end of the install:

```
Skipped 2 files that could not be rendered:
  - vendor/inertiajs/inertia-laravel/resources/boost/guidelines/core.blade.php
  - vendor/laravel/wayfinder/resources/boost/skills/wayfinder-development/SKILL.blade.php
These ship Boost files built for an older Boost version, so Boost used its own where it had them.
Update them with: composer update inertiajs/inertia-laravel laravel/wayfinder
```

Skills already got the fallback for free, since one that fails to parse drops out of the merge and the `.ai` copy stays.

One gap that fallback exposed: the bundled `.ai/inertia-laravel/core.blade.php` only knew v1 and v2, while the package ships v3 guidance. Falling back would have quietly downgraded anyone on Inertia 3, so this pulls the v3 section in behind a `gte('3.0.0')` branch. Wayfinder needed nothing, its bundled copies are already identical to upstream apart from the corrected API.

Also adds an UPGRADE.md section covering the authoring API changes from #891 (`Packages` enum to `PackageRegistry`, `$assist->roster` to `$assist->project`, `usesVersion()` to `uses()`), since package authors hitting this crash have nowhere to look right now. I guessed at the `2.5 From 2.4` heading, rename it to whatever the release ends up being.

I deliberately didn't shim the removed enum. Declaring a class in Roster's namespace to keep old templates rendering means owning a removed API forever, and it only covers this one break. The real fix belongs in those two packages, patches for both are ready but can't land until a release ships `PackageRegistry`.

Verified against the real broken files in a local project: both crashes become skips, and Inertia v3 plus the Wayfinder guideline and skill still land. Tests added for the skip, the fallback, the install warning, and the Inertia version branches.