### PR TITLE
Fix newline normalization corrupting multi-byte UTF-8 in rule files

### DIFF
--- a/src/Rules/RuleFrontmatter.php
+++ b/src/Rules/RuleFrontmatter.php
@@ -10,21 +10,11 @@ use Throwable;
 class RuleFrontmatter
 {
     /**
-     * Matches CRLF, CR and LF only.
-     *
-     * `\R` cannot be used here: without the `u` modifier PCRE matches byte by
-     * byte and `\R` also covers NEL (0x85), which is a continuation byte of
-     * many multi-byte UTF-8 characters. The `u` modifier is not an option
-     * either, since it makes preg_replace() return null for invalid UTF-8.
-     */
-    public const NEWLINE_PATTERN = '/\r\n|\n|\r/';
-
-    /**
      * @return array{paths: array<int, string>, body: string}
      */
     public static function parse(string $content): array
     {
-        $content = (string) preg_replace(self::NEWLINE_PATTERN, "\n", $content);
+        $content = str_replace(["\r\n", "\r"], "\n", $content);
 
         if (preg_match('/^\s*---\s*\n(.*?)\n---\s*\n?/s', $content, $matches) !== 1) {
             return ['paths' => [], 'body' => $content];

--- a/src/Rules/RuleFrontmatter.php
+++ b/src/Rules/RuleFrontmatter.php
@@ -10,11 +10,21 @@ use Throwable;
 class RuleFrontmatter
 {
     /**
+     * Matches CRLF, CR and LF only.
+     *
+     * `\R` cannot be used here: without the `u` modifier PCRE matches byte by
+     * byte and `\R` also covers NEL (0x85), which is a continuation byte of
+     * many multi-byte UTF-8 characters. The `u` modifier is not an option
+     * either, since it makes preg_replace() return null for invalid UTF-8.
+     */
+    public const NEWLINE_PATTERN = '/\r\n|\n|\r/';
+
+    /**
      * @return array{paths: array<int, string>, body: string}
      */
     public static function parse(string $content): array
     {
-        $content = (string) preg_replace('/\R/', "\n", $content);
+        $content = (string) preg_replace(self::NEWLINE_PATTERN, "\n", $content);
 
         if (preg_match('/^\s*---\s*\n(.*?)\n---\s*\n?/s', $content, $matches) !== 1) {
             return ['paths' => [], 'body' => $content];

--- a/src/Rules/RuleRepository.php
+++ b/src/Rules/RuleRepository.php
@@ -116,7 +116,7 @@ class RuleRepository
     public function write(string $glob, string $title, string $note): string
     {
         $glob = trim($glob);
-        $title = trim((string) preg_replace(RuleFrontmatter::NEWLINE_PATTERN, ' ', $title));
+        $title = trim(str_replace(["\r\n", "\r", "\n"], ' ', $title));
         $note = trim($note);
 
         $target = $this->resolveTargetFile($glob);
@@ -287,7 +287,7 @@ class RuleRepository
             try {
                 $parsed = $this->parse($path);
             } catch (Throwable) {
-                $raw = (string) preg_replace(RuleFrontmatter::NEWLINE_PATTERN, "\n", (string) File::get($path));
+                $raw = str_replace(["\r\n", "\r"], "\n", (string) File::get($path));
                 $parsed = ['paths' => [], 'body' => $raw];
             }
         }

--- a/src/Rules/RuleRepository.php
+++ b/src/Rules/RuleRepository.php
@@ -116,7 +116,7 @@ class RuleRepository
     public function write(string $glob, string $title, string $note): string
     {
         $glob = trim($glob);
-        $title = trim((string) preg_replace('/\R/', ' ', $title));
+        $title = trim((string) preg_replace(RuleFrontmatter::NEWLINE_PATTERN, ' ', $title));
         $note = trim($note);
 
         $target = $this->resolveTargetFile($glob);
@@ -287,7 +287,7 @@ class RuleRepository
             try {
                 $parsed = $this->parse($path);
             } catch (Throwable) {
-                $raw = (string) preg_replace('/\R/', "\n", (string) File::get($path));
+                $raw = (string) preg_replace(RuleFrontmatter::NEWLINE_PATTERN, "\n", (string) File::get($path));
                 $parsed = ['paths' => [], 'body' => $raw];
             }
         }

--- a/tests/Feature/Mcp/Tools/RuleToolsTest.php
+++ b/tests/Feature/Mcp/Tools/RuleToolsTest.php
@@ -226,6 +226,53 @@ it('normalizes an absolute path glob to the same area as its relative twin', fun
         ->not->toContain(base_path('app/Http/Controllers/**'));
 });
 
+it('keeps multi-byte characters in a title and note intact', function (): void {
+    // Every one of these characters contains the byte 0x85, which PCRE matches
+    // as NEL when a pattern using `\R` runs outside UTF-8 mode.
+    $title = 'Encoding check: х ゅ 🙅';
+    $note = 'These all contain 0x85: х (U+0445), ゅ (U+3085), 🙅 (U+1F645).';
+
+    $response = (new RecordRule($this->repository))->handle(new Request([
+        'glob' => 'app/Http/Controllers/**',
+        'title' => $title,
+        'note' => $note,
+    ]));
+
+    expect($response)->isToolResult()->toolHasNoError();
+
+    $contents = File::get($this->rulesDir.'/controllers.md');
+
+    expect(mb_check_encoding($contents, 'UTF-8'))->toBeTrue();
+    expect($contents)
+        ->toContain('## '.$title)
+        ->toContain($note);
+});
+
+it('keeps multi-byte characters in earlier entries when a new glob is merged in', function (): void {
+    $tool = new RecordRule($this->repository);
+
+    $tool->handle(new Request([
+        'glob' => 'app/Models/**',
+        'title' => 'Encoding check: х ゅ 🙅',
+        'note' => 'Keep these bytes: х ゅ 🙅.',
+    ]));
+
+    // Merging a new glob into an existing area rewrites the whole file through
+    // the frontmatter parser.
+    $tool->handle(new Request([
+        'glob' => 'app/Models/*.php',
+        'title' => 'Second model note',
+        'note' => 'Watch the users table.',
+    ]));
+
+    $contents = File::get($this->rulesDir.'/models.md');
+
+    expect(mb_check_encoding($contents, 'UTF-8'))->toBeTrue();
+    expect($contents)
+        ->toContain('## Encoding check: х ゅ 🙅')
+        ->toContain('Keep these bytes: х ゅ 🙅.');
+});
+
 it('writes a placeholder index when no rule files have paths', function (): void {
     $this->repository->writeIndex();
 

--- a/tests/Feature/Mcp/Tools/RuleToolsTest.php
+++ b/tests/Feature/Mcp/Tools/RuleToolsTest.php
@@ -7,6 +7,17 @@ use Laravel\Boost\Mcp\Tools\RecordRule;
 use Laravel\Boost\Rules\RuleRepository;
 use Laravel\Mcp\Request;
 
+/**
+ * @return array<int, string>
+ */
+function ruleFiles(string $directory): array
+{
+    return array_values(array_filter(
+        glob($directory.'/*.md') ?: [],
+        fn (string $file): bool => basename($file) !== 'index.md',
+    ));
+}
+
 beforeEach(function (): void {
     $this->originalBasePath = base_path();
     $this->rulesBasePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.'boost-rules-test-'.uniqid();
@@ -26,9 +37,7 @@ afterEach(function (): void {
 });
 
 it('writes a rule into an area file with frontmatter and an entry', function (): void {
-    $tool = new RecordRule($this->repository);
-
-    $response = $tool->handle(new Request([
+    $response = (new RecordRule($this->repository))->handle(new Request([
         'glob' => 'app/Http/Controllers/**',
         'title' => 'Extend BaseController for tenant scoping',
         'note' => 'New controllers must extend App\Http\Controllers\BaseController.',
@@ -37,11 +46,7 @@ it('writes a rule into an area file with frontmatter and an entry', function ():
     expect($response)->isToolResult()->toolHasNoError()
         ->toolTextContains('controllers.md', 'Extend BaseController for tenant scoping');
 
-    $file = $this->rulesDir.'/controllers.md';
-    expect(File::exists($file))->toBeTrue();
-
-    $contents = File::get($file);
-    expect($contents)
+    expect(File::get($this->rulesDir.'/controllers.md'))
         ->toContain('paths:')
         ->toContain('app/Http/Controllers/**')
         ->toContain('# Controllers')
@@ -51,22 +56,14 @@ it('writes a rule into an area file with frontmatter and an entry', function ():
 it('groups a second rule for the same glob into the same file', function (): void {
     $tool = new RecordRule($this->repository);
 
-    $tool->handle(new Request([
-        'glob' => 'app/Http/Controllers/**',
-        'title' => 'First',
-        'note' => 'One.',
-    ]));
-
+    $tool->handle(new Request(['glob' => 'app/Http/Controllers/**', 'title' => 'First', 'note' => 'One.']));
     $tool->handle(new Request([
         'glob' => 'app/Http/Controllers/**',
         'title' => 'Form Requests over inline validation',
         'note' => 'Validate in Form Request classes.',
     ]));
 
-    $files = glob($this->rulesDir.'/*.md');
-    $files = array_filter($files, fn (string $f): bool => basename($f) !== 'index.md');
-
-    expect($files)->toHaveCount(1);
+    expect(ruleFiles($this->rulesDir))->toHaveCount(1);
     expect(File::get($this->rulesDir.'/controllers.md'))
         ->toContain('## First')
         ->toContain('## Form Requests over inline validation');
@@ -88,13 +85,8 @@ it('merges a new glob into an existing area file without losing entries', functi
         'note' => 'Watch the users table.',
     ]));
 
-    $files = glob($this->rulesDir.'/*.md');
-    $files = array_filter($files, fn (string $f): bool => basename($f) !== 'index.md');
-
-    expect($files)->toHaveCount(1);
-
-    $contents = File::get($this->rulesDir.'/models.md');
-    expect($contents)
+    expect(ruleFiles($this->rulesDir))->toHaveCount(1);
+    expect(File::get($this->rulesDir.'/models.md'))
         ->toContain('app/Models/**')
         ->toContain('app/Models/*.php')
         ->toContain('## First model note')
@@ -103,28 +95,13 @@ it('merges a new glob into an existing area file without losing entries', functi
         ->toContain('Watch the users table.');
 });
 
-it('routes different globs to their own area files', function (): void {
-    $tool = new RecordRule($this->repository);
-
-    $tool->handle(new Request(['glob' => 'app/Http/Controllers/**', 'title' => 'A', 'note' => 'a']));
-    $tool->handle(new Request(['glob' => 'app/Models/*.php', 'title' => 'B', 'note' => 'b']));
-
-    expect(File::exists($this->rulesDir.'/controllers.md'))->toBeTrue();
-    expect(File::exists($this->rulesDir.'/models.md'))->toBeTrue();
-});
-
 it('keeps distinct areas that share a last path segment in separate files', function (): void {
     $tool = new RecordRule($this->repository);
 
     $tool->handle(new Request(['glob' => 'app/Admin/Controllers/**', 'title' => 'Admin rule', 'note' => 'Admin only.']));
     $tool->handle(new Request(['glob' => 'app/Api/Controllers/**', 'title' => 'Api rule', 'note' => 'Api only.']));
 
-    $files = glob($this->rulesDir.'/*.md');
-    $files = array_filter($files, fn (string $f): bool => basename($f) !== 'index.md');
-
-    expect($files)->toHaveCount(2);
-    expect(File::exists($this->rulesDir.'/controllers.md'))->toBeTrue();
-    expect(File::exists($this->rulesDir.'/api-controllers.md'))->toBeTrue();
+    expect(ruleFiles($this->rulesDir))->toHaveCount(2);
 
     expect(File::get($this->rulesDir.'/controllers.md'))
         ->toContain('app/Admin/Controllers/**')
@@ -139,13 +116,29 @@ it('keeps distinct areas that share a last path segment in separate files', func
         ->not->toContain('## Admin rule');
 });
 
+it('normalizes an absolute path glob to the same area as its relative twin', function (): void {
+    $tool = new RecordRule($this->repository);
+
+    $tool->handle(new Request(['glob' => 'app/Http/Controllers/**', 'title' => 'Relative', 'note' => 'a']));
+    $tool->handle(new Request([
+        'glob' => base_path('app/Http/Controllers/**'),
+        'title' => 'Absolute',
+        'note' => 'b',
+    ]));
+
+    expect(ruleFiles($this->rulesDir))->toHaveCount(1);
+    expect(File::get($this->rulesDir.'/controllers.md'))
+        ->toContain('## Relative')
+        ->toContain('## Absolute')
+        ->not->toContain(base_path('app/Http/Controllers/**'));
+});
+
 it('does not record a rule into the reserved index file', function (): void {
     $located = $this->repository->write('index/**', 'Index area rule', 'This must survive.');
 
     expect(basename((string) $located))->not->toBe('index.md');
 
-    $index = File::get($this->rulesDir.'/index.md');
-    expect($index)
+    expect(File::get($this->rulesDir.'/index.md'))
         ->toContain('# Project Rules Index')
         ->toContain('index/**')
         ->not->toContain('This must survive.');
@@ -155,17 +148,15 @@ it('does not record a rule into the reserved index file', function (): void {
         ->toContain('This must survive.');
 });
 
-it('rejects a rule with a missing glob, title, or note', function (): void {
-    $response = (new RecordRule($this->repository))->handle(new Request([
-        'glob' => 'app/**',
-        'title' => '',
-        'note' => 'y',
-    ]));
+it('rejects a rule with a missing glob, title, or note', function (string $missing): void {
+    $arguments = ['glob' => 'app/**', 'title' => 'A title', 'note' => 'A note'];
+    $arguments[$missing] = '';
+
+    $response = (new RecordRule($this->repository))->handle(new Request($arguments));
 
     expect($response)->isToolResult()->toolHasError()
-        ->toolTextContains('non-empty glob, title, and note')
-        ->toolTextContains('Missing or empty: title');
-});
+        ->toolTextContains('non-empty glob, title, and note', 'Missing or empty: '.$missing.'.');
+})->with(['glob', 'title', 'note']);
 
 it('is gated by the rules enabled config flag', function (): void {
     config()->set('boost.rules.enabled', false);
@@ -181,9 +172,8 @@ it('regenerates index.md mapping globs to rule files on every write', function (
     $tool->handle(new Request(['glob' => 'app/Http/Controllers/**', 'title' => 'A', 'note' => 'a']));
     $tool->handle(new Request(['glob' => 'app/Models/*.php', 'title' => 'B', 'note' => 'b']));
 
-    $index = $this->rulesDir.'/index.md';
-    expect(File::exists($index))->toBeTrue();
-    expect(File::get($index))
+    expect(ruleFiles($this->rulesDir))->toHaveCount(2);
+    expect(File::get($this->rulesDir.'/index.md'))
         ->toContain('app/Http/Controllers/**')
         ->toContain('.ai/rules/controllers.md')
         ->toContain('app/Models/*.php')
@@ -206,73 +196,6 @@ it('excludes a rule file with no paths frontmatter from the index', function ():
         ->not->toContain('entire project');
 });
 
-it('normalizes an absolute path glob to the same area as its relative twin', function (): void {
-    $tool = new RecordRule($this->repository);
-
-    $tool->handle(new Request(['glob' => 'app/Http/Controllers/**', 'title' => 'Relative', 'note' => 'a']));
-    $tool->handle(new Request([
-        'glob' => base_path('app/Http/Controllers/**'),
-        'title' => 'Absolute',
-        'note' => 'b',
-    ]));
-
-    $files = glob($this->rulesDir.'/*.md');
-    $files = array_filter($files, fn (string $f): bool => basename($f) !== 'index.md');
-
-    expect($files)->toHaveCount(1);
-    expect(File::get($this->rulesDir.'/controllers.md'))
-        ->toContain('## Relative')
-        ->toContain('## Absolute')
-        ->not->toContain(base_path('app/Http/Controllers/**'));
-});
-
-it('keeps multi-byte characters in a title and note intact', function (): void {
-    // Every one of these characters contains the byte 0x85, which PCRE matches
-    // as NEL when a pattern using `\R` runs outside UTF-8 mode.
-    $title = 'Encoding check: х ゅ 🙅';
-    $note = 'These all contain 0x85: х (U+0445), ゅ (U+3085), 🙅 (U+1F645).';
-
-    $response = (new RecordRule($this->repository))->handle(new Request([
-        'glob' => 'app/Http/Controllers/**',
-        'title' => $title,
-        'note' => $note,
-    ]));
-
-    expect($response)->isToolResult()->toolHasNoError();
-
-    $contents = File::get($this->rulesDir.'/controllers.md');
-
-    expect(mb_check_encoding($contents, 'UTF-8'))->toBeTrue();
-    expect($contents)
-        ->toContain('## '.$title)
-        ->toContain($note);
-});
-
-it('keeps multi-byte characters in earlier entries when a new glob is merged in', function (): void {
-    $tool = new RecordRule($this->repository);
-
-    $tool->handle(new Request([
-        'glob' => 'app/Models/**',
-        'title' => 'Encoding check: х ゅ 🙅',
-        'note' => 'Keep these bytes: х ゅ 🙅.',
-    ]));
-
-    // Merging a new glob into an existing area rewrites the whole file through
-    // the frontmatter parser.
-    $tool->handle(new Request([
-        'glob' => 'app/Models/*.php',
-        'title' => 'Second model note',
-        'note' => 'Watch the users table.',
-    ]));
-
-    $contents = File::get($this->rulesDir.'/models.md');
-
-    expect(mb_check_encoding($contents, 'UTF-8'))->toBeTrue();
-    expect($contents)
-        ->toContain('## Encoding check: х ゅ 🙅')
-        ->toContain('Keep these bytes: х ゅ 🙅.');
-});
-
 it('writes a placeholder index when no rule files have paths', function (): void {
     $this->repository->writeIndex();
 
@@ -280,4 +203,32 @@ it('writes a placeholder index when no rule files have paths', function (): void
         ->toContain('# Project Rules Index')
         ->toContain('No rules recorded yet.')
         ->not->toContain('| Applies to |');
+});
+
+it('keeps multi-byte characters intact when writing and when merging a new glob', function (): void {
+    $title = 'Encoding check: х ゅ 🙅 ✅';
+    $note = 'These all contain 0x85: х (U+0445), ゅ (U+3085), 🙅 (U+1F645), ✅ (U+2705).';
+
+    $tool = new RecordRule($this->repository);
+    $file = $this->rulesDir.'/models.md';
+
+    $response = $tool->handle(new Request([
+        'glob' => 'app/Models/**',
+        'title' => $title,
+        'note' => $note,
+    ]));
+
+    expect($response)->isToolResult()->toolHasNoError();
+    expect(mb_check_encoding(File::get($file), 'UTF-8'))->toBeTrue();
+
+    $tool->handle(new Request([
+        'glob' => 'app/Models/*.php',
+        'title' => 'Second model note',
+        'note' => 'Watch the users table.',
+    ]));
+
+    expect(mb_check_encoding(File::get($file), 'UTF-8'))->toBeTrue();
+    expect(File::get($file))
+        ->toContain('## '.$title)
+        ->toContain($note);
 });


### PR DESCRIPTION
`record-rule` writes broken bytes into `.ai/rules/*.md` whenever a rule contains a multi-byte character whose UTF-8 encoding includes the byte `0x85`. The file stops being valid UTF-8 and the tool still reports success.

### Cause

`RuleFrontmatter::parse()` and `RuleRepository::write()` normalize newlines with `preg_replace('/\R/', ...)` and no `u` modifier, so PCRE matches byte by byte. In 8-bit mode `\R` also matches NEL (`0x85`) — which is a continuation byte of a great many characters:

| character | UTF-8 |
| --- | --- |
| `х` U+0445 | `D1 85` |
| `ゅ` U+3085 | `E3 82 85` |
| `🙅` U+1F645 | `F0 9F 99 85` |

The `0x85` is replaced with a newline (or a space, for the title), the leading bytes are left orphaned:

```php
bin2hex('данных');                                 // d0b4d0b0d0bdd0bdd18b d185
bin2hex(preg_replace('/\R/', ' ', 'данных'));      // d0b4d0b0d0bdd0bdd18b d120  <- "х" lost its 0x85
```

(PHP 8.4, PCRE2 10.44.)

### Impact

- `RuleRepository::write()` — the title of the rule being recorded.
- `RuleFrontmatter::parse()` — the **whole file**, every time a new glob is merged into an existing area file: `ensureGlobApplied()` writes the parsed body back, so rules recorded earlier are silently destroyed.

Seen in the wild on a project with cyrillic letters: two area files ended up with invalid bytes over several sessions before anyone noticed.

### Fix

An explicit `/\r\n|\n|\r/`, shared as `RuleFrontmatter::NEWLINE_PATTERN`. `'/\R/u'` was deliberately not used: `preg_replace()` returns `null` for invalid UTF-8 input, which would blank the file instead of merely mangling it.

### Tests

Two cases added to `tests/Feature/Mcp/Tools/RuleToolsTest.php` — a title/note round-trip, and merging a new glob into an existing area file. Both fail on `main` and pass with this change.