### PR TITLE
Describe what LazilyRefreshDatabase actually defers

### DIFF
--- a/.ai/laravel/skill/laravel-best-practices/rules/testing.md
+++ b/.ai/laravel/skill/laravel-best-practices/rules/testing.md
@@ -2,7 +2,7 @@
 
 ## Use `LazilyRefreshDatabase` Over `RefreshDatabase`
 
-`RefreshDatabase` migrates once per process and wraps each test in a rolled-back transaction. `LazilyRefreshDatabase` skips even that first migration if the schema is already up to date.
+`RefreshDatabase` migrates once per process and wraps each test in a rolled-back transaction. `LazilyRefreshDatabase` behaves the same, except it defers that work until a test actually touches the database, so tests that never query it skip the migration entirely.
 
 ## Use Model Assertions Over Raw Database Assertions
 


### PR DESCRIPTION
`testing.md` says `LazilyRefreshDatabase` "skips even that first migration if the schema is already up to date". It defers on database access, not schema state.

The trait hangs `baseRefreshDatabase()` off `beforeExecuting` and `beforeStartingTransaction`, so it fires on first use. Two tests in one class, the first one never querying:

```
[1] test that never queries -> migrated=false
[2] test that runs a query   -> migrated=true
```

Nothing in there checks whether the schema is current. Reworded to match.
