### PR TITLE
Reject Blade templates from remote skills

### DIFF
--- a/src/Console/AddSkillCommand.php
+++ b/src/Console/AddSkillCommand.php
@@ -100,7 +100,7 @@ class AddSkillCommand extends Command
         }
 
         if ($this->availableSkills->isEmpty()) {
-            $this->error('No valid skills are found in the repository.');
+            $this->error('No valid skills are found in the repository. Remote skills must provide a SKILL.md; SKILL.blade.php is not supported.');
 
             return false;
         }

--- a/src/Skills/Remote/GitHubSkillProvider.php
+++ b/src/Skills/Remote/GitHubSkillProvider.php
@@ -38,7 +38,7 @@ class GitHubSkillProvider
         $basePath = $this->repository->path;
 
         $skillMarkers = collect($tree['tree'])
-            ->filter(fn (array $item): bool => $item['type'] === 'blob' && in_array(basename((string) $item['path']), ['SKILL.md', 'SKILL.blade.php'], true));
+            ->filter(fn (array $item): bool => $item['type'] === 'blob' && basename((string) $item['path']) === 'SKILL.md');
 
         if ($basePath !== '') {
             $prefix = $basePath.'/';
@@ -73,11 +73,18 @@ class GitHubSkillProvider
             return false;
         }
 
+        $files = $skillFiles
+            ->filter(fn (array $item): bool => $item['type'] === 'blob')
+            ->reject(fn (array $item): bool => str_ends_with((string) $item['path'], '.blade.php'));
+
+        if (! $files->contains(fn (array $item): bool => basename((string) $item['path']) === 'SKILL.md')) {
+            return false;
+        }
+
         if (! $this->ensureDirectoryExists($targetPath)) {
             return false;
         }
 
-        $files = $skillFiles->filter(fn (array $item): bool => $item['type'] === 'blob');
         $directories = $skillFiles->filter(fn (array $item): bool => $item['type'] === 'tree');
 
         foreach ($directories as $dir) {

--- a/src/Skills/Remote/GitHubSkillProvider.php
+++ b/src/Skills/Remote/GitHubSkillProvider.php
@@ -75,7 +75,7 @@ class GitHubSkillProvider
 
         $files = $skillFiles
             ->filter(fn (array $item): bool => $item['type'] === 'blob')
-            ->reject(fn (array $item): bool => str_ends_with((string) $item['path'], '.blade.php'));
+            ->reject(fn (array $item): bool => preg_match('/\.(php\d?|phar|phtml)$/i', (string) $item['path']) === 1);
 
         if (! $files->contains(fn (array $item): bool => basename((string) $item['path']) === 'SKILL.md')) {
             return false;
@@ -83,17 +83,6 @@ class GitHubSkillProvider
 
         if (! $this->ensureDirectoryExists($targetPath)) {
             return false;
-        }
-
-        $directories = $skillFiles->filter(fn (array $item): bool => $item['type'] === 'tree');
-
-        foreach ($directories as $dir) {
-            $relativePath = $this->getRelativePath($dir['path'], $skill->path);
-            $localPath = $targetPath.'/'.$relativePath;
-
-            if (! $this->ensureDirectoryExists($localPath)) {
-                return false;
-            }
         }
 
         return $this->downloadFiles($files->toArray(), $targetPath, $skill->path);

--- a/tests/Feature/Console/AddSkillCommandTest.php
+++ b/tests/Feature/Console/AddSkillCommandTest.php
@@ -54,6 +54,24 @@ it('shows error when no skills found', function (): void {
         ->expectsOutputToContain('No valid skills are found');
 });
 
+it('does not offer Blade-only skills from remote repositories', function (): void {
+    Http::fake([
+        'api.github.com/repos/owner/repo' => Http::response(['default_branch' => 'main']),
+        'api.github.com/repos/owner/repo/git/trees/main?recursive=1' => Http::response([
+            'sha' => 'abc123',
+            'tree' => [
+                ['path' => 'remote-skill', 'type' => 'tree', 'sha' => 'def'],
+                ['path' => 'remote-skill/SKILL.blade.php', 'type' => 'blob', 'sha' => 'ghi', 'size' => 123],
+            ],
+            'truncated' => false,
+        ]),
+    ]);
+
+    $this->artisan('boost:add-skill', ['repo' => 'owner/repo', '--list' => true])
+        ->assertFailed()
+        ->expectsOutputToContain('No valid skills are found');
+});
+
 it('shows error when api request fails', function (): void {
     Http::fake([
         'api.github.com/repos/owner/repo/git/trees/main?recursive=1' => Http::response(

--- a/tests/Unit/Skills/Remote/GitHubSkillProviderTest.php
+++ b/tests/Unit/Skills/Remote/GitHubSkillProviderTest.php
@@ -422,7 +422,7 @@ it('uses services.github.token for authentication when boost.github.token is not
     Http::assertSent(fn ($request): bool => $request->hasHeader('Authorization', 'Bearer gh-token-456'));
 });
 
-it('discovers skills with SKILL.blade.php marker', function (): void {
+it('only discovers Markdown skill markers from remote repositories', function (): void {
     Http::fake([
         ...fakeGitHubRepo(),
         ...fakeTreeResponse([
@@ -436,11 +436,48 @@ it('discovers skills with SKILL.blade.php marker', function (): void {
     $fetcher = new GitHubSkillProvider(new GitHubRepository('owner', 'repo'));
     $skills = $fetcher->discoverSkills();
 
-    expect($skills)->toHaveCount(2)
-        ->and($skills->has('skill-one'))->toBeTrue()
+    expect($skills)->toHaveCount(1)
+        ->and($skills->has('skill-one'))->toBeFalse()
         ->and($skills->has('skill-two'))->toBeTrue()
-        ->and($skills->get('skill-one')->name)->toBe('skill-one')
         ->and($skills->get('skill-two')->name)->toBe('skill-two');
+});
+
+it('does not download Blade templates from remote skills', function (): void {
+    $targetDir = sys_get_temp_dir().'/boost-test-'.uniqid();
+
+    Http::fake([
+        ...fakeGitHubRepo(),
+        ...fakeTreeResponse([
+            ['path' => 'skill-one', 'type' => 'tree', 'sha' => 'def'],
+            ['path' => 'skill-one/SKILL.md', 'type' => 'blob', 'sha' => 'ghi', 'size' => 123],
+            ['path' => 'skill-one/references', 'type' => 'tree', 'sha' => 'jkl'],
+            ['path' => 'skill-one/references/example.blade.php', 'type' => 'blob', 'sha' => 'mno', 'size' => 456],
+        ]),
+        'raw.githubusercontent.com/owner/repo/main/skill-one/SKILL.md' => Http::response('# SKILL Content'),
+        'raw.githubusercontent.com/owner/repo/main/skill-one/references/example.blade.php' => Http::response('template'),
+    ]);
+
+    $skill = new RemoteSkill(
+        name: 'skill-one',
+        repo: 'owner/repo',
+        path: 'skill-one'
+    );
+
+    try {
+        $fetcher = new GitHubSkillProvider(new GitHubRepository('owner', 'repo'));
+        $result = $fetcher->downloadSkill($skill, $targetDir);
+
+        expect($result)->toBeTrue()
+            ->and($targetDir.'/SKILL.md')->toBeFile()
+            ->and($targetDir.'/references/example.blade.php')->not->toBeFile();
+
+        Http::assertNotSent(fn ($request): bool => str_contains((string) $request->url(), '.blade.php'));
+    } finally {
+        @unlink($targetDir.'/references/example.blade.php');
+        @rmdir($targetDir.'/references');
+        @unlink($targetDir.'/SKILL.md');
+        @rmdir($targetDir);
+    }
 });
 
 it('discovers skills in wildcard paths like .ai/*/skills', function (): void {

--- a/tests/Unit/Skills/Remote/GitHubSkillProviderTest.php
+++ b/tests/Unit/Skills/Remote/GitHubSkillProviderTest.php
@@ -480,6 +480,35 @@ it('does not download Blade templates from remote skills', function (): void {
     }
 });
 
+it('does not download PHP files whatever their casing', function (): void {
+    $targetDir = sys_get_temp_dir().'/boost-test-'.uniqid();
+
+    Http::fake([
+        ...fakeGitHubRepo(),
+        ...fakeTreeResponse([
+            ['path' => 'skill-one', 'type' => 'tree', 'sha' => 'def'],
+            ['path' => 'skill-one/SKILL.md', 'type' => 'blob', 'sha' => 'ghi', 'size' => 123],
+            ['path' => 'skill-one/SKILL.Blade.php', 'type' => 'blob', 'sha' => 'jkl', 'size' => 456],
+            ['path' => 'skill-one/payload.PHP', 'type' => 'blob', 'sha' => 'mno', 'size' => 456],
+        ]),
+        'raw.githubusercontent.com/owner/repo/main/skill-one/SKILL.md' => Http::response('# SKILL Content'),
+    ]);
+
+    $skill = new RemoteSkill(name: 'skill-one', repo: 'owner/repo', path: 'skill-one');
+
+    try {
+        $fetcher = new GitHubSkillProvider(new GitHubRepository('owner', 'repo'));
+
+        expect($fetcher->downloadSkill($skill, $targetDir))->toBeTrue()
+            ->and($targetDir.'/SKILL.md')->toBeFile();
+
+        Http::assertNotSent(fn ($request): bool => str_contains(strtolower((string) $request->url()), '.php'));
+    } finally {
+        @unlink($targetDir.'/SKILL.md');
+        @rmdir($targetDir);
+    }
+});
+
 it('discovers skills in wildcard paths like .ai/*/skills', function (): void {
     Http::fake([
         ...fakeGitHubRepo(),


### PR DESCRIPTION
## Summary

- Accept `SKILL.md` as the remote skill entrypoint.
- Skip remote `*.blade.php` files before they can reach later Blade-render paths.
- Preserve support for explicitly local, user-authored Blade templates.

## Why

Remote repository content is not trusted application code. Keeping remote skills Markdown-only preserves the remote boundary as data rather than allowing template code to be installed and rendered later.

## Validation

- Added regressions for a Blade-only remote directory and a nested Blade file that must never be fetched or written.
- `GitHubSkillProviderTest`: 22 passed, 57 assertions.
- Focused `boost:add-skill --list` regression: 1 passed, 2 assertions.
- Pint and PHPStan pass.

## Compatibility

This only restricts newly downloaded remote skills. Existing local Blade templates remain supported. Previously downloaded remote Blade files cannot be reliably identified without provenance, so users should remove or replace any untrusted existing template with Markdown.

Closes #893
