### PR TITLE
Fix the JavaScript hook example in the Livewire 3 skill

### DIFF
--- a/.ai/livewire/3/skill/livewire-development/SKILL.blade.php
+++ b/.ai/livewire/3/skill/livewire-development/SKILL.blade.php
@@ -76,13 +76,16 @@ You can listen for `livewire:init` to hook into Livewire initialization:
 @boostsnippet("Livewire Init Hook Example", "js")
 document.addEventListener('livewire:init', function () {
     Livewire.hook('request', ({ fail }) => {
-        if (fail && fail.status === 419) {
-            alert('Your session expired');
-        }
+        fail(({ status, preventDefault }) => {
+            if (status === 419) {
+                preventDefault();
+                alert('Your session expired');
+            }
+        });
     });
 
-    Livewire.hook('message.failed', (message, component) => {
-        console.error(message);
+    Livewire.hook('commit', ({ fail }) => {
+        fail(() => console.error('Livewire commit failed'));
     });
 });
 @endboostsnippet


### PR DESCRIPTION
The JS hooks example in the Livewire 3 skill has two hooks in it, and neither one fires on v3.

**`message.failed` is a Livewire 2 hook.** The v3 upgrade guide lists it under "New lifecycle hooks" as one of the four `message.*` hooks folded into `commit`, with the old body moving into the `fail()` callback. Nothing dispatches `message.failed` in v3, so that handler is dead.

**The 419 check has the wrong shape.** It reads `fail.status`, but `fail` is the callback registrar, not the failure object. `status` shows up on the callback's argument, so `fail` is truthy, `fail.status` is `undefined`, and the branch never runs. The guide covers this exact case under "Page expired hook", since it's the documented replacement for v2's `Livewire.onPageExpired()`:

```js
Livewire.hook('request', ({ fail }) => {
    fail(({ status, preventDefault }) => {
        if (status === 419) {
            preventDefault()
            confirm('Your custom page expiration behavior...')
        }
    })
})
```

I followed that, kept the skill's original `alert()` text, and included `preventDefault()` like the guide does, otherwise Livewire's own page-expired dialog fires on top of the alert.

Looks like the example started as a port of the Livewire 2 skill's `onPageExpired()` / `onError()` pair and the shape got lost on the way over. It's the only JS example in the skill, so right now an agent following it writes session-expiry and failure handling that silently does nothing.

Covers item 4 of #895, the rest of that issue is untouched. One `.ai` file, no test, same as #918 and #913.
