### PR TITLE
Skip package discovery prompt when run via composer script

### DIFF
--- a/src/Console/UpdateCommand.php
+++ b/src/Console/UpdateCommand.php
@@ -59,7 +59,7 @@ class UpdateCommand extends Command
             return;
         }
 
-        if (! $this->input->isInteractive()) {
+        if (! $this->input->isInteractive() || $this->runningAsComposerScript()) {
             return;
         }
 
@@ -88,5 +88,14 @@ class UpdateCommand extends Command
 
         return ThirdPartyPackage::discover()
             ->filter(fn (ThirdPartyPackage $pkg, string $name): bool => ! in_array($name, $configuredPackages, true));
+    }
+
+    /**
+     * Composer sets COMPOSER_DEV_MODE for the entire install/update run, including
+     * post-update-cmd scripts, so prompting there would block an unattended `composer update`.
+     */
+    protected function runningAsComposerScript(): bool
+    {
+        return getenv('COMPOSER_DEV_MODE') !== false;
     }
 }

--- a/tests/Feature/Console/UpdateCommandTest.php
+++ b/tests/Feature/Console/UpdateCommandTest.php
@@ -410,6 +410,35 @@ it('adds selected new packages to config during discovery', function (): void {
         ->and($config->getPackages())->toContain('vendor/awesome-pkg');
 })->skipOnWindows();
 
+it('skips new-package discovery prompt when running as a composer script', function (): void {
+    $config = new Config;
+    $config->setAgents(['claude_code']);
+    $config->setGuidelines(true);
+    $config->setPackages([]);
+
+    $newPackage = new ThirdPartyPackage('vendor/awesome-pkg', true, false);
+
+    Prompt::fake([]);
+
+    $command = Mockery::mock(UpdateCommand::class)
+        ->makePartial()
+        ->shouldAllowMockingProtectedMethods();
+    $command->shouldReceive('option')->with('no-discover')->andReturn(false);
+    $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('resolveNewPackages')->andReturn(collect(['vendor/awesome-pkg' => $newPackage]));
+    $command->shouldReceive('runningAsComposerScript')->andReturn(true);
+    $command->shouldReceive('callSilently')->andReturn(0);
+    $command->setLaravel($this->app);
+
+    $input = new ArrayInput([]);
+    $output = new OutputStyle($input, new BufferedOutput);
+    $command->setInput($input);
+    $command->setOutput($output);
+
+    expect($command->handle($config))->toBe(0)
+        ->and($config->getPackages())->toBe([]);
+})->skipOnWindows();
+
 it('skips skills when --ignore-skills flag is set even if skills are configured', function (): void {
     $config = new Config;
     $config->setAgents(['claude_code']);


### PR DESCRIPTION
A lot of people wire `boost:update` into `composer.json`'s `post-update-cmd`:

```json
"post-update-cmd": [
    "@php artisan boost:update --ansi"
]
```

Since #882 made third-party guideline discovery the default, this means every `composer update` run in a terminal pops the "New packages with guidelines/skills discovered!" multiselect and blocks waiting for input, even though nobody's sitting there to answer it. `isInteractive()` alone can't catch this because the script still inherits a real TTY from the parent `composer update`.

This checks for `COMPOSER_DEV_MODE`, which Composer sets in the environment for the whole duration of an `install`/`update` run (including any `post-update-cmd` scripts), and skips the discovery prompt when it's present. 