### PR TITLE
Add Pest 5 TIA guidance

### DIFF
--- a/.ai/pest/5/core.blade.php
+++ b/.ai/pest/5/core.blade.php
@@ -1,0 +1,14 @@
+@php
+/** @var \Laravel\Boost\Install\GuidelineAssist $assist */
+@endphp
+@if($assist->hasLocallyEnabledPestTia())
+## Pest TIA
+
+- Pest 5 Test Impact Analysis is enabled for local runs through `pest()->tia()->locally()` in `tests/Pest.php`.
+- For routine verification, run `{{ $assist->artisanCommand('test --compact') }}`. TIA automatically executes affected tests and replays unaffected results.
+- Preserve the project's existing parallel-testing convention when running these commands. TIA does not require `--parallel`, and `--dirty` is not a substitute for TIA.
+- After large refactors or when the dependency graph appears stale, rebuild it with `{{ $assist->phpCommand('./vendor/bin/pest --compact --tia --fresh') }}`.
+- Before finalizing substantial or high-risk changes, run the complete suite without TIA using `{{ $assist->phpCommand('./vendor/bin/pest --compact --no-tia') }}`.
+- Normal CI verification must execute the complete suite without TIA. A dedicated job that records a shared TIA baseline is the only exception.
+- Recording a TIA baseline requires PCOV or Xdebug.
+@endif

--- a/src/Install/GuidelineAssist.php
+++ b/src/Install/GuidelineAssist.php
@@ -110,6 +110,28 @@ class GuidelineAssist
         return $this->project->js()->uses($package);
     }
 
+    public function hasLocallyEnabledPestTia(): bool
+    {
+        $path = base_path('tests/Pest.php');
+
+        if (! is_file($path) || ($contents = file_get_contents($path)) === false) {
+            return false;
+        }
+
+        $code = collect(token_get_all($contents))
+            ->reject(fn (mixed $token): bool => is_array($token) && in_array($token[0], [
+                T_WHITESPACE,
+                T_COMMENT,
+                T_DOC_COMMENT,
+                T_CONSTANT_ENCAPSED_STRING,
+                T_ENCAPSED_AND_WHITESPACE,
+            ], true))
+            ->map(fn (mixed $token): string => is_array($token) ? $token[1] : $token)
+            ->join('');
+
+        return preg_match('/(?<![A-Z0-9_$>:\\\\])(?:\\\\pest|pest)\(\)->tia\(\)(?:(?!;).)*->locally\(\)/is', $code) === 1;
+    }
+
     public function nodePackageManager(): string
     {
         return ($this->project->js()->packageManager() ?? JsPackageManager::Npm)->value;
@@ -138,6 +160,21 @@ class GuidelineAssist
     public function artisanCommand(string $command): string
     {
         return "{$this->artisan()} {$command}";
+    }
+
+    public function phpCommand(string $command): string
+    {
+        $phpExecutable = config('boost.executable_paths.php');
+
+        if ($phpExecutable) {
+            return "{$phpExecutable} {$command}";
+        }
+
+        if ($this->config->usesSail) {
+            return Sail::command("php {$command}");
+        }
+
+        return "php {$command}";
     }
 
     public function composerCommand(string $command): string

--- a/tests/Feature/Install/GuidelineComposerTest.php
+++ b/tests/Feature/Install/GuidelineComposerTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\File;
 use Laravel\Boost\Install\GuidelineAssist;
 use Laravel\Boost\Install\GuidelineComposer;
 use Laravel\Boost\Install\GuidelineConfig;
@@ -67,6 +68,50 @@ test('includes package guidelines only for installed packages', function (): voi
         ->toContain('=== pest/core rules ===')
         ->not->toContain('=== inertia-react/core rules ===');
 });
+
+test('includes Pest 5 TIA guidance only when locally enabled', function (string $version, ?string $configuration, bool $expected): void {
+    config(['boost.rules.enabled' => false]);
+
+    $originalBasePath = base_path();
+    $basePath = sys_get_temp_dir().'/boost-pest-tia-guideline-'.bin2hex(random_bytes(4));
+
+    File::ensureDirectoryExists($basePath.'/tests');
+    app()->setBasePath($basePath);
+
+    if ($configuration !== null) {
+        File::put($basePath.'/tests/Pest.php', "<?php\n\n{$configuration}\n");
+    }
+
+    try {
+        mockProjectPackages($this->project, new PackageCollection([
+            rosterPackage('laravel/framework', '11.0.0'),
+            rosterPackage('pestphp/pest', $version),
+        ]));
+
+        $guidelines = $this->composer->compose();
+
+        if ($expected) {
+            expect($guidelines)
+                ->toContain('=== pest/v5 rules ===')
+                ->toContain('Pest 5 Test Impact Analysis')
+                ->toContain('php artisan test --compact')
+                ->toContain('php ./vendor/bin/pest --compact --tia --fresh')
+                ->toContain('php ./vendor/bin/pest --compact --no-tia');
+        } else {
+            expect($guidelines)
+                ->not->toContain('=== pest/v5 rules ===')
+                ->not->toContain('Pest 5 Test Impact Analysis');
+        }
+    } finally {
+        app()->setBasePath($originalBasePath);
+        File::deleteDirectory($basePath);
+    }
+})->with([
+    'Pest 5 with local TIA' => ['5.0.0', 'pest()->tia()->locally();', true],
+    'Pest 5 without TIA configuration' => ['5.0.0', null, false],
+    'Pest 5 with always-on TIA' => ['5.0.0', 'pest()->tia()->always();', false],
+    'Pest 4 with local TIA syntax' => ['4.1.0', 'pest()->tia()->locally();', false],
+]);
 
 test('excludes scoped block content from the composed blob when scoped guidelines are enabled', function (): void {
     config(['boost.rules.scoped_guidelines' => true]);

--- a/tests/Unit/Install/GuidelineAssistTest.php
+++ b/tests/Unit/Install/GuidelineAssistTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\File;
 use Laravel\Boost\Install\GuidelineAssist;
 use Laravel\Boost\Install\GuidelineConfig;
 use Laravel\Boost\Install\Sail;
@@ -36,6 +37,67 @@ test('php executable config takes precedence over Sail', function (): void {
 
     expect($assist->artisan())->toBe('/usr/local/bin/php8.3 artisan');
 });
+
+test('php command falls back to the system PHP executable', function (): void {
+    config(['boost.executable_paths.php' => null]);
+
+    $assist = new GuidelineAssist($this->project, $this->config);
+
+    expect($assist->phpCommand('./vendor/bin/pest --compact'))
+        ->toBe('php ./vendor/bin/pest --compact');
+});
+
+test('php command falls back to Sail when no executable is configured', function (): void {
+    config(['boost.executable_paths.php' => null]);
+    $this->config->usesSail = true;
+
+    $assist = new GuidelineAssist($this->project, $this->config);
+
+    expect($assist->phpCommand('./vendor/bin/pest --compact'))
+        ->toBe(Sail::command('php ./vendor/bin/pest --compact'));
+});
+
+test('configured PHP executable takes precedence over Sail for PHP commands', function (): void {
+    config(['boost.executable_paths.php' => 'herd php']);
+    $this->config->usesSail = true;
+
+    $assist = new GuidelineAssist($this->project, $this->config);
+
+    expect($assist->phpCommand('./vendor/bin/pest --compact'))
+        ->toBe('herd php ./vendor/bin/pest --compact');
+});
+
+test('detects locally enabled Pest TIA configuration', function (?string $configuration, bool $expected): void {
+    $originalBasePath = base_path();
+    $basePath = sys_get_temp_dir().'/boost-pest-tia-'.bin2hex(random_bytes(4));
+
+    File::ensureDirectoryExists($basePath.'/tests');
+    app()->setBasePath($basePath);
+
+    if ($configuration !== null) {
+        File::put($basePath.'/tests/Pest.php', "<?php\n\n{$configuration}\n");
+    }
+
+    try {
+        $assist = new GuidelineAssist($this->project, $this->config);
+
+        expect($assist->hasLocallyEnabledPestTia())->toBe($expected);
+    } finally {
+        app()->setBasePath($originalBasePath);
+        File::deleteDirectory($basePath);
+    }
+})->with([
+    'single line' => ['pest()->tia()->locally();', true],
+    'multiline chain' => ["pest()->tia()\n    ->baselined()\n    ->locally();", true],
+    'case-insensitive global call' => ['PEST()->TIA()->LOCALLY();', true],
+    'fully-qualified global call' => ['\pest()->tia()->locally();', true],
+    'commented out' => ['// pest()->tia()->locally();', false],
+    'string example' => ["\$example = 'pest()->tia()->locally();';", false],
+    'variable function' => ['$pest()->tia()->locally();', false],
+    'object method' => ['$object->pest()->tia()->locally();', false],
+    'always enabled' => ['pest()->tia()->always();', false],
+    'missing Pest configuration' => [null, false],
+]);
 
 test('composer executable falls back to Sail when no config is set', function (): void {
     config(['boost.executable_paths.composer' => null]);


### PR DESCRIPTION
## Summary

- add global Pest 5 TIA guidance only when `tests/Pest.php` enables `pest()->tia()->locally()`
- render direct Pest commands through plain PHP, Sail, or a configured PHP executable such as `herd php`
- ignore commented and string examples while keeping the guidance limited to Pest 5 projects

## Benefit

Agents can use affected-test replay for routine local verification, rebuild stale dependency graphs, and intentionally run the complete suite before high-risk changes without hard-coding a developer-specific runner. Projects that install Pest 5 without enabling local TIA are unchanged.

## Testing

- `vendor/bin/pest --compact tests/Unit/Install/GuidelineAssistTest.php tests/Feature/Install/GuidelineComposerTest.php` (116 tests, 287 assertions)
- `vendor/bin/pest --compact`
- `vendor/bin/phpstan --memory-limit=-1`
- `vendor/bin/pint --dirty --format agent`