### PR TITLE
Include `PATCH` in the CSRF rule

### DIFF
--- a/.ai/laravel/skill/laravel-best-practices/rules/security.md
+++ b/.ai/laravel/skill/laravel-best-practices/rules/security.md
@@ -90,7 +90,7 @@ Correct:
 
 ## CSRF Protection
 
-Include `@csrf` in all POST/PUT/DELETE Blade forms. Inertia doesn't use `@csrf`; its HTTP client sends the `XSRF-TOKEN` cookie back as the `X-XSRF-TOKEN` header, which Laravel accepts in place of the `_token` field.
+Include `@csrf` in all POST/PUT/PATCH/DELETE Blade forms. Inertia doesn't use `@csrf`; its HTTP client sends the `XSRF-TOKEN` cookie back as the `X-XSRF-TOKEN` header, which Laravel accepts in place of the `_token` field.
 
 Incorrect:
 ```blade


### PR DESCRIPTION
Require @csrf in all POST/PUT/PATCH/DELETE Blade forms. PATCH forms use method spoofing but still require CSRF protection.

> Anytime you define a "POST", "PUT", "PATCH", or "DELETE" HTML form in your application, you should include a hidden CSRF _token field in the form so that the CSRF protection middleware can validate the request.

https://laravel.com/docs/13.x/csrf#preventing-csrf-requests