### PR TITLE
Correct the wire:model default in the Livewire 4 skill

### DIFF
--- a/.ai/livewire/4/skill/livewire-development/SKILL.blade.php
+++ b/.ai/livewire/4/skill/livewire-development/SKILL.blade.php
@@ -126,7 +126,7 @@ These things changed in Livewire 4, but may not have been updated in this applic
 
 - Always use `wire:key` in loops
 - Use `wire:loading` for loading states
-- Use `wire:model.live` for instant updates (default is debounced)
+- Use `wire:model.live` for live updates; `wire:model` is deferred by default
 - Validate and authorize in actions (treat like HTTP requests)
 
 ## Configuration


### PR DESCRIPTION
The v4 skill says `wire:model`'s default is debounced. It's deferred, and the 150ms debounce belongs to `.live`.

Livewire's docs: "By default, Livewire will only send a network request when an action is performed (like `wire:click` or `wire:submit`), NOT when a `wire:model` input is updated."

The v3 skill already has it right on line 33, so this brings v4 in line.
