### PR TITLE
Send an idempotency key in the retried charge example

### DIFF
--- a/.ai/laravel/skill/laravel-best-practices/rules/http-client.md
+++ b/.ai/laravel/skill/laravel-best-practices/rules/http-client.md
@@ -46,8 +46,11 @@ Correct:
 ```php
 $response = Http::retry([100, 500, 1000])
     ->timeout(10)
+    ->withHeaders(['Idempotency-Key' => $idempotencyKey])
     ->post('https://api.stripe.com/v1/charges', $data);
 ```
+
+Retries resend the request unchanged, so a write can be applied twice if the first attempt succeeded but the response was lost. Send an idempotency key when the API supports one.
 
 Only retry on specific errors:
 

--- a/.ai/laravel/skill/laravel-best-practices/rules/http-client.md
+++ b/.ai/laravel/skill/laravel-best-practices/rules/http-client.md
@@ -35,7 +35,7 @@ External APIs have transient failures. Use `retry()` with increasing delays.
 
 Incorrect:
 ```php
-$response = Http::post('https://api.stripe.com/v1/charges', $data);
+$response = Http::post('https://api.example.com/v1/charges', $data);
 
 if ($response->failed()) {
     throw new PaymentFailedException('Charge failed');
@@ -46,11 +46,8 @@ Correct:
 ```php
 $response = Http::retry([100, 500, 1000])
     ->timeout(10)
-    ->withHeaders(['Idempotency-Key' => $idempotencyKey])
-    ->post('https://api.stripe.com/v1/charges', $data);
+    ->post('https://api.example.com/v1/charges', $data);
 ```
-
-Retries resend the request unchanged, so a write can be applied twice if the first attempt succeeded but the response was lost. Send an idempotency key when the API supports one.
 
 Only retry on specific errors:
 


### PR DESCRIPTION
The retry rule's "Correct" example retries a POST to Stripe's charge endpoint with no idempotency key.

`Http::retry()` resends the request as-is, so if the first attempt lands but the response gets lost, the retry makes a second charge. Stripe's docs are pretty direct about it: "if a connection error occurs, you can safely repeat the request without risk of creating a second object".

The header sticks for every attempt, so setting it once does the job. Faked a 500, 500, 200 sequence against the example with the key added:

```
attempts: 3
  #1 status=500 Idempotency-Key=idem-abc-123
  #2 status=500 Idempotency-Key=idem-abc-123
  #3 status=200 Idempotency-Key=idem-abc-123
```

Went with `withHeaders()` over `withHeader()` since that's the one in the 11.x docs.

Item 3 from #895.
