### PR TITLE
Correct the Inertia CSRF guidance in the best practices skill

### DIFF
--- a/.ai/laravel/skill/laravel-best-practices/rules/security.md
+++ b/.ai/laravel/skill/laravel-best-practices/rules/security.md
@@ -90,7 +90,7 @@ Correct:
 
 ## CSRF Protection
 
-Include `@csrf` in all POST/PUT/DELETE Blade forms. In Inertia apps, the `@csrf` directive is automatically applied.
+Include `@csrf` in all POST/PUT/DELETE Blade forms. Inertia doesn't use `@csrf`; its HTTP client sends the `XSRF-TOKEN` cookie back as the `X-XSRF-TOKEN` header, which Laravel accepts in place of the `_token` field.
 
 Incorrect:
 ```blade


### PR DESCRIPTION
`security.md` currently tells agents that "in Inertia apps, the `@csrf` directive is automatically applied". It isn't. `@csrf` is a Blade directive that compiles to a hidden `_token` input, and an Inertia page is a Vue/React/Svelte component, so there's no Blade form for it to be applied to.

What actually happens is in `@inertiajs/core`'s HTTP client, which reads the `XSRF-TOKEN` cookie and sends it back as the `X-XSRF-TOKEN` header ([xhrHttpClient.ts](https://github.com/inertiajs/inertia/blob/master/packages/core/src/xhrHttpClient.ts)); Laravel's `PreventRequestForgery` accepts that header in place of `_token`. The old wording was "Not needed in Inertia", which was terse but not wrong; #764 replaced it with the current sentence.

Fixes #912