### PR TITLE
Correct the cache tag driver support list

### DIFF
--- a/.ai/laravel/skill/laravel-best-practices/rules/caching.md
+++ b/.ai/laravel/skill/laravel-best-practices/rules/caching.md
@@ -34,7 +34,7 @@ If the same cache key is read multiple times per request (e.g., a service called
 
 ## Use Cache Tags to Invalidate Related Groups
 
-Without tags, invalidating a group of entries requires tracking every key. Tags let you flush atomically. Only works with `redis`, `memcached`, `dynamodb` — not `file` or `database`.
+Without tags, invalidating a group of entries requires tracking every key. Tags let you flush atomically. Not supported by the `file`, `dynamodb`, `database` or `storage` drivers.
 
 ```php
 Cache::tags(['user-1'])->flush();


### PR DESCRIPTION
`caching.md` says cache tags "Only works with `redis`, `memcached`, `dynamodb`". Dynamodb doesn't support tags.

The 13.x docs are blunt about it: "Cache tags are not supported when using the `file`, `dynamodb`, `database`, or `storage` cache drivers."

The framework agrees. `DynamoDbStore` doesn't extend `TaggableStore`, so `Repository::tags()` throws `BadMethodCallException('This cache store does not support tagging.')` rather than flushing anything:

```
RedisStore       TaggableStore
MemcachedStore   TaggableStore
ArrayStore       TaggableStore
ApcStore         TaggableStore
DynamoDbStore    (no parent)
FileStore        (no parent)
DatabaseStore    (no parent)
StorageStore     (no parent)
```

So an agent on dynamodb following this rule writes code that throws. Swapped the sentence for the unsupported list straight out of the docs, which also picks up `storage`.
