### PR TITLE
Ignore commented-out entries when checking for existing MCP servers

### DIFF
--- a/src/Install/Mcp/FileWriter.php
+++ b/src/Install/Mcp/FileWriter.php
@@ -175,10 +175,26 @@ class FileWriter
 
     protected function serverExistsInContent(string $content, string $serverKey): bool
     {
+        $content = $this->maskUnquotedComments($content);
+
         $quotedPattern = '/["\']'.preg_quote($serverKey, '/').'["\']\\s*:/';
         $unquotedPattern = '/(?<=^|\\s|,|{)'.preg_quote($serverKey, '/').'\\s*:/m';
 
         return preg_match($quotedPattern, $content) || preg_match($unquotedPattern, $content);
+    }
+
+    protected function maskUnquotedComments(string $content): string
+    {
+        // Match quoted strings (keep) or line and block comments (blank out, keeping length and line breaks)
+        $pattern = '/"(?:\\\\.|[^"\\\\])*"|\'(?:\\\\.|[^\'\\\\])*\'|\\/\\/[^\\n]*|\\/\\*[\\s\\S]*?\\*\\//';
+
+        return preg_replace_callback(
+            $pattern,
+            fn (array $matches): string => Str::startsWith($matches[0], ['//', '/*'])
+                ? (string) preg_replace('/[^\n]/', ' ', $matches[0])
+                : $matches[0],
+            $content
+        ) ?? $content;
     }
 
     protected function injectNewConfigKey(string $content): bool
@@ -240,6 +256,7 @@ class FileWriter
 
     protected function findMatchingClosingBrace(string $content, int $openBracePos): int|false
     {
+        $content = $this->maskUnquotedComments($content);
         $braceCount = 1;
         $length = strlen($content);
         $stringQuote = null;
@@ -276,7 +293,7 @@ class FileWriter
         $innerContent = substr($content, $openBracePos + 1, $closeBracePos - $openBracePos - 1);
 
         // Skip whitespace and comments to find last meaningful character
-        $trimmed = preg_replace('/\s+|\/\/.*$/m', '', $innerContent);
+        $trimmed = preg_replace('/\s+/', '', $this->maskUnquotedComments($innerContent));
 
         // If empty or ends with opening brace, no comma needed
         if (blank($trimmed) || Str::endsWith($trimmed, '{')) {
@@ -289,21 +306,15 @@ class FileWriter
 
     protected function findCommaInsertionPoint(string $content, int $openBracePos, int $closeBracePos): int
     {
+        // Comments are blanked out so they are skipped as whitespace below
+        $content = $this->maskUnquotedComments($content);
+
         // Work backwards from closing brace to find last meaningful character
         for ($i = $closeBracePos - 1; $i > $openBracePos; $i--) {
             $char = $content[$i];
 
             // Skip whitespace and newlines
             if (in_array($char, [' ', "\t", "\n", "\r"], true)) {
-                continue;
-            }
-
-            // Skip comments (simple approach - if we hit //, skip to start of line)
-            if ($i > 0 && $content[$i - 1] === '/' && $char === '/') {
-                // Find start of this line
-                $lineStart = strrpos($content, "\n", $i - strlen($content)) ?: 0;
-                $i = $lineStart;
-
                 continue;
             }
 

--- a/src/Install/Mcp/FileWriter.php
+++ b/src/Install/Mcp/FileWriter.php
@@ -91,43 +91,39 @@ class FileWriter
 
     protected function updateJson5File(string $content): bool
     {
+        $masked = $this->maskUnquotedComments($content);
         $configKeyPattern = '/["\']'.preg_quote($this->configKey, '/').'["\']\\s*:\\s*\\{/';
 
-        if (preg_match($configKeyPattern, $content, $matches, PREG_OFFSET_CAPTURE)) {
-            return $this->injectIntoExistingConfigKey($content, $matches);
+        if (preg_match($configKeyPattern, $masked, $matches, PREG_OFFSET_CAPTURE)) {
+            return $this->injectIntoExistingConfigKey($content, $masked, $matches);
         }
 
-        return $this->injectNewConfigKey($content);
+        return $this->injectNewConfigKey($content, $masked);
     }
 
-    protected function injectIntoExistingConfigKey(string $content, array $matches): bool
+    protected function injectIntoExistingConfigKey(string $content, string $masked, array $matches): bool
     {
-        // $matches[0][1] contains the position of the configKey pattern match
         $configKeyStart = $matches[0][1];
 
-        // Find the opening brace of the configKey object
-        $openBracePos = strpos($content, '{', $configKeyStart);
+        $openBracePos = strpos($masked, '{', $configKeyStart);
 
         if ($openBracePos === false) {
             return false;
         }
 
-        // Find the matching closing brace for this configKey object
-        $closeBracePos = $this->findMatchingClosingBrace($content, $openBracePos);
+        $closeBracePos = $this->findMatchingClosingBrace($masked, $openBracePos);
 
         if ($closeBracePos === false) {
             return false;
         }
 
-        // Filter out servers that already exist
-        $serversToAdd = $this->filterExistingServers($content, $openBracePos, $closeBracePos);
+        $serversToAdd = $this->filterExistingServers($masked, $openBracePos, $closeBracePos);
 
         if ($serversToAdd === []) {
             return true;
         }
 
-        // Detect indentation from surrounding content
-        $indentLength = $this->detectIndentation($content, $closeBracePos);
+        $indentLength = $this->detectIndentation($masked, $closeBracePos);
 
         $serverJsonParts = [];
 
@@ -137,29 +133,13 @@ class FileWriter
 
         $serversJson = implode(','."\n", $serverJsonParts);
 
-        // Check if we need a comma and add it to the preceding content
-        $needsComma = $this->needsCommaBeforeClosingBrace($content, $openBracePos, $closeBracePos);
+        $insertPos = $this->findInsertionPoint($masked, $openBracePos, $closeBracePos);
+        $lineEnd = $insertPos + strcspn($masked, "\n", $insertPos, $closeBracePos - $insertPos);
 
-        if (! $needsComma) {
-            $newContent = substr_replace($content, $serversJson, $closeBracePos, 0);
+        $newContent = substr_replace($content, $serversJson, $lineEnd, 0);
 
-            return $this->writeFile($newContent);
-        }
-
-        // Find the position to add comma (after the last meaningful character)
-        $commaPosition = $this->findCommaInsertionPoint($content, $openBracePos, $closeBracePos);
-
-        if ($commaPosition !== -1) {
-            // Anything non-blank before the brace is a trailing comment: comma goes ahead of it, servers after it.
-            if (trim(substr($content, $commaPosition, $closeBracePos - $commaPosition)) === '') {
-                $newContent = substr_replace($content, ',', $commaPosition, 0);
-                $newContent = substr_replace($newContent, $serversJson, $commaPosition + 1, 0);
-            } else {
-                $newContent = substr_replace($content, $serversJson, $closeBracePos, 0);
-                $newContent = substr_replace($newContent, ',', $commaPosition, 0);
-            }
-        } else {
-            $newContent = substr_replace($content, $serversJson, $closeBracePos, 0);
+        if (! in_array($masked[$insertPos - 1], ['{', ','], true)) {
+            $newContent = substr_replace($newContent, ',', $insertPos, 0);
         }
 
         return $this->writeFile($newContent);
@@ -181,8 +161,6 @@ class FileWriter
 
     protected function serverExistsInContent(string $content, string $serverKey): bool
     {
-        $content = $this->maskUnquotedComments($content);
-
         $quotedPattern = '/["\']'.preg_quote($serverKey, '/').'["\']\\s*:/';
         $unquotedPattern = '/(?<=^|\\s|,|{)'.preg_quote($serverKey, '/').'\\s*:/m';
 
@@ -203,9 +181,9 @@ class FileWriter
         ) ?? $content;
     }
 
-    protected function injectNewConfigKey(string $content): bool
+    protected function injectNewConfigKey(string $content, string $masked): bool
     {
-        $openBracePos = strpos($content, '{');
+        $openBracePos = strpos($masked, '{');
 
         if ($openBracePos === false) {
             return false;
@@ -220,7 +198,7 @@ class FileWriter
         $serversJson = implode(',', $serverJsonParts);
         $configKeySection = '"'.$this->configKey.'": {'.$serversJson.'}';
 
-        $needsComma = $this->needsCommaAfterBrace($content, $openBracePos);
+        $needsComma = $this->needsCommaAfterBrace($masked, $openBracePos);
         $injection = $configKeySection.($needsComma ? ',' : '');
 
         $newContent = substr_replace($content, $injection, $openBracePos + 1, 0);
@@ -232,15 +210,12 @@ class FileWriter
     {
         $json = json_encode($serverConfig, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 
-        // Normalize line endings to Unix style
         $json = str_replace("\r\n", "\n", $json);
 
-        // If no indentation needed, return as-is
         if (empty($baseIndent)) {
             return '"'.$key.'": '.$json;
         }
 
-        // Apply indentation to each line of the JSON
         $baseIndent = str_repeat(' ', $baseIndent);
         $lines = explode("\n", $json);
         $firstLine = array_shift($lines);
@@ -254,15 +229,13 @@ class FileWriter
 
     protected function needsCommaAfterBrace(string $content, int $bracePosition): bool
     {
-        $afterBrace = substr($content, $bracePosition + 1);
-        $trimmed = preg_replace('/^\s*(?:\/\/.*$)?/m', '', $afterBrace);
+        $trimmed = ltrim(substr($content, $bracePosition + 1));
 
         return filled($trimmed) && ! Str::startsWith($trimmed, '}');
     }
 
     protected function findMatchingClosingBrace(string $content, int $openBracePos): int|false
     {
-        $content = $this->maskUnquotedComments($content);
         $braceCount = 1;
         $length = strlen($content);
         $stringQuote = null;
@@ -293,68 +266,32 @@ class FileWriter
         return false;
     }
 
-    protected function needsCommaBeforeClosingBrace(string $content, int $openBracePos, int $closeBracePos): bool
+    protected function findInsertionPoint(string $content, int $openBracePos, int $closeBracePos): int
     {
-        // Get content between opening and closing braces
-        $innerContent = substr($content, $openBracePos + 1, $closeBracePos - $openBracePos - 1);
-
-        // Skip whitespace and comments to find last meaningful character
-        $trimmed = preg_replace('/\s+/', '', $this->maskUnquotedComments($innerContent));
-
-        // If empty or ends with opening brace, no comma needed
-        if (blank($trimmed) || Str::endsWith($trimmed, '{')) {
-            return false;
-        }
-
-        // If ends with comma, no additional comma needed
-        return ! Str::endsWith($trimmed, ',');
-    }
-
-    protected function findCommaInsertionPoint(string $content, int $openBracePos, int $closeBracePos): int
-    {
-        // Comments are blanked out so they are skipped as whitespace below
-        $content = $this->maskUnquotedComments($content);
-
-        // Work backwards from closing brace to find last meaningful character
         for ($i = $closeBracePos - 1; $i > $openBracePos; $i--) {
-            $char = $masked[$i];
-
-            // Skip whitespace and newlines
-            if (in_array($char, [' ', "\t", "\n", "\r"], true)) {
-                continue;
-            }
-
-            // Found last meaningful character, comma goes after it
-            if ($char !== ',') {
+            if (! in_array($content[$i], [' ', "\t", "\n", "\r"], true)) {
                 return $i + 1;
             }
-
-            // Already has comma, no insertion needed
-            return -1;
         }
 
-        // Fallback - insert right after opening brace
         return $openBracePos + 1;
     }
 
     public function detectIndentation(string $content, int $nearPosition): int
     {
-        // Look backwards from the position to find server-level indentation
-        // We want to find lines that look like: "server-name": {
-
         $lines = explode("\n", substr($content, 0, $nearPosition));
 
-        // Look for the most recent server definition to match its indentation
         for ($i = count($lines) - 1; $i >= 0; $i--) {
             $line = $lines[$i];
 
-            // Match server definitions: any amount of whitespace + "key": {
-            if (preg_match('/^(\s*)"[^"]+"\s*:\s*\{/', $line, $matches)) {
-                return strlen($matches[1]);
+            if (preg_match('/^(\s*)"([^"]+)"\s*:\s*\{/', $line, $matches)) {
+                $indent = strlen($matches[1]);
+
+                // The configKey line itself sits one level shallower than its servers
+                return $matches[2] === $this->configKey ? max($indent * 2, 4) : $indent;
             }
         }
 
-        // Fallback: assume 8 spaces (2 levels of 4-space indentation typical for JSON)
         return $this->defaultIndentation;
     }
 
@@ -391,23 +328,11 @@ class FileWriter
 
     protected function hasUnquotedComments(string $content): bool
     {
-        // Match double-quoted strings (skip), line comments (//), or block comments (/* */)
-        $pattern = '/"(?:\\\\.|[^"\\\\])*"|(\/\/.*)|(\\/\\*[\\s\\S]*?\\*\\/)/';
-
-        if (preg_match_all($pattern, $content, $matches, PREG_SET_ORDER)) {
-            foreach ($matches as $match) {
-                if (! empty($match[1]) || ! empty($match[2])) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
+        return $this->maskUnquotedComments($content) !== $content;
     }
 
     protected function hasSingleQuotedStrings(string $content): bool
     {
-        // Match double-quoted strings (skip) or single-quoted strings (detect)
         $pattern = '/"(?:\\\\.|[^"\\\\])*"|\'(?:\\\\.|[^\'\\\\])*\'/';
 
         if (preg_match_all($pattern, $content, $matches)) {
@@ -448,7 +373,6 @@ class FileWriter
     {
         $json = json_encode($config, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 
-        // Normalize line endings to Unix style
         if ($json) {
             $json = str_replace("\r\n", "\n", $json);
         }

--- a/src/Install/Mcp/FileWriter.php
+++ b/src/Install/Mcp/FileWriter.php
@@ -181,10 +181,26 @@ class FileWriter
 
     protected function serverExistsInContent(string $content, string $serverKey): bool
     {
+        $content = $this->maskUnquotedComments($content);
+
         $quotedPattern = '/["\']'.preg_quote($serverKey, '/').'["\']\\s*:/';
         $unquotedPattern = '/(?<=^|\\s|,|{)'.preg_quote($serverKey, '/').'\\s*:/m';
 
         return preg_match($quotedPattern, $content) || preg_match($unquotedPattern, $content);
+    }
+
+    protected function maskUnquotedComments(string $content): string
+    {
+        // Match quoted strings (keep) or line and block comments (blank out, keeping length and line breaks)
+        $pattern = '/"(?:\\\\.|[^"\\\\])*"|\'(?:\\\\.|[^\'\\\\])*\'|\\/\\/[^\\n]*|\\/\\*[\\s\\S]*?\\*\\//';
+
+        return preg_replace_callback(
+            $pattern,
+            fn (array $matches): string => Str::startsWith($matches[0], ['//', '/*'])
+                ? (string) preg_replace('/[^\n]/', ' ', $matches[0])
+                : $matches[0],
+            $content
+        ) ?? $content;
     }
 
     protected function injectNewConfigKey(string $content): bool
@@ -246,6 +262,7 @@ class FileWriter
 
     protected function findMatchingClosingBrace(string $content, int $openBracePos): int|false
     {
+        $content = $this->maskUnquotedComments($content);
         $braceCount = 1;
         $length = strlen($content);
         $stringQuote = null;
@@ -282,7 +299,7 @@ class FileWriter
         $innerContent = substr($content, $openBracePos + 1, $closeBracePos - $openBracePos - 1);
 
         // Skip whitespace and comments to find last meaningful character
-        $trimmed = preg_replace('/\s+|\/\/.*$/m', '', $innerContent);
+        $trimmed = preg_replace('/\s+/', '', $this->maskUnquotedComments($innerContent));
 
         // If empty or ends with opening brace, no comma needed
         if (blank($trimmed) || Str::endsWith($trimmed, '{')) {
@@ -295,14 +312,8 @@ class FileWriter
 
     protected function findCommaInsertionPoint(string $content, int $openBracePos, int $closeBracePos): int
     {
-        // Strings are matched only to skip them; comments become equal-length spaces so offsets still line up.
-        $masked = preg_replace_callback(
-            '/"(?:\\\\.|[^"\\\\])*"|\'(?:\\\\.|[^\'\\\\])*\'|(\/\/[^\r\n]*)|(\/\*[\s\S]*?\*\/)/',
-            fn (array $match): string => ($match[1] ?? '') !== '' || ($match[2] ?? '') !== ''
-                ? str_repeat(' ', strlen($match[0]))
-                : $match[0],
-            $content
-        ) ?? $content;
+        // Comments are blanked out so they are skipped as whitespace below
+        $content = $this->maskUnquotedComments($content);
 
         // Work backwards from closing brace to find last meaningful character
         for ($i = $closeBracePos - 1; $i > $openBracePos; $i--) {

--- a/tests/Unit/Install/Mcp/FileWriterTest.php
+++ b/tests/Unit/Install/Mcp/FileWriterTest.php
@@ -482,6 +482,98 @@ test('updates JSON5 file with only single-quoted strings', function (): void {
     expect($writtenContent)->toContain('"boost"', "'existing'");
 });
 
+test('injects a server that is only present as a comment', function (): void {
+    $writtenContent = '';
+    $commentedOutJson5 = <<<'JSON5'
+    {
+        "mcpServers": {
+            // "boost": { "command": "php", "args": ["artisan", "boost:mcp"] }
+        }
+    }
+    JSON5;
+
+    mockFileOperations(
+        fileExists: true,
+        content: $commentedOutJson5,
+        capturedContent: $writtenContent
+    );
+
+    File::shouldReceive('size')->andReturn(200);
+
+    $result = (new FileWriter('/path/to/mcp.json'))
+        ->addServerConfig('boost', [
+            'command' => 'php',
+            'args' => ['artisan', 'boost:mcp'],
+        ])
+        ->save();
+
+    expect($result)->toBeTrue();
+    expect($writtenContent)->toContain(
+        '"command": "php"', // New server added
+        '// "boost"' // Commented out server preserved
+    );
+});
+
+test('injects a server that is only present as a block comment', function (): void {
+    $writtenContent = '';
+    $commentedOutJson5 = <<<'JSON5'
+    {
+        "mcpServers": {
+            /* "boost": { "command": "php" } */
+        }
+    }
+    JSON5;
+
+    mockFileOperations(
+        fileExists: true,
+        content: $commentedOutJson5,
+        capturedContent: $writtenContent
+    );
+
+    File::shouldReceive('size')->andReturn(200);
+
+    $result = (new FileWriter('/path/to/mcp.json'))
+        ->addServerConfig('boost', [
+            'command' => 'php',
+            'args' => ['artisan', 'boost:mcp'],
+        ])
+        ->save();
+
+    expect($result)->toBeTrue();
+    expect($writtenContent)->toContain(
+        '"command": "php"', // New server added
+        '/* "boost"' // Commented out server preserved
+    )->not->toContain('*/,'); // No comma appended to the comment
+});
+
+test('does not duplicate an existing server whose config contains slashes', function (): void {
+    $json5 = <<<'JSON5'
+    {
+        "mcpServers": {
+            // Remote servers
+            "boost": { "url": "https://example.com/mcp" }
+        }
+    }
+    JSON5;
+
+    File::swap(Mockery::mock(Filesystem::class));
+
+    File::shouldReceive('ensureDirectoryExists')->once();
+    File::shouldReceive('exists')->andReturn(true);
+    File::shouldReceive('size')->andReturn(200);
+    File::shouldReceive('get')->andReturn($json5);
+    File::shouldReceive('put')->never(); // The URL slashes are not mistaken for a comment, so nothing is written
+
+    $result = (new FileWriter('/path/to/mcp.json'))
+        ->addServerConfig('boost', [
+            'command' => 'php',
+            'args' => ['artisan', 'boost:mcp'],
+        ])
+        ->save();
+
+    expect($result)->toBeTrue();
+});
+
 test('detectIndentation works correctly with various patterns', function (string $content, int $position, int $expected, string $description): void {
     $writer = new FileWriter('/tmp/test.json');
 

--- a/tests/Unit/Install/Mcp/FileWriterTest.php
+++ b/tests/Unit/Install/Mcp/FileWriterTest.php
@@ -580,10 +580,21 @@ test('injects a server that is only present as a comment', function (): void {
         ->save();
 
     expect($result)->toBeTrue();
-    expect($writtenContent)->toContain(
-        '"command": "php"', // New server added
-        '// "boost"' // Commented out server preserved
-    );
+    expect($writtenContent)->toBe(<<<'JSON5'
+    {
+        "mcpServers": {
+            "boost": {
+                "command": "php",
+                "args": [
+                    "artisan",
+                    "boost:mcp"
+                ]
+            }
+            // "boost": { "command": "php", "args": ["artisan", "boost:mcp"] }
+        }
+    }
+
+    JSON5);
 });
 
 test('injects a server that is only present as a block comment', function (): void {
@@ -612,38 +623,63 @@ test('injects a server that is only present as a block comment', function (): vo
         ->save();
 
     expect($result)->toBeTrue();
-    expect($writtenContent)->toContain(
-        '"command": "php"', // New server added
-        '/* "boost"' // Commented out server preserved
-    )->not->toContain('*/,'); // No comma appended to the comment
-});
-
-test('does not duplicate an existing server whose config contains slashes', function (): void {
-    $json5 = <<<'JSON5'
+    expect($writtenContent)->toBe(<<<'JSON5'
     {
         "mcpServers": {
-            // Remote servers
-            "boost": { "url": "https://example.com/mcp" }
+            "boost": {
+                "command": "php",
+                "args": [
+                    "artisan",
+                    "boost:mcp"
+                ]
+            }
+            /* "boost": { "command": "php" } */
+        }
+    }
+
+    JSON5);
+});
+
+test('injects into the real configKey when a commented-out copy of it comes first', function (): void {
+    $writtenContent = '';
+    $json5 = <<<'JSON5'
+    {
+        // "mcpServers": {
+        //     "boost": { "command": "php" }
+        // }
+        "mcpServers": {
+            "other": { "command": "x" } // has a } brace
         }
     }
     JSON5;
 
-    File::swap(Mockery::mock(Filesystem::class));
+    mockFileOperations(
+        fileExists: true,
+        content: $json5,
+        capturedContent: $writtenContent
+    );
 
-    File::shouldReceive('ensureDirectoryExists')->once();
-    File::shouldReceive('exists')->andReturn(true);
     File::shouldReceive('size')->andReturn(200);
-    File::shouldReceive('get')->andReturn($json5);
-    File::shouldReceive('put')->never(); // The URL slashes are not mistaken for a comment, so nothing is written
 
     $result = (new FileWriter('/path/to/mcp.json'))
-        ->addServerConfig('boost', [
-            'command' => 'php',
-            'args' => ['artisan', 'boost:mcp'],
-        ])
+        ->addServerConfig('boost', ['command' => 'php'])
         ->save();
 
     expect($result)->toBeTrue();
+    expect($writtenContent)->toBe(<<<'JSON5'
+    {
+        // "mcpServers": {
+        //     "boost": { "command": "php" }
+        // }
+        "mcpServers": {
+            "other": { "command": "x" }, // has a } brace
+            "boost": {
+                "command": "php"
+            }
+        }
+    }
+
+    JSON5);
 });
 
 test('detectIndentation works correctly with various patterns', function (string $content, int $position, int $expected, string $description): void {
@@ -940,6 +976,12 @@ function indentationDetectionCases(): array
             0,
             8,
             'Should fallback to 8 spaces for empty content',
+        ],
+        'empty configKey object' => [
+            "{\n  \"mcpServers\": {\n  }\n}",
+            25,
+            4,
+            'Should indent one level deeper than the configKey line when it has no servers',
         ],
     ];
 }

--- a/tests/Unit/Install/Mcp/FileWriterTest.php
+++ b/tests/Unit/Install/Mcp/FileWriterTest.php
@@ -554,6 +554,98 @@ test('updates JSON5 file with only single-quoted strings', function (): void {
     expect($writtenContent)->toContain('"boost"', "'existing'");
 });
 
+test('injects a server that is only present as a comment', function (): void {
+    $writtenContent = '';
+    $commentedOutJson5 = <<<'JSON5'
+    {
+        "mcpServers": {
+            // "boost": { "command": "php", "args": ["artisan", "boost:mcp"] }
+        }
+    }
+    JSON5;
+
+    mockFileOperations(
+        fileExists: true,
+        content: $commentedOutJson5,
+        capturedContent: $writtenContent
+    );
+
+    File::shouldReceive('size')->andReturn(200);
+
+    $result = (new FileWriter('/path/to/mcp.json'))
+        ->addServerConfig('boost', [
+            'command' => 'php',
+            'args' => ['artisan', 'boost:mcp'],
+        ])
+        ->save();
+
+    expect($result)->toBeTrue();
+    expect($writtenContent)->toContain(
+        '"command": "php"', // New server added
+        '// "boost"' // Commented out server preserved
+    );
+});
+
+test('injects a server that is only present as a block comment', function (): void {
+    $writtenContent = '';
+    $commentedOutJson5 = <<<'JSON5'
+    {
+        "mcpServers": {
+            /* "boost": { "command": "php" } */
+        }
+    }
+    JSON5;
+
+    mockFileOperations(
+        fileExists: true,
+        content: $commentedOutJson5,
+        capturedContent: $writtenContent
+    );
+
+    File::shouldReceive('size')->andReturn(200);
+
+    $result = (new FileWriter('/path/to/mcp.json'))
+        ->addServerConfig('boost', [
+            'command' => 'php',
+            'args' => ['artisan', 'boost:mcp'],
+        ])
+        ->save();
+
+    expect($result)->toBeTrue();
+    expect($writtenContent)->toContain(
+        '"command": "php"', // New server added
+        '/* "boost"' // Commented out server preserved
+    )->not->toContain('*/,'); // No comma appended to the comment
+});
+
+test('does not duplicate an existing server whose config contains slashes', function (): void {
+    $json5 = <<<'JSON5'
+    {
+        "mcpServers": {
+            // Remote servers
+            "boost": { "url": "https://example.com/mcp" }
+        }
+    }
+    JSON5;
+
+    File::swap(Mockery::mock(Filesystem::class));
+
+    File::shouldReceive('ensureDirectoryExists')->once();
+    File::shouldReceive('exists')->andReturn(true);
+    File::shouldReceive('size')->andReturn(200);
+    File::shouldReceive('get')->andReturn($json5);
+    File::shouldReceive('put')->never(); // The URL slashes are not mistaken for a comment, so nothing is written
+
+    $result = (new FileWriter('/path/to/mcp.json'))
+        ->addServerConfig('boost', [
+            'command' => 'php',
+            'args' => ['artisan', 'boost:mcp'],
+        ])
+        ->save();
+
+    expect($result)->toBeTrue();
+});
+
 test('detectIndentation works correctly with various patterns', function (string $content, int $position, int $expected, string $description): void {
     $writer = new FileWriter('/tmp/test.json');
 


### PR DESCRIPTION
`boost:install --mcp` reports success but writes nothing when the server key only shows up in a commented-out line inside `mcpServers`. That happens when you disable a server and later run install to bring it back.

`serverExistsInContent()` matches against the raw slice between the `mcpServers` braces, so `// "laravel-boost": {...}` counts as an existing entry and the server is filtered out before injection. The check now runs on the content with comments removed, and quoted strings are left alone so a `//` inside a value like `"url": "https://example.com"` still reads as real config rather than a comment.

Fixes #932