### PR TITLE
Point the Livewire 4 stream migration at the correct parameter

### DIFF
--- a/src/Mcp/Prompts/UpgradeLivewirev4/upgrade-livewire-v4.blade.php
+++ b/src/Mcp/Prompts/UpgradeLivewirev4/upgrade-livewire-v4.blade.php
@@ -44,7 +44,7 @@ Search the codebase for patterns affected by v4 changes:
 
 **Medium Priority Searches:**
 - `wire:transition` with modifiers (`.opacity`, `.scale`, `.duration`) - Modifiers removed
-- `$this->stream(` - Parameter order changed; positional calls now fail silently
+- `$this->stream(` - Positional calls fail silently; named calls using `to:` are unchanged
 - Array property replacements from JavaScript - Hook behavior changed
 
 **Low Priority Searches:**
@@ -326,29 +326,29 @@ If you're extending Livewire's core functionality or using these methods directl
 
 **Streaming:**
 
-The `stream()` method parameter order has changed, and the target is now split across three parameters:
+The `stream()` method parameter order has changed, and the target is now split across three parameters. **Named-parameter calls need no changes at all** - `to:` is still valid in v4 and is what the v4 `wire:stream` documentation uses throughout:
 
 @boostsnippet('Stream Method Signature', 'php')
-// Before (v3)
-$this->stream(to: 'status', content: 'Hello', replace: true);
+// Valid in both v3 and v4 - leave this alone
+$this->stream(to: 'target', content: 'Hello', replace: true);
 
-// After (v4) - `to:` still works as an alias for `name:`
-$this->stream(content: 'Hello', replace: true, name: 'status');
+// Equivalent in v4 - `to:` is an alias for `name:`
+$this->stream(content: 'Hello', replace: true, name: 'target');
 @endboostsnippet
 
-`name:` targets a `wire:stream="status"` directive, which is exactly what `to:` did in v3, so named-parameter calls keep working untouched. v4 adds `el:` for a CSS selector and `ref:` for a `wire:ref`. Do not use `el:` to replace `to:` - it targets a different thing and streaming will silently stop working.
+`name:` (and `to:`) match a `wire:stream="target"` directive, so the value is a directive name, never a CSS selector. v4 also accepts `el:` for a CSS selector and `ref:` for a `wire:ref`. Do not use `el:` to replace `to:` - it targets by selector instead of by directive name, so streaming silently stops working.
 
-Positional calls do break, and they break silently:
+Only positional calls break, and they break silently:
 
 @boostsnippet('Stream Positional Parameters', 'php')
-// Before (v3) - ('status', 'Hello') meant (target, content)
-$this->stream('status', 'Hello');
+// Before (v3) - ('target', 'Hello') meant (target, content)
+$this->stream('target', 'Hello');
 
 // After (v4) - the first argument is now the content
-$this->stream('Hello', name: 'status');
+$this->stream('Hello', name: 'target');
 @endboostsnippet
 
-Left unchanged, the v3 positional form streams the literal string `"status"` into the component root and treats `'Hello'` as `replace: true`. No error is raised.
+Left unchanged, the v3 positional form binds `'target'` to `content:` and `'Hello'` to `replace:`, leaves every target parameter null, and streams nothing at all. No error is raised.
 
 [Learn more about streaming →](/docs/4.x/wire-stream)
 

--- a/src/Mcp/Prompts/UpgradeLivewirev4/upgrade-livewire-v4.blade.php
+++ b/src/Mcp/Prompts/UpgradeLivewirev4/upgrade-livewire-v4.blade.php
@@ -333,17 +333,17 @@ The `stream()` method parameter order has changed:
 $this->stream(to: '#container', content: 'Hello', replace: true);
 
 // After (v4)
-$this->stream(content: 'Hello', replace: true, el: '#container');
+$this->stream(content: 'Hello', replace: true, name: '#container');
 @endboostsnippet
 
-If you're using named parameters (as shown above), note that `to:` has been renamed to `el:`. If you're using positional parameters, you'll need to update to the following:
+If you're using named parameters (as shown above), note that `to:` has been renamed to `name:`. If you're using positional parameters, you'll need to update to the following:
 
 @boostsnippet('Stream Positional Parameters', 'php')
 // Before (v3) - positional parameters
 $this->stream('#container', 'Hello');
 
 // After (v4) - positional/named parameters
-$this->stream('Hello', el: '#container');
+$this->stream('Hello', name: '#container');
 @endboostsnippet
 
 [Learn more about streaming →](/docs/4.x/wire-stream)

--- a/src/Mcp/Prompts/UpgradeLivewirev4/upgrade-livewire-v4.blade.php
+++ b/src/Mcp/Prompts/UpgradeLivewirev4/upgrade-livewire-v4.blade.php
@@ -44,7 +44,7 @@ Search the codebase for patterns affected by v4 changes:
 
 **Medium Priority Searches:**
 - `wire:transition` with modifiers (`.opacity`, `.scale`, `.duration`) - Modifiers removed
-- `$this->stream(` - Parameter order changed
+- `$this->stream(` - Parameter order changed; positional calls now fail silently
 - Array property replacements from JavaScript - Hook behavior changed
 
 **Low Priority Searches:**
@@ -326,25 +326,29 @@ If you're extending Livewire's core functionality or using these methods directl
 
 **Streaming:**
 
-The `stream()` method parameter order has changed:
+The `stream()` method parameter order has changed, and the target is now split across three parameters:
 
 @boostsnippet('Stream Method Signature', 'php')
 // Before (v3)
-$this->stream(to: '#container', content: 'Hello', replace: true);
+$this->stream(to: 'status', content: 'Hello', replace: true);
 
-// After (v4)
-$this->stream(content: 'Hello', replace: true, name: '#container');
+// After (v4) - `to:` still works as an alias for `name:`
+$this->stream(content: 'Hello', replace: true, name: 'status');
 @endboostsnippet
 
-If you're using named parameters (as shown above), note that `to:` has been renamed to `name:`. If you're using positional parameters, you'll need to update to the following:
+`name:` targets a `wire:stream="status"` directive, which is exactly what `to:` did in v3, so named-parameter calls keep working untouched. v4 adds `el:` for a CSS selector and `ref:` for a `wire:ref`. Do not use `el:` to replace `to:` - it targets a different thing and streaming will silently stop working.
+
+Positional calls do break, and they break silently:
 
 @boostsnippet('Stream Positional Parameters', 'php')
-// Before (v3) - positional parameters
-$this->stream('#container', 'Hello');
+// Before (v3) - ('status', 'Hello') meant (target, content)
+$this->stream('status', 'Hello');
 
-// After (v4) - positional/named parameters
-$this->stream('Hello', name: '#container');
+// After (v4) - the first argument is now the content
+$this->stream('Hello', name: 'status');
 @endboostsnippet
+
+Left unchanged, the v3 positional form streams the literal string `"status"` into the component root and treats `'Hello'` as `replace: true`. No error is raised.
 
 [Learn more about streaming →](/docs/4.x/wire-stream)
 


### PR DESCRIPTION
The v4 upgrade guide says `to:` became `el:` on `stream()`. It became `name:`.

Ran all three against Livewire v4.4.0 and dumped the streamed payload:

```
to:    type=directive  name="count"   el=null
name:  type=directive  name="count"   el=null
el:    type=element    name=null      el="count"
```

`to:` and `name:` are identical. `el:` produces a different stream type, so it stops matching `wire:stream="count"` and gets treated as a CSS selector instead. Livewire's own shim agrees: `if ($to) $name = $to;` under a "legacy 'to' parameter" comment.

So following the guide, streaming quietly stops working during the upgrade.
