### PR TITLE
Treat blank executable path config values as unset

### DIFF
--- a/src/Install/Agents/Agent.php
+++ b/src/Install/Agents/Agent.php
@@ -32,7 +32,7 @@ abstract class Agent
 
     public function getPhpPath(bool $forceAbsolutePath = false): string
     {
-        $phpBinaryPath = config('boost.executable_paths.php') ?? 'php';
+        $phpBinaryPath = config('boost.executable_paths.php') ?: 'php';
 
         if ($phpBinaryPath === 'php' && ($this->useAbsolutePathForMcp() || $forceAbsolutePath)) {
             return PHP_BINARY;

--- a/src/Install/GuidelineAssist.php
+++ b/src/Install/GuidelineAssist.php
@@ -122,9 +122,9 @@ class GuidelineAssist
 
     public function nodePackageManagerCommand(string $command): string
     {
-        $npmExecutable = config('boost.executable_paths.npm') ?: null;
+        $npmExecutable = config('boost.executable_paths.npm');
 
-        if ($npmExecutable !== null) {
+        if ($npmExecutable) {
             return "{$npmExecutable} {$command}";
         }
 
@@ -142,9 +142,9 @@ class GuidelineAssist
 
     public function composerCommand(string $command): string
     {
-        $composerExecutable = config('boost.executable_paths.composer') ?: null;
+        $composerExecutable = config('boost.executable_paths.composer');
 
-        if ($composerExecutable !== null) {
+        if ($composerExecutable) {
             return "{$composerExecutable} {$command}";
         }
 
@@ -157,9 +157,9 @@ class GuidelineAssist
 
     public function binCommand(string $command): string
     {
-        $vendorBinPrefix = config('boost.executable_paths.vendor_bin') ?: null;
+        $vendorBinPrefix = config('boost.executable_paths.vendor_bin');
 
-        if ($vendorBinPrefix !== null) {
+        if ($vendorBinPrefix) {
             return "{$vendorBinPrefix}{$command}";
         }
 
@@ -172,9 +172,9 @@ class GuidelineAssist
 
     public function artisan(): string
     {
-        $phpExecutable = config('boost.executable_paths.php') ?: null;
+        $phpExecutable = config('boost.executable_paths.php');
 
-        if ($phpExecutable !== null) {
+        if ($phpExecutable) {
             return "{$phpExecutable} artisan";
         }
 

--- a/src/Install/GuidelineAssist.php
+++ b/src/Install/GuidelineAssist.php
@@ -122,7 +122,7 @@ class GuidelineAssist
 
     public function nodePackageManagerCommand(string $command): string
     {
-        $npmExecutable = config('boost.executable_paths.npm');
+        $npmExecutable = config('boost.executable_paths.npm') ?: null;
 
         if ($npmExecutable !== null) {
             return "{$npmExecutable} {$command}";
@@ -142,7 +142,7 @@ class GuidelineAssist
 
     public function composerCommand(string $command): string
     {
-        $composerExecutable = config('boost.executable_paths.composer');
+        $composerExecutable = config('boost.executable_paths.composer') ?: null;
 
         if ($composerExecutable !== null) {
             return "{$composerExecutable} {$command}";
@@ -157,7 +157,7 @@ class GuidelineAssist
 
     public function binCommand(string $command): string
     {
-        $vendorBinPrefix = config('boost.executable_paths.vendor_bin');
+        $vendorBinPrefix = config('boost.executable_paths.vendor_bin') ?: null;
 
         if ($vendorBinPrefix !== null) {
             return "{$vendorBinPrefix}{$command}";
@@ -172,7 +172,7 @@ class GuidelineAssist
 
     public function artisan(): string
     {
-        $phpExecutable = config('boost.executable_paths.php');
+        $phpExecutable = config('boost.executable_paths.php') ?: null;
 
         if ($phpExecutable !== null) {
             return "{$phpExecutable} artisan";

--- a/src/Install/Sail.php
+++ b/src/Install/Sail.php
@@ -37,7 +37,7 @@ class Sail
 
     public static function binaryPath(): string
     {
-        return config('boost.executable_paths.sail') ?? self::DEFAULT_BINARY_PATH;
+        return config('boost.executable_paths.sail') ?: self::DEFAULT_BINARY_PATH;
     }
 
     public function isInstalled(): bool

--- a/src/Mcp/ToolExecutor.php
+++ b/src/Mcp/ToolExecutor.php
@@ -125,7 +125,7 @@ class ToolExecutor
      */
     protected function buildCommand(string $toolClass, array $arguments): array
     {
-        $phpBinary = config('boost.executable_paths.php') ?? PHP_BINARY;
+        $phpBinary = config('boost.executable_paths.php') ?: PHP_BINARY;
         $normalized = CommandNormalizer::normalize($phpBinary);
 
         return [

--- a/src/Services/BrowserLogger.php
+++ b/src/Services/BrowserLogger.php
@@ -265,17 +265,17 @@ HTML;
      */
     private static function captureTypes(mixed $levels): array
     {
-        if (! is_array($levels) || $levels === []) {
+        $levels = is_array($levels)
+            ? array_filter($levels, fn (mixed $level): bool => is_string($level) && trim($level) !== '')
+            : [];
+
+        if ($levels === []) {
             return self::AllBrowserLogTypes;
         }
 
         $captureTypes = [];
 
         foreach ($levels as $level) {
-            if (! is_string($level)) {
-                continue;
-            }
-
             $level = strtolower(trim($level));
             $level = $level === 'warn' ? 'warning' : $level;
 

--- a/tests/Feature/Mcp/ToolExecutorTest.php
+++ b/tests/Feature/Mcp/ToolExecutorTest.php
@@ -202,6 +202,22 @@ test('buildCommand preserves absolute paths with spaces', function (): void {
     expect($command[0])->toBe('/Applications/Some App/bin/php');
 });
 
+test('buildCommand falls back to PHP_BINARY when the configured path is blank', function (mixed $blank): void {
+    config(['boost.executable_paths.php' => $blank]);
+
+    $executor = new ToolExecutor;
+
+    $reflection = new ReflectionClass($executor);
+    $method = $reflection->getMethod('buildCommand');
+
+    $command = $method->invoke($executor, 'SomeTool', []);
+
+    expect($command[0])->toBe(PHP_BINARY);
+})->with([
+    'empty string' => '',
+    'false' => false,
+]);
+
 test('buildCommand splits multi-token wrapper commands', function (): void {
     config(['boost.executable_paths.php' => 'herd php']);
 

--- a/tests/Feature/Mcp/Tools/BrowserLogsTest.php
+++ b/tests/Feature/Mcp/Tools/BrowserLogsTest.php
@@ -112,6 +112,9 @@ test('browser logger script captures the configured log levels', function (?arra
     'warn alias' => [['warn'], ['warning', 'error']],
     'missing configuration' => [null, ['log', 'debug', 'info', 'warning', 'error', 'table']],
     'empty configuration' => [[], ['log', 'debug', 'info', 'warning', 'error', 'table']],
+    'blank env var' => [[''], ['log', 'debug', 'info', 'warning', 'error', 'table']],
+    'whitespace only' => [['   '], ['log', 'debug', 'info', 'warning', 'error', 'table']],
+    'blank entries alongside a level' => [['', 'error'], ['error']],
 ]);
 
 test('browser logs endpoint processes logs correctly', function (): void {

--- a/tests/Unit/Install/Agents/AgentTest.php
+++ b/tests/Unit/Install/Agents/AgentTest.php
@@ -345,6 +345,17 @@ test('getPhpPath maintains default behavior when forceAbsolutePath is false and 
     expect($environment->getPhpPath(false))->toBe('php');
 });
 
+test('getPhpPath treats a blank configured path as unset', function (mixed $blank): void {
+    config(['boost.executable_paths.php' => $blank]);
+
+    $environment = new TestAgent($this->strategyFactory);
+    expect($environment->getPhpPath(false))->toBe('php');
+    expect($environment->getPhpPath(true))->toBe(PHP_BINARY);
+})->with([
+    'empty string' => '',
+    'false' => false,
+]);
+
 test('getPhpPath uses configured default_php_bin from config', function (): void {
     config(['boost.executable_paths.php' => '/usr/local/bin/php8.3']);
 

--- a/tests/Unit/Install/GuidelineAssistTest.php
+++ b/tests/Unit/Install/GuidelineAssistTest.php
@@ -260,3 +260,25 @@ test('appPath normalizes separators to forward slashes', function (): void {
     expect($assist->appPath('Http/Kernel.php'))->toBe('app/Http/Kernel.php');
     expect($assist->appPath('Console/Commands/'))->toBe('app/Console/Commands/');
 });
+
+test('blank executable path config is treated as unset', function (mixed $blank): void {
+    config([
+        'boost.executable_paths.php' => $blank,
+        'boost.executable_paths.composer' => $blank,
+        'boost.executable_paths.npm' => $blank,
+        'boost.executable_paths.vendor_bin' => $blank,
+    ]);
+    $this->config->usesSail = false;
+
+    $assist = Mockery::mock(GuidelineAssist::class, [$this->project, $this->config])->makePartial();
+    $assist->shouldAllowMockingProtectedMethods();
+    $assist->shouldReceive('discover')->andReturn([]);
+
+    expect($assist->artisan())->toBe('php artisan');
+    expect($assist->composerCommand('require foo/bar'))->toBe('composer require foo/bar');
+    expect($assist->nodePackageManagerCommand('install'))->toBe('npm install');
+    expect($assist->binCommand('pint'))->toBe('vendor/bin/pint');
+})->with([
+    'empty string' => '',
+    'false' => false,
+]);

--- a/tests/Unit/Install/SailTest.php
+++ b/tests/Unit/Install/SailTest.php
@@ -107,6 +107,15 @@ test('sail binary path defaults to vendor/bin/sail', function (): void {
     expect(Sail::binaryPath())->toBe('vendor'.DIRECTORY_SEPARATOR.'bin'.DIRECTORY_SEPARATOR.'sail');
 });
 
+test('blank sail binary path falls back to the default', function (mixed $blank): void {
+    config(['boost.executable_paths.sail' => $blank]);
+
+    expect(Sail::binaryPath())->toBe('vendor'.DIRECTORY_SEPARATOR.'bin'.DIRECTORY_SEPARATOR.'sail');
+})->with([
+    'empty string' => '',
+    'false' => false,
+]);
+
 test('isInstalled detects every Docker Compose filename supported by default', function (string $composeFile): void {
     global $sailTempDir;
 


### PR DESCRIPTION
`BOOST_PHP_EXECUTABLE_PATH=` in `.env` resolves to `''`, not `null`, so the `??` and `!== null` guards on `executable_paths` take it as a real path.

on a fresh app with just that one blank line, `boost:install` exits 0 and writes an `.mcp.json` with no `command` key at all, since the writer filters the empty string out:

```json
{"mcpServers":{"laravel-boost":{"args":["artisan","boost:mcp"]}}}
```

and all 18 `php artisan` in the generated `CLAUDE.md` come out as ` artisan`.

`?:` catches the blank spellings the current guards miss:

| `.env` | `env()` | today | with `?:` |
|---|---|---|---|
| `KEY=` | `''` | `''` | fallback |
| `KEY= ` (trailing space) | `''` | `''` | fallback |
| `KEY=empty` | `''` | `''` | fallback |
| `KEY=false` | `false` | `false` | fallback |
| `KEY=/usr/bin/php` | path | path | path |
| unset or `KEY=null` | `null` | fallback | fallback |

that's the 7 places reading `executable_paths`: the four guards in `GuidelineAssist` get `?: null` so the existing `!== null` checks still read the same, and `Agent::getPhpPath`, `ToolExecutor::buildCommand` and `Sail::binaryPath` swap `??` for `?:`. `Codex::mcpServerConfig` already filters `''` out itself so I left it alone.

went with `?:` rather than `filled()` because `filled(false)` is `true`, which would let a `false` through as a path. `?: null` also matches what `BoostServiceProvider` already does with `$log['userAgent'] ?: null`.

same blank line after this gives `"command": "php"` and 18/18 `php artisan`.

Fixes #930
