### PR TITLE
Wrap lockForUpdate example in a transaction

### DIFF
--- a/.ai/laravel/skill/laravel-best-practices/rules/architecture.md
+++ b/.ai/laravel/skill/laravel-best-practices/rules/architecture.md
@@ -103,8 +103,12 @@ Cache::lock('order-processing-'.$order->id, 10)->block(5, function () use ($orde
     $order->process();
 });
 
-// Or at query level
-$product = Product::where('id', $id)->lockForUpdate()->first();
+// Or at query level, inside a transaction
+DB::transaction(function () use ($id) {
+    $product = Product::where('id', $id)->lockForUpdate()->first();
+
+    // Read and update the product while the lock is held...
+});
 ```
 
 ## Use `mb_*` String Functions


### PR DESCRIPTION
## What changed

- wrap the `lockForUpdate()` example in `DB::transaction()`
- keep the protected read and subsequent update work inside the transaction callback

## Why

A pessimistic row lock only protects the full operation when it remains active through the related reads and writes. The previous example ran the locking query by itself, so the lock could be released before the application performed the protected work.

## Validation

- `git diff --check`
- `php -l` on the updated PHP example

Partially addresses #895 (item 2).
