### PR TITLE
Point the Inertia Form reset props at the version that added them

### DIFF
--- a/.ai/inertia-react/2/skill/inertia-react-development/SKILL.blade.php
+++ b/.ai/inertia-react/2/skill/inertia-react-development/SKILL.blade.php
@@ -194,7 +194,7 @@ import { Form } from '@inertiajs/react'
 </Form>
 @endboostsnippet
 @else
-Note: This version of Inertia does not support `resetOnError`, `resetOnSuccess`, or `setDefaultsOnSuccess` on the `<Form>` component. Using these props will cause errors. Upgrade to Inertia v2.2.0+ to use these features.
+Note: This version of Inertia does not support `resetOnError`, `resetOnSuccess`, or `setDefaultsOnSuccess` on the `<Form>` component. Using these props will cause errors. Upgrade to Inertia v2.1.2+ to use these features.
 @endif
 
 Forms can also be built using the `useForm` helper for more programmatic control. Use the `search-docs` tool with a query of `useForm helper` for guidance.

--- a/.ai/inertia-svelte/2/skill/inertia-svelte-development/SKILL.blade.php
+++ b/.ai/inertia-svelte/2/skill/inertia-svelte-development/SKILL.blade.php
@@ -165,7 +165,7 @@ import { Form } from '@inertiajs/svelte'
 </Form>
 @endboostsnippet
 @else
-Note: This version of Inertia does not support `resetOnError`, `resetOnSuccess`, or `setDefaultsOnSuccess` on the `<Form>` component. Using these props will cause errors. Upgrade to Inertia v2.2.0+ to use these features.
+Note: This version of Inertia does not support `resetOnError`, `resetOnSuccess`, or `setDefaultsOnSuccess` on the `<Form>` component. Using these props will cause errors. Upgrade to Inertia v2.1.2+ to use these features.
 @endif
 
 Forms can also be built using the `useForm` hook for more programmatic control. Use the `search-docs` tool with a query of `useForm helper` for guidance.

--- a/.ai/inertia-vue/2/skill/inertia-vue-development/SKILL.blade.php
+++ b/.ai/inertia-vue/2/skill/inertia-vue-development/SKILL.blade.php
@@ -233,7 +233,7 @@ import { Form } from '@inertiajs/vue3'
 @endboostsnippet
 @endverbatim
 @else
-Note: This version of Inertia does not support `resetOnError`, `resetOnSuccess`, or `setDefaultsOnSuccess` on the `<Form>` component. Using these props will cause errors. Upgrade to Inertia v2.2.0+ to use these features.
+Note: This version of Inertia does not support `resetOnError`, `resetOnSuccess`, or `setDefaultsOnSuccess` on the `<Form>` component. Using these props will cause errors. Upgrade to Inertia v2.1.2+ to use these features.
 @endif
 
 Forms can also be built using the `useForm` composable for more programmatic control. Use the `search-docs` tool with a query of `useForm helper` for guidance.


### PR DESCRIPTION
The `<Form>` reset props note tells people to upgrade to v2.2.0. Those props landed in v2.1.2.

From the v2.1.2 release notes: "Add `resetOnError`, `resetOnSuccess`, `setDefaultsOnSuccess` to Form component" (inertiajs/inertia#2514). v2.2.0 was nested prop merging and `<InfiniteScroll>`.

Boost already has the right number in code, `hasFormComponentResets()` checks `gte('2.1.2')`, so the note was pointing further than it needs to. Same line in the vue, react and svelte skills.
