### PR TITLE
Ignore a repository-root SKILL.md so add-skill cannot delete the whole skills directory

### DIFF
--- a/src/Console/AddSkillCommand.php
+++ b/src/Console/AddSkillCommand.php
@@ -100,7 +100,7 @@ class AddSkillCommand extends Command
         }
 
         if ($this->availableSkills->isEmpty()) {
-            $this->error('No valid skills are found in the repository. Remote skills must provide a SKILL.md; SKILL.blade.php is not supported.');
+            $this->error('No valid skills are found in the repository. Each skill must live in its own directory containing a SKILL.md — a SKILL.md at the repository root is not a skill. SKILL.blade.php is not supported.');
 
             return false;
         }

--- a/src/Skills/Remote/GitHubSkillProvider.php
+++ b/src/Skills/Remote/GitHubSkillProvider.php
@@ -38,7 +38,10 @@ class GitHubSkillProvider
         $basePath = $this->repository->path;
 
         $skillMarkers = collect($tree['tree'])
-            ->filter(fn (array $item): bool => $item['type'] === 'blob' && basename((string) $item['path']) === 'SKILL.md');
+            ->filter(fn (array $item): bool => $item['type'] === 'blob'
+                && basename((string) $item['path']) === 'SKILL.md'
+                // A skill is named after its directory, so a repository-root SKILL.md has no name to take.
+                && dirname((string) $item['path']) !== '.');
 
         if ($basePath !== '') {
             $prefix = $basePath.'/';

--- a/tests/Feature/Console/AddSkillCommandTest.php
+++ b/tests/Feature/Console/AddSkillCommandTest.php
@@ -508,7 +508,6 @@ it('displays error when rate limit is exceeded', function (): void {
 });
 
 it('does not wipe installed skills when the repository has a root level SKILL.md', function (): void {
-    File::deleteDirectory(base_path('.ai/skills'));
     File::ensureDirectoryExists(base_path('.ai/skills/existing-skill'));
     File::put(base_path('.ai/skills/existing-skill/SKILL.md'), 'keep me');
 
@@ -521,12 +520,9 @@ it('does not wipe installed skills when the repository has a root level SKILL.md
             ],
             'truncated' => false,
         ]),
-        'raw.githubusercontent.com/*' => Http::response('# Root skill'),
     ]);
 
     $this->artisan('boost:add-skill', ['repo' => 'owner/repo', '--all' => true, '--skip-audit' => true])->run();
 
     expect(File::exists(base_path('.ai/skills/existing-skill/SKILL.md')))->toBeTrue();
-
-    File::deleteDirectory(base_path('.ai/skills'));
 });

--- a/tests/Feature/Console/AddSkillCommandTest.php
+++ b/tests/Feature/Console/AddSkillCommandTest.php
@@ -506,3 +506,27 @@ it('displays error when rate limit is exceeded', function (): void {
         ->assertFailed()
         ->expectsOutputToContain('GitHub API rate limit exceeded');
 });
+
+it('does not wipe installed skills when the repository has a root level SKILL.md', function (): void {
+    File::deleteDirectory(base_path('.ai/skills'));
+    File::ensureDirectoryExists(base_path('.ai/skills/existing-skill'));
+    File::put(base_path('.ai/skills/existing-skill/SKILL.md'), 'keep me');
+
+    Http::fake([
+        'api.github.com/repos/owner/repo' => Http::response(['default_branch' => 'main']),
+        'api.github.com/repos/owner/repo/git/trees/main?recursive=1' => Http::response([
+            'sha' => 'abc123',
+            'tree' => [
+                ['path' => 'SKILL.md', 'type' => 'blob', 'sha' => 'def', 'size' => 123],
+            ],
+            'truncated' => false,
+        ]),
+        'raw.githubusercontent.com/*' => Http::response('# Root skill'),
+    ]);
+
+    $this->artisan('boost:add-skill', ['repo' => 'owner/repo', '--all' => true, '--skip-audit' => true])->run();
+
+    expect(File::exists(base_path('.ai/skills/existing-skill/SKILL.md')))->toBeTrue();
+
+    File::deleteDirectory(base_path('.ai/skills'));
+});

--- a/tests/Unit/Skills/Remote/GitHubSkillProviderTest.php
+++ b/tests/Unit/Skills/Remote/GitHubSkillProviderTest.php
@@ -528,3 +528,35 @@ it('discovers skills in wildcard paths like .ai/*/skills', function (): void {
         ->and($skills->has('my-skill'))->toBeTrue()
         ->and($skills->get('my-skill')->path)->toBe('.ai/claude/skills/my-skill');
 });
+
+it('ignores a SKILL.md at the repository root', function (): void {
+    Http::fake([
+        ...fakeGitHubRepo(),
+        ...fakeTreeResponse([
+            ['path' => 'SKILL.md', 'type' => 'blob', 'sha' => 'aaa', 'size' => 123],
+            ['path' => 'README.md', 'type' => 'blob', 'sha' => 'bbb', 'size' => 456],
+        ]),
+    ]);
+
+    $fetcher = new GitHubSkillProvider(new GitHubRepository('owner', 'repo'));
+
+    // A root SKILL.md would otherwise be named "." and resolve to the skills directory itself.
+    expect($fetcher->discoverSkills())->toBeEmpty();
+});
+
+it('still finds nested skills when the repository root also has a SKILL.md', function (): void {
+    Http::fake([
+        ...fakeGitHubRepo(),
+        ...fakeTreeResponse([
+            ['path' => 'SKILL.md', 'type' => 'blob', 'sha' => 'aaa', 'size' => 123],
+            ['path' => 'skill-one', 'type' => 'tree', 'sha' => 'bbb'],
+            ['path' => 'skill-one/SKILL.md', 'type' => 'blob', 'sha' => 'ccc', 'size' => 456],
+        ]),
+    ]);
+
+    $fetcher = new GitHubSkillProvider(new GitHubRepository('owner', 'repo'));
+    $skills = $fetcher->discoverSkills();
+
+    expect($skills)->toHaveCount(1)
+        ->and($skills->keys()->all())->toBe(['skill-one']);
+});


### PR DESCRIPTION
Running `boost:add-skill` against a repo that keeps its `SKILL.md` at the root deletes everything in `.ai/skills` and installs nothing. That layout is the normal one for a single-skill repo, so this is reachable by just pointing the command at one.

The chain:

1. `discoverSkills()` accepts any blob named `SKILL.md`. For a root-level one, `dirname()` is `.`, so the skill is named `.`.
2. `skillTargetPath()` builds `.ai/skills/.`, which is the skills directory itself.
3. `addSkills()` sees `is_dir()` is true and calls `File::deleteDirectory('.ai/skills/.')` before downloading. That returns `true` and takes every installed skill with it.
4. `downloadSkill()` then bails anyway, because `extractSkillFilesFromTree()` looks for the prefix `./` and finds nothing.

So you end up with an empty `.ai/skills` and "Some skills failed to install", which does not point anywhere near what actually happened.

Ran it end to end against the real command:

```
BEFORE .ai/skills: ["another-skill","my-important-skill"]
AFTER  .ai/skills: []
```

A skill takes its name from its directory, so a root `SKILL.md` has no name to take. Skipping it at discovery removes the whole path. There is already a test called "ignores files at root level", it just uses README/LICENSE and never a root `SKILL.md`.

Three tests added: root `SKILL.md` is ignored, nested skills still work when a root one is present, and an end to end one asserting an installed skill survives.
