### PR TITLE
Ignore the connection table prefix when reading table details

### DIFF
--- a/src/Mcp/Tools/DatabaseSchema.php
+++ b/src/Mcp/Tools/DatabaseSchema.php
@@ -152,18 +152,21 @@ class DatabaseSchema extends Tool
     protected function getAllTableColumnTypes(?string $connection, string $filter = ''): array
     {
         $tables = [];
+        $allTables = $this->getAllTables($connection);
 
-        foreach ($this->getAllTables($connection) as $table) {
-            $tableName = is_object($table) ? $table->name : ($table['name'] ?? '');
+        DB::connection($connection)->withoutTablePrefix(function () use ($connection, $allTables, $filter, &$tables): void {
+            foreach ($allTables as $table) {
+                $tableName = is_object($table) ? $table->name : ($table['name'] ?? '');
 
-            if ($filter !== '' && ! str_contains(strtolower($tableName), strtolower($filter))) {
-                continue;
+                if ($filter !== '' && ! str_contains(strtolower($tableName), strtolower($filter))) {
+                    continue;
+                }
+
+                $tables[$tableName] = collect(Schema::connection($connection)->getColumns($tableName))
+                    ->pluck('type', 'name')
+                    ->all();
             }
-
-            $tables[$tableName] = collect(Schema::connection($connection)->getColumns($tableName))
-                ->pluck('type', 'name')
-                ->all();
-        }
+        });
 
         return $tables;
     }
@@ -181,9 +184,16 @@ class DatabaseSchema extends Tool
         $driver = SchemaDriverFactory::make($connection);
 
         try {
-            $columns = $this->getTableColumns($connection, $tableName, $includeColumnDetails);
-            $indexes = $this->getTableIndexes($connection, $tableName);
-            $foreignKeys = $this->getTableForeignKeys($connection, $tableName);
+            $columns = [];
+            $indexes = [];
+            $foreignKeys = [];
+
+            DB::connection($connection)->withoutTablePrefix(function () use ($connection, $tableName, $includeColumnDetails, &$columns, &$indexes, &$foreignKeys): void {
+                $columns = $this->getTableColumns($connection, $tableName, $includeColumnDetails);
+                $indexes = $this->getTableIndexes($connection, $tableName);
+                $foreignKeys = $this->getTableForeignKeys($connection, $tableName);
+            });
+
             $triggers = $driver->getTriggers($tableName);
             $checkConstraints = $driver->getCheckConstraints($tableName);
 

--- a/src/Mcp/Tools/DatabaseSchema.php
+++ b/src/Mcp/Tools/DatabaseSchema.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Mcp\Tools;
 
+use Closure;
 use Exception;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\JsonSchema\Types\Type;
@@ -12,6 +13,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
 use Laravel\Boost\Mcp\Tools\DatabaseSchema\SchemaDriverFactory;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
@@ -100,27 +102,66 @@ class DatabaseSchema extends Tool
     ): array {
         $result = [
             'engine' => DB::connection($connection)->getDriverName(),
-            'tables' => $summary
+            'tables' => $this->withoutTablePrefix($connection, fn (): array => $summary
                 ? $this->getAllTableColumnTypes($connection, $filter)
-                : $this->getAllTablesStructure($connection, $filter, $includeColumnDetails),
+                : $this->getAllTablesStructure($connection, $filter, $includeColumnDetails)),
         ];
 
-        if ($summary) {
+        if (! $summary) {
+            $driver = SchemaDriverFactory::make($connection);
+
+            if ($includeViews) {
+                $result['views'] = $driver->getViews();
+            }
+
+            if ($includeRoutines) {
+                $result['routines'] = [
+                    'stored_procedures' => $driver->getStoredProcedures(),
+                    'functions' => $driver->getFunctions(),
+                    'sequences' => $driver->getSequences(),
+                ];
+            }
+        }
+
+        return $this->stripTablePrefix($connection, $result);
+    }
+
+    /**
+     * Report names as the application writes them, since Eloquent and the query builder re-apply the prefix.
+     *
+     * @param  array<string, mixed>  $result
+     * @return array<string, mixed>
+     */
+    protected function stripTablePrefix(?string $connection, array $result): array
+    {
+        $prefix = DB::connection($connection)->getTablePrefix();
+
+        if ($prefix === '') {
             return $result;
         }
 
-        $driver = SchemaDriverFactory::make($connection);
+        $strip = fn (string $name): string => Str::replaceStart($prefix, '', $name);
 
-        if ($includeViews) {
-            $result['views'] = $driver->getViews();
+        $tables = [];
+
+        foreach ($result['tables'] as $name => $structure) {
+            if (is_array($structure['foreign_keys'] ?? null)) {
+                foreach ($structure['foreign_keys'] as $index => $foreignKey) {
+                    $structure['foreign_keys'][$index]['foreign_table'] = $strip($foreignKey['foreign_table']);
+                }
+            }
+
+            $tables[$strip((string) $name)] = $structure;
         }
 
-        if ($includeRoutines) {
-            $result['routines'] = [
-                'stored_procedures' => $driver->getStoredProcedures(),
-                'functions' => $driver->getFunctions(),
-                'sequences' => $driver->getSequences(),
-            ];
+        $result['tables'] = $tables;
+
+        foreach ($result['views'] ?? [] as $key => $view) {
+            foreach (['name', 'viewname'] as $field) {
+                if (is_string($name = data_get($view, $field))) {
+                    data_set($result['views'][$key], $field, $strip($name));
+                }
+            }
         }
 
         return $result;
@@ -152,23 +193,46 @@ class DatabaseSchema extends Tool
     protected function getAllTableColumnTypes(?string $connection, string $filter = ''): array
     {
         $tables = [];
-        $allTables = $this->getAllTables($connection);
 
-        DB::connection($connection)->withoutTablePrefix(function () use ($connection, $allTables, $filter, &$tables): void {
-            foreach ($allTables as $table) {
-                $tableName = is_object($table) ? $table->name : ($table['name'] ?? '');
+        foreach ($this->getAllTables($connection) as $table) {
+            $tableName = is_object($table) ? $table->name : ($table['name'] ?? '');
 
-                if ($filter !== '' && ! str_contains(strtolower($tableName), strtolower($filter))) {
-                    continue;
-                }
-
-                $tables[$tableName] = collect(Schema::connection($connection)->getColumns($tableName))
-                    ->pluck('type', 'name')
-                    ->all();
+            if ($filter !== '' && ! str_contains(strtolower($tableName), strtolower($filter))) {
+                continue;
             }
-        });
+
+            $tables[$tableName] = collect(Schema::connection($connection)->getColumns($tableName))
+                ->pluck('type', 'name')
+                ->all();
+        }
 
         return $tables;
+    }
+
+    /**
+     * Schema drivers read the catalog, so table names arrive with the connection prefix already applied.
+     *
+     * @template TReturn
+     *
+     * @param  Closure(): TReturn  $callback
+     * @return TReturn
+     */
+    protected function withoutTablePrefix(?string $connection, Closure $callback): mixed
+    {
+        $db = DB::connection($connection);
+        $prefix = $db->getTablePrefix();
+
+        if ($prefix === '') {
+            return $callback();
+        }
+
+        $db->setTablePrefix('');
+
+        try {
+            return $callback();
+        } finally {
+            $db->setTablePrefix($prefix);
+        }
     }
 
     /**
@@ -184,16 +248,9 @@ class DatabaseSchema extends Tool
         $driver = SchemaDriverFactory::make($connection);
 
         try {
-            $columns = [];
-            $indexes = [];
-            $foreignKeys = [];
-
-            DB::connection($connection)->withoutTablePrefix(function () use ($connection, $tableName, $includeColumnDetails, &$columns, &$indexes, &$foreignKeys): void {
-                $columns = $this->getTableColumns($connection, $tableName, $includeColumnDetails);
-                $indexes = $this->getTableIndexes($connection, $tableName);
-                $foreignKeys = $this->getTableForeignKeys($connection, $tableName);
-            });
-
+            $columns = $this->getTableColumns($connection, $tableName, $includeColumnDetails);
+            $indexes = $this->getTableIndexes($connection, $tableName);
+            $foreignKeys = $this->getTableForeignKeys($connection, $tableName);
             $triggers = $driver->getTriggers($tableName);
             $checkConstraints = $driver->getCheckConstraints($tableName);
 

--- a/tests/Feature/Mcp/Tools/DatabaseSchemaTest.php
+++ b/tests/Feature/Mcp/Tools/DatabaseSchemaTest.php
@@ -207,3 +207,77 @@ test('it filters tables in summary mode', function (): void {
                 ->and($schemaArray['tables']['users']['email'])->toContain('varchar');
         });
 });
+
+test('it returns table details on a connection with a table prefix', function (): void {
+    config()->set('database.connections.testing.prefix', 'boost_');
+    DB::purge('testing');
+
+    Schema::create('teams', function (Blueprint $table): void {
+        $table->id();
+    });
+
+    Schema::create('users', function (Blueprint $table): void {
+        $table->id();
+        $table->string('email')->index();
+        $table->foreignId('team_id')->constrained('teams');
+    });
+
+    $tool = new DatabaseSchema;
+    $response = $tool->handle(new Request(['filter' => 'user']));
+
+    expect($response)->isToolResult()
+        ->toolHasNoError()
+        ->toolJsonContent(function (array $schemaArray): void {
+            expect($schemaArray['tables'])->toHaveKey('boost_users');
+
+            $userTable = $schemaArray['tables']['boost_users'];
+            expect($userTable['columns'])->toHaveKeys(['id', 'email', 'team_id'])
+                ->and($userTable['columns']['email']['type'])->toContain('varchar')
+                ->and($userTable['indexes'])->not->toBeEmpty()
+                ->and($userTable['foreign_keys'])->not->toBeEmpty();
+        });
+});
+
+test('it returns column types on a connection with a table prefix in summary mode', function (): void {
+    config()->set('database.connections.testing.prefix', 'boost_');
+    DB::purge('testing');
+
+    Schema::create('users', function (Blueprint $table): void {
+        $table->id();
+        $table->string('email');
+    });
+
+    $tool = new DatabaseSchema;
+    $response = $tool->handle(new Request(['summary' => true, 'filter' => 'user']));
+
+    expect($response)->isToolResult()
+        ->toolHasNoError()
+        ->toolJsonContent(function (array $schemaArray): void {
+            expect($schemaArray['tables'])->toHaveKey('boost_users')
+                ->and($schemaArray['tables']['boost_users'])->toHaveKeys(['id', 'email'])
+                ->and($schemaArray['tables']['boost_users']['email'])->toContain('varchar');
+        });
+});
+
+test('it returns table details for tables that do not carry the connection prefix', function (): void {
+    config()->set('database.connections.testing.prefix', 'boost_');
+    DB::purge('testing');
+
+    Schema::create('users', function (Blueprint $table): void {
+        $table->id();
+        $table->string('email');
+    });
+
+    DB::statement('create table users (legacy_column varchar(255))');
+
+    $tool = new DatabaseSchema;
+    $response = $tool->handle(new Request(['filter' => 'user']));
+
+    expect($response)->isToolResult()
+        ->toolHasNoError()
+        ->toolJsonContent(function (array $schemaArray): void {
+            expect($schemaArray['tables']['users']['columns'])->toHaveKey('legacy_column')
+                ->and($schemaArray['tables']['users']['columns'])->not->toHaveKey('email')
+                ->and($schemaArray['tables']['boost_users']['columns'])->toHaveKeys(['id', 'email']);
+        });
+});

--- a/tests/Feature/Mcp/Tools/DatabaseSchemaTest.php
+++ b/tests/Feature/Mcp/Tools/DatabaseSchemaTest.php
@@ -228,9 +228,9 @@ test('it returns table details on a connection with a table prefix', function ()
     expect($response)->isToolResult()
         ->toolHasNoError()
         ->toolJsonContent(function (array $schemaArray): void {
-            expect($schemaArray['tables'])->toHaveKey('boost_users');
+            expect($schemaArray['tables'])->toHaveKey('users');
 
-            $userTable = $schemaArray['tables']['boost_users'];
+            $userTable = $schemaArray['tables']['users'];
             expect($userTable['columns'])->toHaveKeys(['id', 'email', 'team_id'])
                 ->and($userTable['columns']['email']['type'])->toContain('varchar')
                 ->and($userTable['indexes'])->not->toBeEmpty()
@@ -253,10 +253,39 @@ test('it returns column types on a connection with a table prefix in summary mod
     expect($response)->isToolResult()
         ->toolHasNoError()
         ->toolJsonContent(function (array $schemaArray): void {
-            expect($schemaArray['tables'])->toHaveKey('boost_users')
-                ->and($schemaArray['tables']['boost_users'])->toHaveKeys(['id', 'email'])
-                ->and($schemaArray['tables']['boost_users']['email'])->toContain('varchar');
+            expect($schemaArray['tables'])->toHaveKey('users')
+                ->and($schemaArray['tables']['users'])->toHaveKeys(['id', 'email'])
+                ->and($schemaArray['tables']['users']['email'])->toContain('varchar');
         });
+});
+
+test('it restores the connection table prefix after reading the schema', function (): void {
+    config()->set('database.connections.testing.prefix', 'boost_');
+    DB::purge('testing');
+
+    Schema::create('users', function (Blueprint $table): void {
+        $table->id();
+    });
+
+    (new DatabaseSchema)->handle(new Request(['filter' => 'user']));
+
+    expect(DB::connection('testing')->getTablePrefix())->toBe('boost_');
+});
+
+test('it restores the connection table prefix when reading the schema fails', function (): void {
+    config()->set('database.connections.testing.prefix', 'boost_');
+    DB::purge('testing');
+
+    $tool = new class extends DatabaseSchema
+    {
+        protected function getAllTables(?string $connection): array
+        {
+            throw new RuntimeException('catalog unavailable');
+        }
+    };
+
+    expect(fn (): mixed => $tool->handle(new Request))->toThrow(RuntimeException::class)
+        ->and(DB::connection('testing')->getTablePrefix())->toBe('boost_');
 });
 
 test('it returns table details for tables that do not carry the connection prefix', function (): void {
@@ -268,16 +297,78 @@ test('it returns table details for tables that do not carry the connection prefi
         $table->string('email');
     });
 
-    DB::statement('create table users (legacy_column varchar(255))');
+    DB::statement('create table legacy_audit (legacy_column varchar(255))');
 
     $tool = new DatabaseSchema;
-    $response = $tool->handle(new Request(['filter' => 'user']));
+    $response = $tool->handle(new Request);
 
     expect($response)->isToolResult()
         ->toolHasNoError()
         ->toolJsonContent(function (array $schemaArray): void {
-            expect($schemaArray['tables']['users']['columns'])->toHaveKey('legacy_column')
-                ->and($schemaArray['tables']['users']['columns'])->not->toHaveKey('email')
-                ->and($schemaArray['tables']['boost_users']['columns'])->toHaveKeys(['id', 'email']);
+            expect($schemaArray['tables']['legacy_audit']['columns'])->toHaveKey('legacy_column')
+                ->and($schemaArray['tables']['users']['columns'])->toHaveKeys(['id', 'email']);
+        });
+});
+
+test('it strips the prefix from foreign key targets and view names', function (): void {
+    config()->set('database.connections.testing.prefix', 'boost_');
+    DB::purge('testing');
+
+    Schema::create('teams', function (Blueprint $table): void {
+        $table->id();
+    });
+
+    Schema::create('users', function (Blueprint $table): void {
+        $table->id();
+        $table->foreignId('team_id')->constrained('teams');
+    });
+
+    DB::statement('create view boost_active_users as select id from boost_users');
+
+    $tool = new DatabaseSchema;
+    $response = $tool->handle(new Request(['include_views' => true, 'filter' => 'user']));
+
+    expect($response)->isToolResult()
+        ->toolHasNoError()
+        ->toolJsonContent(function (array $schemaArray): void {
+            expect($schemaArray['tables']['users']['foreign_keys'][0]['foreign_table'])->toBe('teams')
+                ->and(collect($schemaArray['views'])->pluck('name'))->toContain('active_users');
+        });
+});
+
+test('it strips the prefix from view rows that name the view something other than "name"', function (): void {
+    config()->set('database.connections.testing.prefix', 'boost_');
+    DB::purge('testing');
+
+    $tool = new class extends DatabaseSchema
+    {
+        /** @return array<string, mixed> */
+        public function strip(array $result): array
+        {
+            return $this->stripTablePrefix('testing', $result);
+        }
+    };
+
+    $result = $tool->strip([
+        'tables' => [],
+        'views' => [
+            (object) ['schemaname' => 'public', 'viewname' => 'boost_active_users'],
+            ['name' => 'boost_archived_users'],
+        ],
+    ]);
+
+    expect($result['views'][0]->viewname)->toBe('active_users')
+        ->and($result['views'][1]['name'])->toBe('archived_users');
+});
+
+test('it leaves names untouched on a connection without a table prefix', function (): void {
+    $tool = new DatabaseSchema;
+    $response = $tool->handle(new Request);
+
+    expect($response)->isToolResult()
+        ->toolHasNoError()
+        ->toolJsonContent(function (array $schemaArray): void {
+            expect($schemaArray['tables'])->toHaveKey('examples')
+                ->and($schemaArray['tables']['examples']['columns'])->toHaveKeys(['id', 'name']);
         });
 });


### PR DESCRIPTION
On a connection with a table prefix, the `database-schema` tool returned every table with empty `columns`, `indexes` and `foreign_keys`, without any error.

The table names come from the schema drivers, which read the catalog directly and so return them exactly as stored. `Schema::getColumns()`, `getIndexes()` and `getForeignKeys()` then prepend the connection prefix, so the lookup is for a table that does not exist and the result is empty. This runs those calls inside `Connection::withoutTablePrefix()`, the same way `db:table` handles catalog names. The driver-level calls for triggers and check constraints are untouched, since they query the catalog and already expect the stored name.

Fixes #920