### PR TITLE
Invert "non-interactive" logic in `boost:install` and `boost:update`

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -50,7 +50,6 @@ class InstallCommand extends Command
         {--guidelines : Install AI guidelines}
         {--skills : Install agent skills}
         {--mcp : Install MCP server configuration}
-        {--no-third-party : Skip guidelines & skills shipped by third-party packages}
         {--packages= : Third-party packages to include, comma separated, or "all" or "none"}';
 
     /** @var Collection<int, Agent> */
@@ -271,10 +270,6 @@ class InstallCommand extends Command
             return $this->requestedThirdPartyPackages($packages);
         }
 
-        if ($this->option('no-third-party')) {
-            return collect();
-        }
-
         if ($packages->isEmpty()) {
             return collect();
         }
@@ -284,7 +279,9 @@ class InstallCommand extends Command
             ->values();
 
         if (! $this->input->isInteractive()) {
-            return $this->thirdPartyPackagesWithoutPrompt($packages, $defaults);
+            $this->reportSkippedThirdPartyPackages($packages->keys()->diff($defaults));
+
+            return $defaults;
         }
 
         return collect(multiselect(
@@ -323,28 +320,25 @@ class InstallCommand extends Command
         $unknown = $requested->reject(fn (string $name): bool => $packages->has($name));
 
         if ($unknown->isNotEmpty()) {
-            throw new Exception('Unknown third-party package(s) passed to --packages: '.$unknown->join(', ').'.');
+            $this->fail('Unknown third-party package(s) passed to --packages: '.$unknown->join(', ').'.');
         }
 
         return $requested;
     }
 
     /**
-     * A first install takes everything discovered; an existing config keeps its own answer.
+     * Third-party guidelines are rendered into agent instructions, so they stay opt-in.
      *
-     * @param  Collection<string, ThirdPartyPackage>  $packages
-     * @param  Collection<int, string>  $defaults
-     * @return Collection<int, string>
+     * @param  Collection<int, string>  $skipped
      */
-    protected function thirdPartyPackagesWithoutPrompt(Collection $packages, Collection $defaults): Collection
+    protected function reportSkippedThirdPartyPackages(Collection $skipped): void
     {
-        $selected = $this->config->isValid() ? $defaults : $packages->keys()->values();
-
-        if ($selected->isNotEmpty()) {
-            $this->line('Including third-party guidelines/skills: '.$selected->join(', ').'. Run [php artisan boost:install] interactively to change this.');
+        if ($skipped->isEmpty()) {
+            return;
         }
 
-        return $selected;
+        $this->line('Skipped third-party guidelines/skills from: '.$skipped->join(', ').'.');
+        $this->line('Review and add them with [php artisan boost:install], or --packages='.$skipped->first().'.');
     }
 
     protected function selectIntegrations(): void

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -50,7 +50,8 @@ class InstallCommand extends Command
         {--guidelines : Install AI guidelines}
         {--skills : Install agent skills}
         {--mcp : Install MCP server configuration}
-        {--no-third-party : Skip guidelines & skills shipped by third-party packages}';
+        {--no-third-party : Skip guidelines & skills shipped by third-party packages}
+        {--packages= : Third-party packages to include, comma separated, or "all" or "none"}';
 
     /** @var Collection<int, Agent> */
     private Collection $selectedAgents;
@@ -264,11 +265,15 @@ class InstallCommand extends Command
      */
     protected function selectThirdPartyPackages(): Collection
     {
+        $packages = ThirdPartyPackage::discover();
+
+        if ($this->option('packages') !== null) {
+            return $this->requestedThirdPartyPackages($packages);
+        }
+
         if ($this->option('no-third-party')) {
             return collect();
         }
-
-        $packages = ThirdPartyPackage::discover();
 
         if ($packages->isEmpty()) {
             return collect();
@@ -291,6 +296,37 @@ class InstallCommand extends Command
             scroll: 10,
             hint: 'You can add or remove them later by running this command again',
         ));
+    }
+
+    /**
+     * @param  Collection<string, ThirdPartyPackage>  $packages
+     * @return Collection<int, string>
+     *
+     * @throws Exception
+     */
+    protected function requestedThirdPartyPackages(Collection $packages): Collection
+    {
+        $requested = Str::of($this->option('packages'))
+            ->explode(',')
+            ->map(fn (string $name): string => trim($name))
+            ->filter()
+            ->values();
+
+        if ($requested->containsStrict('none')) {
+            return collect();
+        }
+
+        if ($requested->containsStrict('all')) {
+            return $packages->keys()->values();
+        }
+
+        $unknown = $requested->reject(fn (string $name): bool => $packages->has($name));
+
+        if ($unknown->isNotEmpty()) {
+            throw new Exception('Unknown third-party package(s) passed to --packages: '.$unknown->join(', ').'.');
+        }
+
+        return $requested;
     }
 
     /**

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -49,7 +49,8 @@ class InstallCommand extends Command
     protected $signature = 'boost:install
         {--guidelines : Install AI guidelines}
         {--skills : Install agent skills}
-        {--mcp : Install MCP server configuration}';
+        {--mcp : Install MCP server configuration}
+        {--no-third-party : Skip guidelines & skills shipped by third-party packages}';
 
     /** @var Collection<int, Agent> */
     private Collection $selectedAgents;
@@ -263,6 +264,10 @@ class InstallCommand extends Command
      */
     protected function selectThirdPartyPackages(): Collection
     {
+        if ($this->option('no-third-party')) {
+            return collect();
+        }
+
         $packages = ThirdPartyPackage::discover();
 
         if ($packages->isEmpty()) {
@@ -274,7 +279,7 @@ class InstallCommand extends Command
             ->values();
 
         if (! $this->input->isInteractive()) {
-            return $defaults;
+            return $this->thirdPartyPackagesWithoutPrompt($packages, $defaults);
         }
 
         return collect(multiselect(
@@ -286,6 +291,24 @@ class InstallCommand extends Command
             scroll: 10,
             hint: 'You can add or remove them later by running this command again',
         ));
+    }
+
+    /**
+     * A first install takes everything discovered; an existing config keeps its own answer.
+     *
+     * @param  Collection<string, ThirdPartyPackage>  $packages
+     * @param  Collection<int, string>  $defaults
+     * @return Collection<int, string>
+     */
+    protected function thirdPartyPackagesWithoutPrompt(Collection $packages, Collection $defaults): Collection
+    {
+        $selected = $this->config->isValid() ? $defaults : $packages->keys()->values();
+
+        if ($selected->isNotEmpty()) {
+            $this->line('Including third-party guidelines/skills: '.$selected->join(', ').'. Run [php artisan boost:install] interactively to change this.');
+        }
+
+        return $selected;
     }
 
     protected function selectIntegrations(): void

--- a/src/Console/UpdateCommand.php
+++ b/src/Console/UpdateCommand.php
@@ -65,12 +65,9 @@ class UpdateCommand extends Command
             return;
         }
 
-        if ($this->runningAsComposerScript()) {
-            return;
-        }
-
-        if (! $this->input->isInteractive()) {
-            $this->addPackages($config, $newPackages->keys()->all());
+        if (! $this->input->isInteractive() || $this->runningAsComposerScript()) {
+            $this->line('New packages with guidelines/skills available: '.$newPackages->keys()->join(', ').'.');
+            $this->line('Review and add them with [php artisan boost:update].');
 
             return;
         }
@@ -86,21 +83,9 @@ class UpdateCommand extends Command
             hint: 'Select packages to include their guidelines and skills',
         );
 
-        $this->addPackages($config, $selectedPackages);
-    }
-
-    /**
-     * @param  array<int, string>  $packages
-     */
-    protected function addPackages(Config $config, array $packages): void
-    {
-        if ($packages === []) {
-            return;
+        if ($selectedPackages !== []) {
+            $config->setPackages(array_merge($config->getPackages(), $selectedPackages));
         }
-
-        $config->setPackages(array_merge($config->getPackages(), $packages));
-
-        $this->info('Added third-party guidelines/skills: '.implode(', ', $packages).'.');
     }
 
     /**

--- a/src/Console/UpdateCommand.php
+++ b/src/Console/UpdateCommand.php
@@ -65,7 +65,13 @@ class UpdateCommand extends Command
             return;
         }
 
-        if (! $this->input->isInteractive() || $this->runningAsComposerScript()) {
+        if ($this->runningAsComposerScript()) {
+            return;
+        }
+
+        if (! $this->input->isInteractive()) {
+            $this->addPackages($config, $newPackages->keys()->all());
+
             return;
         }
 
@@ -80,9 +86,21 @@ class UpdateCommand extends Command
             hint: 'Select packages to include their guidelines and skills',
         );
 
-        if ($selectedPackages !== []) {
-            $config->setPackages(array_merge($config->getPackages(), $selectedPackages));
+        $this->addPackages($config, $selectedPackages);
+    }
+
+    /**
+     * @param  array<int, string>  $packages
+     */
+    protected function addPackages(Config $config, array $packages): void
+    {
+        if ($packages === []) {
+            return;
         }
+
+        $config->setPackages(array_merge($config->getPackages(), $packages));
+
+        $this->info('Added third-party guidelines/skills: '.implode(', ', $packages).'.');
     }
 
     /**

--- a/tests/Feature/Console/InstallCommandThirdPartyTest.php
+++ b/tests/Feature/Console/InstallCommandThirdPartyTest.php
@@ -112,3 +112,68 @@ it('selects no third-party packages when --no-third-party is passed', function (
 
     expect($method->invoke($command)->all())->toBe([]);
 });
+
+it('selects exactly the packages named by --packages', function (): void {
+    $output = new BufferedOutput;
+    $command = makeThirdPartyInstallCommand(new Config, $output);
+
+    $packages = collect([
+        'vendor/one' => new ThirdPartyPackage('vendor/one', true, false),
+        'vendor/two' => new ThirdPartyPackage('vendor/two', false, true),
+    ]);
+
+    $method = new ReflectionMethod($command, 'requestedThirdPartyPackages');
+
+    $command->setInput(new ArrayInput(['--packages' => 'vendor/two'], $command->getDefinition()));
+
+    expect($method->invoke($command, $packages)->all())->toBe(['vendor/two']);
+});
+
+it('selects every discovered package for --packages=all and none for --packages=none', function (): void {
+    $output = new BufferedOutput;
+    $command = makeThirdPartyInstallCommand(new Config, $output);
+
+    $packages = collect([
+        'vendor/one' => new ThirdPartyPackage('vendor/one', true, false),
+        'vendor/two' => new ThirdPartyPackage('vendor/two', false, true),
+    ]);
+
+    $method = new ReflectionMethod($command, 'requestedThirdPartyPackages');
+
+    $command->setInput(new ArrayInput(['--packages' => 'all'], $command->getDefinition()));
+    expect($method->invoke($command, $packages)->all())->toBe(['vendor/one', 'vendor/two']);
+
+    $command->setInput(new ArrayInput(['--packages' => 'none'], $command->getDefinition()));
+    expect($method->invoke($command, $packages)->all())->toBe([]);
+});
+
+it('fails when --packages names a package that was not discovered', function (): void {
+    $output = new BufferedOutput;
+    $command = makeThirdPartyInstallCommand(new Config, $output);
+
+    $packages = collect(['vendor/one' => new ThirdPartyPackage('vendor/one', true, false)]);
+
+    $method = new ReflectionMethod($command, 'requestedThirdPartyPackages');
+
+    $command->setInput(new ArrayInput(['--packages' => 'vendor/one,vendor/typo'], $command->getDefinition()));
+
+    expect(fn () => $method->invoke($command, $packages))
+        ->toThrow(Exception::class, 'vendor/typo');
+});
+
+it('lets --packages override --no-third-party', function (): void {
+    $output = new BufferedOutput;
+    $command = makeThirdPartyInstallCommand(new Config, $output);
+
+    $input = new ArrayInput([
+        '--no-third-party' => true,
+        '--packages' => 'vendor/not-installed',
+    ], $command->getDefinition());
+    $input->setInteractive(false);
+    $command->setInput($input);
+
+    $method = new ReflectionMethod($command, 'selectThirdPartyPackages');
+
+    expect(fn () => $method->invoke($command))
+        ->toThrow(Exception::class, 'vendor/not-installed');
+});

--- a/tests/Feature/Console/InstallCommandThirdPartyTest.php
+++ b/tests/Feature/Console/InstallCommandThirdPartyTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Console\OutputStyle;
+use Illuminate\Support\Collection;
+use Laravel\Boost\Console\Enums\Theme;
+use Laravel\Boost\Console\InstallCommand;
+use Laravel\Boost\Install\AgentsDetector;
+use Laravel\Boost\Install\Cloud;
+use Laravel\Boost\Install\Nightwatch;
+use Laravel\Boost\Install\Sail;
+use Laravel\Boost\Install\ThirdPartyPackage;
+use Laravel\Boost\Support\Config;
+use Laravel\Prompts\Terminal;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+beforeEach(function (): void {
+    (new Config)->flush();
+});
+
+afterEach(function (): void {
+    (new Config)->flush();
+    Mockery::close();
+});
+
+function makeThirdPartyInstallCommand(Config $config, BufferedOutput $output): InstallCommand
+{
+    $nightwatch = Mockery::mock(Nightwatch::class);
+    $nightwatch->shouldReceive('isInstalled')->andReturn(false);
+
+    $sail = Mockery::mock(Sail::class);
+    $sail->shouldReceive('isInstalled')->andReturn(false);
+    $sail->shouldReceive('isActive')->andReturn(false);
+
+    $terminal = Mockery::mock(Terminal::class);
+    $terminal->shouldReceive('initDimensions');
+
+    $command = new class(app(AgentsDetector::class), Mockery::mock(Cloud::class), $config, $nightwatch, $sail, $terminal) extends InstallCommand
+    {
+        /**
+         * @param  Collection<string, ThirdPartyPackage>  $packages
+         * @param  Collection<int, string>  $defaults
+         * @return Collection<int, string>
+         */
+        public function packagesWithoutPrompt($packages, $defaults)
+        {
+            return $this->thirdPartyPackagesWithoutPrompt($packages, $defaults);
+        }
+
+        protected function displayBoostHeader(string $featureName, string $projectName, ?Theme $theme = null): void {}
+    };
+
+    $command->setLaravel(app());
+    $command->setOutput(new OutputStyle(new ArrayInput([]), $output));
+
+    return $command;
+}
+
+it('selects every discovered package when installing non-interactively without an existing config', function (): void {
+    $output = new BufferedOutput;
+    $command = makeThirdPartyInstallCommand(new Config, $output);
+
+    $packages = collect([
+        'vendor/one' => new ThirdPartyPackage('vendor/one', true, false),
+        'vendor/two' => new ThirdPartyPackage('vendor/two', false, true),
+    ]);
+
+    expect($command->packagesWithoutPrompt($packages, collect())->all())
+        ->toBe(['vendor/one', 'vendor/two'])
+        ->and($output->fetch())->toContain('vendor/one, vendor/two');
+});
+
+it('keeps the packages an existing config already recorded when installing non-interactively', function (): void {
+    $config = new Config;
+    $config->setAgents(['claude_code']);
+    $config->setPackages(['vendor/one']);
+
+    $output = new BufferedOutput;
+    $command = makeThirdPartyInstallCommand($config, $output);
+
+    $packages = collect([
+        'vendor/one' => new ThirdPartyPackage('vendor/one', true, false),
+        'vendor/two' => new ThirdPartyPackage('vendor/two', false, true),
+    ]);
+
+    expect($command->packagesWithoutPrompt($packages, collect(['vendor/one']))->all())
+        ->toBe(['vendor/one']);
+});
+
+it('stays silent when a non-interactive install selects no packages', function (): void {
+    $config = new Config;
+    $config->setAgents(['claude_code']);
+
+    $output = new BufferedOutput;
+    $command = makeThirdPartyInstallCommand($config, $output);
+
+    expect($command->packagesWithoutPrompt(collect(), collect())->all())->toBe([])
+        ->and($output->fetch())->toBe('');
+});
+
+it('selects no third-party packages when --no-third-party is passed', function (): void {
+    $output = new BufferedOutput;
+    $command = makeThirdPartyInstallCommand(new Config, $output);
+
+    $input = new ArrayInput(['--no-third-party' => true], $command->getDefinition());
+    $input->setInteractive(false);
+    $command->setInput($input);
+
+    $method = new ReflectionMethod($command, 'selectThirdPartyPackages');
+
+    expect($method->invoke($command)->all())->toBe([]);
+});

--- a/tests/Feature/Console/InstallCommandThirdPartyTest.php
+++ b/tests/Feature/Console/InstallCommandThirdPartyTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Console\ManuallyFailedException;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Support\Collection;
 use Laravel\Boost\Console\Enums\Theme;
@@ -25,7 +26,7 @@ afterEach(function (): void {
     Mockery::close();
 });
 
-function makeThirdPartyInstallCommand(Config $config, BufferedOutput $output): InstallCommand
+function makeThirdPartyInstallCommand(BufferedOutput $output): InstallCommand
 {
     $nightwatch = Mockery::mock(Nightwatch::class);
     $nightwatch->shouldReceive('isInstalled')->andReturn(false);
@@ -37,18 +38,8 @@ function makeThirdPartyInstallCommand(Config $config, BufferedOutput $output): I
     $terminal = Mockery::mock(Terminal::class);
     $terminal->shouldReceive('initDimensions');
 
-    $command = new class(app(AgentsDetector::class), Mockery::mock(Cloud::class), $config, $nightwatch, $sail, $terminal) extends InstallCommand
+    $command = new class(app(AgentsDetector::class), Mockery::mock(Cloud::class), new Config, $nightwatch, $sail, $terminal) extends InstallCommand
     {
-        /**
-         * @param  Collection<string, ThirdPartyPackage>  $packages
-         * @param  Collection<int, string>  $defaults
-         * @return Collection<int, string>
-         */
-        public function packagesWithoutPrompt($packages, $defaults)
-        {
-            return $this->thirdPartyPackagesWithoutPrompt($packages, $defaults);
-        }
-
         protected function displayBoostHeader(string $featureName, string $projectName, ?Theme $theme = null): void {}
     };
 
@@ -58,122 +49,63 @@ function makeThirdPartyInstallCommand(Config $config, BufferedOutput $output): I
     return $command;
 }
 
-it('selects every discovered package when installing non-interactively without an existing config', function (): void {
-    $output = new BufferedOutput;
-    $command = makeThirdPartyInstallCommand(new Config, $output);
+function invokeThirdPartyMethod(InstallCommand $command, string $method, mixed ...$args): mixed
+{
+    return (new ReflectionMethod($command, $method))->invoke($command, ...$args);
+}
 
-    $packages = collect([
+function discoveredPackages(): Collection
+{
+    return collect([
         'vendor/one' => new ThirdPartyPackage('vendor/one', true, false),
         'vendor/two' => new ThirdPartyPackage('vendor/two', false, true),
     ]);
-
-    expect($command->packagesWithoutPrompt($packages, collect())->all())
-        ->toBe(['vendor/one', 'vendor/two'])
-        ->and($output->fetch())->toContain('vendor/one, vendor/two');
-});
-
-it('keeps the packages an existing config already recorded when installing non-interactively', function (): void {
-    $config = new Config;
-    $config->setAgents(['claude_code']);
-    $config->setPackages(['vendor/one']);
-
-    $output = new BufferedOutput;
-    $command = makeThirdPartyInstallCommand($config, $output);
-
-    $packages = collect([
-        'vendor/one' => new ThirdPartyPackage('vendor/one', true, false),
-        'vendor/two' => new ThirdPartyPackage('vendor/two', false, true),
-    ]);
-
-    expect($command->packagesWithoutPrompt($packages, collect(['vendor/one']))->all())
-        ->toBe(['vendor/one']);
-});
-
-it('stays silent when a non-interactive install selects no packages', function (): void {
-    $config = new Config;
-    $config->setAgents(['claude_code']);
-
-    $output = new BufferedOutput;
-    $command = makeThirdPartyInstallCommand($config, $output);
-
-    expect($command->packagesWithoutPrompt(collect(), collect())->all())->toBe([])
-        ->and($output->fetch())->toBe('');
-});
-
-it('selects no third-party packages when --no-third-party is passed', function (): void {
-    $output = new BufferedOutput;
-    $command = makeThirdPartyInstallCommand(new Config, $output);
-
-    $input = new ArrayInput(['--no-third-party' => true], $command->getDefinition());
-    $input->setInteractive(false);
-    $command->setInput($input);
-
-    $method = new ReflectionMethod($command, 'selectThirdPartyPackages');
-
-    expect($method->invoke($command)->all())->toBe([]);
-});
+}
 
 it('selects exactly the packages named by --packages', function (): void {
-    $output = new BufferedOutput;
-    $command = makeThirdPartyInstallCommand(new Config, $output);
-
-    $packages = collect([
-        'vendor/one' => new ThirdPartyPackage('vendor/one', true, false),
-        'vendor/two' => new ThirdPartyPackage('vendor/two', false, true),
-    ]);
-
-    $method = new ReflectionMethod($command, 'requestedThirdPartyPackages');
-
+    $command = makeThirdPartyInstallCommand(new BufferedOutput);
     $command->setInput(new ArrayInput(['--packages' => 'vendor/two'], $command->getDefinition()));
 
-    expect($method->invoke($command, $packages)->all())->toBe(['vendor/two']);
+    expect(invokeThirdPartyMethod($command, 'requestedThirdPartyPackages', discoveredPackages())->all())
+        ->toBe(['vendor/two']);
 });
 
 it('selects every discovered package for --packages=all and none for --packages=none', function (): void {
-    $output = new BufferedOutput;
-    $command = makeThirdPartyInstallCommand(new Config, $output);
-
-    $packages = collect([
-        'vendor/one' => new ThirdPartyPackage('vendor/one', true, false),
-        'vendor/two' => new ThirdPartyPackage('vendor/two', false, true),
-    ]);
-
-    $method = new ReflectionMethod($command, 'requestedThirdPartyPackages');
+    $command = makeThirdPartyInstallCommand(new BufferedOutput);
 
     $command->setInput(new ArrayInput(['--packages' => 'all'], $command->getDefinition()));
-    expect($method->invoke($command, $packages)->all())->toBe(['vendor/one', 'vendor/two']);
+    expect(invokeThirdPartyMethod($command, 'requestedThirdPartyPackages', discoveredPackages())->all())
+        ->toBe(['vendor/one', 'vendor/two']);
 
     $command->setInput(new ArrayInput(['--packages' => 'none'], $command->getDefinition()));
-    expect($method->invoke($command, $packages)->all())->toBe([]);
+    expect(invokeThirdPartyMethod($command, 'requestedThirdPartyPackages', discoveredPackages())->all())
+        ->toBe([]);
 });
 
 it('fails when --packages names a package that was not discovered', function (): void {
-    $output = new BufferedOutput;
-    $command = makeThirdPartyInstallCommand(new Config, $output);
-
-    $packages = collect(['vendor/one' => new ThirdPartyPackage('vendor/one', true, false)]);
-
-    $method = new ReflectionMethod($command, 'requestedThirdPartyPackages');
-
+    $command = makeThirdPartyInstallCommand(new BufferedOutput);
     $command->setInput(new ArrayInput(['--packages' => 'vendor/one,vendor/typo'], $command->getDefinition()));
 
-    expect(fn () => $method->invoke($command, $packages))
-        ->toThrow(Exception::class, 'vendor/typo');
+    expect(fn () => invokeThirdPartyMethod($command, 'requestedThirdPartyPackages', discoveredPackages()))
+        ->toThrow(ManuallyFailedException::class, 'vendor/typo');
 });
 
-it('lets --packages override --no-third-party', function (): void {
+it('reports the third-party packages a non-interactive install left out', function (): void {
     $output = new BufferedOutput;
-    $command = makeThirdPartyInstallCommand(new Config, $output);
+    $command = makeThirdPartyInstallCommand($output);
 
-    $input = new ArrayInput([
-        '--no-third-party' => true,
-        '--packages' => 'vendor/not-installed',
-    ], $command->getDefinition());
-    $input->setInteractive(false);
-    $command->setInput($input);
+    invokeThirdPartyMethod($command, 'reportSkippedThirdPartyPackages', collect(['vendor/one', 'vendor/two']));
 
-    $method = new ReflectionMethod($command, 'selectThirdPartyPackages');
+    expect($output->fetch())
+        ->toContain('Skipped third-party guidelines/skills from: vendor/one, vendor/two.')
+        ->toContain('--packages=vendor/one');
+});
 
-    expect(fn () => $method->invoke($command))
-        ->toThrow(Exception::class, 'vendor/not-installed');
+it('stays silent when a non-interactive install left nothing out', function (): void {
+    $output = new BufferedOutput;
+    $command = makeThirdPartyInstallCommand($output);
+
+    invokeThirdPartyMethod($command, 'reportSkippedThirdPartyPackages', collect());
+
+    expect($output->fetch())->toBe('');
 });

--- a/tests/Feature/Console/UpdateCommandTest.php
+++ b/tests/Feature/Console/UpdateCommandTest.php
@@ -11,7 +11,6 @@ use Laravel\Prompts\Key;
 use Laravel\Prompts\Prompt;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
-use Symfony\Component\Console\Output\NullOutput;
 
 beforeEach(function (): void {
     (new Config)->flush();
@@ -514,7 +513,7 @@ it('exits silently when --ignore-skills flag is set and no guidelines are config
         ->assertSuccessful();
 });
 
-it('adds new packages without prompting when running in non-interactive mode', function (): void {
+it('reports but does not add new packages when running in non-interactive mode', function (): void {
     $config = new Config;
     $config->setAgents(['claude_code']);
     $config->setGuidelines(true);
@@ -538,34 +537,11 @@ it('adds new packages without prompting when running in non-interactive mode', f
 
     $command->setInput($nonInteractiveInput);
     $command->setLaravel($this->app);
-    $command->setOutput(new OutputStyle($nonInteractiveInput, new NullOutput));
+    $buffer = new BufferedOutput;
+    $command->setOutput(new OutputStyle($nonInteractiveInput, $buffer));
 
     expect($command->handle($config))->toBe(0);
 
-    expect($config->getPackages())->toBe(['vendor/awesome-pkg']);
+    expect($config->getPackages())->toBe([])
+        ->and($buffer->fetch())->toContain('vendor/awesome-pkg');
 })->skipOnWindows();
-
-it('leaves config untouched when non-interactive discovery finds nothing new', function (): void {
-    $config = new Config;
-    $config->setAgents(['claude_code']);
-    $config->setGuidelines(true);
-    $config->setPackages(['vendor/known-pkg']);
-
-    $command = Mockery::mock(UpdateCommand::class)
-        ->makePartial()
-        ->shouldAllowMockingProtectedMethods();
-    $command->shouldReceive('option')->with('no-discover')->andReturn(false);
-    $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
-    $command->shouldReceive('runningAsComposerScript')->andReturn(false);
-    $command->shouldReceive('resolveNewPackages')->andReturn(collect());
-    $command->shouldReceive('callSilently')->andReturn(0);
-    $command->setLaravel($this->app);
-
-    $input = new ArrayInput([]);
-    $input->setInteractive(false);
-    $command->setInput($input);
-    $command->setOutput(new OutputStyle($input, new BufferedOutput));
-
-    expect($command->handle($config))->toBe(0)
-        ->and($config->getPackages())->toBe(['vendor/known-pkg']);
-});

--- a/tests/Feature/Console/UpdateCommandTest.php
+++ b/tests/Feature/Console/UpdateCommandTest.php
@@ -514,7 +514,7 @@ it('exits silently when --ignore-skills flag is set and no guidelines are config
         ->assertSuccessful();
 });
 
-it('skips new-package discovery prompt when running in non-interactive mode', function (): void {
+it('adds new packages without prompting when running in non-interactive mode', function (): void {
     $config = new Config;
     $config->setAgents(['claude_code']);
     $config->setGuidelines(true);
@@ -530,6 +530,7 @@ it('skips new-package discovery prompt when running in non-interactive mode', fu
     $command->shouldReceive('option')->with('no-discover')->andReturn(false);
     $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
     $command->shouldReceive('resolveNewPackages')->andReturn(collect(['vendor/awesome-pkg' => $newPackage]));
+    $command->shouldReceive('runningAsComposerScript')->andReturn(false);
     $command->shouldReceive('callSilently')->andReturn(0);
 
     $nonInteractiveInput = new ArrayInput([]);
@@ -541,5 +542,30 @@ it('skips new-package discovery prompt when running in non-interactive mode', fu
 
     expect($command->handle($config))->toBe(0);
 
-    expect($config->getPackages())->toBe([]);
+    expect($config->getPackages())->toBe(['vendor/awesome-pkg']);
 })->skipOnWindows();
+
+it('leaves config untouched when non-interactive discovery finds nothing new', function (): void {
+    $config = new Config;
+    $config->setAgents(['claude_code']);
+    $config->setGuidelines(true);
+    $config->setPackages(['vendor/known-pkg']);
+
+    $command = Mockery::mock(UpdateCommand::class)
+        ->makePartial()
+        ->shouldAllowMockingProtectedMethods();
+    $command->shouldReceive('option')->with('no-discover')->andReturn(false);
+    $command->shouldReceive('option')->with('ignore-skills')->andReturn(false);
+    $command->shouldReceive('runningAsComposerScript')->andReturn(false);
+    $command->shouldReceive('resolveNewPackages')->andReturn(collect());
+    $command->shouldReceive('callSilently')->andReturn(0);
+    $command->setLaravel($this->app);
+
+    $input = new ArrayInput([]);
+    $input->setInteractive(false);
+    $command->setInput($input);
+    $command->setOutput(new OutputStyle($input, new BufferedOutput));
+
+    expect($command->handle($config))->toBe(0)
+        ->and($config->getPackages())->toBe(['vendor/known-pkg']);
+});


### PR DESCRIPTION
Fixes #948 

Currently, when running `boost:install` or `boost:update` in non-interactive mode, it skips compiling (discovered) third-party guidelines altogether, as discovery prompts the user to select which guidelines to include. And an agent will often run these commands interactively, resulting in an agent-scaffolded app never including third-party guidelines (and never communicating this to the user).

But we can logically assume that if a user has installed third-party packages, they will want to use them according to third-party guidelines. This PR therefore inverts the non-interactive logic, and adds an explicit `--packages` option and a `--no-third-party` flag if third-party packages should be explicitly added per package or skipped completely.