### PR TITLE
Publish the configuration keys Boost already reads

### DIFF
--- a/config/boost.php
+++ b/config/boost.php
@@ -19,6 +19,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Application Purpose
+    |--------------------------------------------------------------------------
+    |
+    | A short description of what your application does. When set, Boost adds
+    | it to the top of the guidelines it generates so agents know what they
+    | are working on before they read any of your application's code.
+    |
+    */
+
+    'purpose' => env('BOOST_PURPOSE'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Boost Project Rules
     |--------------------------------------------------------------------------
     |
@@ -65,6 +78,67 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | GitHub Token
+    |--------------------------------------------------------------------------
+    |
+    | Boost sends this token when downloading remote skills with the
+    | boost:add-skill command, raising GitHub's rate limit and allowing
+    | private repositories to be read. Falls back to services.github.token.
+    |
+    */
+
+    'github' => [
+        'token' => env('BOOST_GITHUB_TOKEN'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Enforce Tests
+    |--------------------------------------------------------------------------
+    |
+    | This option determines whether Boost includes its guideline instructing
+    | agents to write tests. When left null, Boost decides for you based on
+    | whether your application already has a working test suite set up.
+    |
+    */
+
+    'enforce_tests' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Boost MCP Server
+    |--------------------------------------------------------------------------
+    |
+    | Each MCP tool runs in its own subprocess and is stopped once the timeout
+    | below is reached. You may also drop any of Boost's bundled tools, or
+    | register tool classes of your own, using the two arrays below.
+    |
+    */
+
+    'mcp' => [
+        'tool_timeout' => 180,
+
+        'tools' => [
+            'include' => [],
+            'exclude' => [],
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Tinker Tool
+    |--------------------------------------------------------------------------
+    |
+    | The Tinker MCP tool lets agents execute arbitrary PHP within your
+    | application, so it is not registered unless you opt in here. Only
+    | enable it when you are comfortable with agents running code.
+    |
+    */
+
+    'tinker_tool_enabled' => env('BOOST_TINKER_TOOL_ENABLED', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Boost Executables Paths
     |--------------------------------------------------------------------------
     |
@@ -79,6 +153,7 @@ return [
         'composer' => env('BOOST_COMPOSER_EXECUTABLE_PATH'),
         'npm' => env('BOOST_NPM_EXECUTABLE_PATH'),
         'vendor_bin' => env('BOOST_VENDOR_BIN_EXECUTABLE_PATH'),
+        'sail' => env('BOOST_SAIL_EXECUTABLE_PATH'),
         'current_directory' => env('BOOST_CURRENT_DIRECTORY_EXECUTABLE_PATH'),
     ],
 


### PR DESCRIPTION
`config/boost.php` publishes 12 keys. The code reads 60.

Some of the gaps are things people would actually want. `mcp.tools.exclude` drops a bundled MCP tool, `mcp.tools.include` registers tool classes of your own, `tinker_tool_enabled` switches on the Tinker tool that ships off, and `purpose` gets prepended to every guideline file Boost generates. Right now you only find any of them by reading src.

So this publishes the eight user-facing ones, same shape as #910:

| key | read at |
|---|---|
| `purpose` | `foundation.blade.php:15` |
| `github.token` | `GitHubSkillProvider.php:283` |
| `enforce_tests` | `InstallCommand.php:200` |
| `mcp.tool_timeout` | `ToolExecutor.php:70` |
| `mcp.tools.include` | `ToolRegistry.php:42` |
| `mcp.tools.exclude` | `ToolRegistry.php:28` |
| `tinker_tool_enabled` | `Tinker.php:29` |

`executable_paths.sail` is the eighth and the odd one out, five of its six siblings were already published.

Every default is the value its call site already falls back to, so publishing this changes nothing until someone edits it.

I left `enforce_tests` and `mcp.tool_timeout` as plain values rather than `env()`, because a blank line in .env breaks both. `BOOST_ENFORCE_TESTS=` gives you `''`, which sails past the `!== null` check and quietly turns enforcement off. Blank timeout is worse, tried it in a real app first:

```
BOOST_MCP_TOOL_TIMEOUT=
getTimeout() : 1 seconds
```

`(int) ''` is 0 and `max(1, 0)` is 1, so every tool would give up after a second. Same class as #930.

Skipped `hosted.api_url` (internal) and `browser_logs` (reads like a legacy alias sitting next to `browser_logs_watcher`, probably wants removing rather than publishing). Left the 38 `agents.*` path keys alone too, happy to do those separately if you want them public.

One caveat worth knowing: `mergeConfigFrom` is a shallow merge, so anyone with an already-published config keeps their copy and won't see these until they republish.
