### PR TITLE
Correct the Wayfinder query parameter return value

### DIFF
--- a/.ai/wayfinder/skill/wayfinder-development/SKILL.blade.php
+++ b/.ai/wayfinder/skill/wayfinder-development/SKILL.blade.php
@@ -55,7 +55,7 @@ destroy.delete(1)
 store.form() // { action: "/posts", method: "post" }
 
 // Query parameters...
-show(1, { query: { page: 1 } }) // "/posts/1?page=1"
+show(1, { query: { page: 1 } }) // { url: "/posts/1?page=1", method: "get" }
 @endboostsnippet
 
 @if($assist->project->php()->uses(\Laravel\Boost\Support\PackageRegistry::INERTIA_LARAVEL) || $assist->project->js()->uses([\Laravel\Boost\Support\PackageRegistry::INERTIA_REACT, \Laravel\Boost\Support\PackageRegistry::INERTIA_VUE, \Laravel\Boost\Support\PackageRegistry::INERTIA_SVELTE]))


### PR DESCRIPTION
The query parameter example says `show()` returns a URL string. It returns the route object.

Generated the route with `wayfinder:generate` and ran it:

```
show(1, {query})     -> {"url":"/posts/1?page=1","method":"get"}  typeof: object
show.url(1, {query}) -> "/posts/1?page=1"                         typeof: string
interpolated into an href: [object Object]
```

Only `.url()` gives you the string. The line right above already shows `show(1)` returning an object, so the snippet contradicts itself too.
