### PR TITLE
Add the missing PHP opening tag to the Volt class-based example

### DIFF
--- a/.ai/volt/skill/volt-development/SKILL.blade.php
+++ b/.ai/volt/skill/volt-development/SKILL.blade.php
@@ -43,6 +43,8 @@ $double = computed(fn () => $this->count * 2);
 ### Class-Based Components
 
 @boostsnippet("Volt Class-based Component", "php")
+<?php
+
 use Livewire\Volt\Component;
 
 new class extends Component {


### PR DESCRIPTION
The class-based example closes with `?>` but never opens with `<?php`, so copying it verbatim gives you a file that prints the PHP as text.

Four snippets in `.ai/` contain `?>`. The other three all open properly:

```
livewire/4  Single-File Component   <?php ... ?>
folio       Render Hook Example     <?php ... ?>
volt        Functional Component    <?php ... ?>
volt        Class-based Component          ... ?>
```

The tagless snippets elsewhere are fragments and have no `?>` either, so they're consistent. This one is the only unbalanced snippet in the repo.
