### PR TITLE
Fix the foreign key index example so it actually creates an index

### DIFF
--- a/.ai/laravel/skill/laravel-best-practices/rules/migrations.md
+++ b/.ai/laravel/skill/laravel-best-practices/rules/migrations.md
@@ -62,7 +62,7 @@ Correct:
 ```php
 Schema::create('orders', function (Blueprint $table) {
     $table->id();
-    $table->foreignId('user_id')->constrained()->index();
+    $table->foreignId('user_id')->index()->constrained();
     $table->string('status')->index();
     $table->timestamp('shipped_at')->nullable()->index();
     $table->timestamps();


### PR DESCRIPTION
The "Add Indexes in the Migration" example doesn't create the index it's demonstrating.

`constrained()` returns a `ForeignKeyDefinition`, so the `->index()` chained after it sets an attribute on the foreign key instead of the column, and `addFluentIndexes()` only reads those off columns. Same migration three ways, on 11.55.1 and 13.24:

```
->constrained()->index()  (current)    primary(id)
->index()->constrained()  (this PR)    orders_user_id_index(user_id)  primary(id)
->constrained()  (control, no index)   primary(id)
```

The current form and the control come out identical, so the `->index()` isn't doing anything. `db-performance.md:112` already has the working order.
