### PR TITLE
Correct the mimes and extensions guidance for file upload validation

### DIFF
--- a/.ai/laravel/skill/laravel-best-practices/rules/security.md
+++ b/.ai/laravel/skill/laravel-best-practices/rules/security.md
@@ -121,7 +121,7 @@ Route::post('/login', LoginController::class)->middleware('throttle:login');
 
 ## Validate File Uploads
 
-Validate extension, MIME type, and size. The `mimes` rule checks extensions; use `mimetypes` for actual MIME type validation. Never trust client-provided filenames.
+Validate MIME type and size. Both `mimes` and `mimetypes` read the file's contents to guess its MIME type; `mimes` just expresses the allow-list as extensions. The `extensions` rule checks only the client-supplied filename, so never rely on it alone. Never trust client-provided filenames.
 
 ```php
 public function rules(): array


### PR DESCRIPTION
`laravel-best-practices` has the file upload rule backwards:

> The `mimes` rule checks extensions; use `mimetypes` for actual MIME type validation.

per the [docs](https://laravel.com/docs/12.x/validation#rule-mimes), `mimes` "actually validates the MIME type of the file by reading the file's contents and guessing its MIME type". `mimetypes` does the same, just spelled as MIME strings instead of extensions. the rule that trusts the client is `extensions`, which isn't mentioned at all: "You should never rely on validating a file by its user-assigned extension alone."

covers item 1 of #895. code sample was already fine, left it.
