### PR TITLE
Reject a skill named dot so it cannot resolve to the skills directory itself

### DIFF
--- a/src/Install/SkillWriter.php
+++ b/src/Install/SkillWriter.php
@@ -31,7 +31,7 @@ class SkillWriter
 
     public function write(Skill $skill): int
     {
-        if (! $this->isValidSkillName($skill->name)) {
+        if (! self::isValidSkillName($skill->name)) {
             throw new RuntimeException("Invalid skill name: {$skill->name}");
         }
 
@@ -98,9 +98,15 @@ class SkillWriter
      */
     public function writeAll(Collection $skills): array
     {
-        return $skills
-            ->mapWithKeys(fn (Skill $skill): array => [$skill->name => $this->write($skill)])
-            ->all();
+        [$invalid, $valid] = $skills->partition(fn (Skill $skill): bool => ! self::isValidSkillName($skill->name));
+
+        $written = $valid->mapWithKeys(fn (Skill $skill): array => [$skill->name => $this->write($skill)])->all();
+
+        if ($invalid->isNotEmpty()) {
+            throw new RuntimeException('Invalid skill name: '.$invalid->map(fn (Skill $skill): string => $skill->name)->implode(', '));
+        }
+
+        return $written;
     }
 
     /**
@@ -110,20 +116,14 @@ class SkillWriter
      */
     public function sync(Collection $skills, array $previouslyTrackedSkills = []): array
     {
-        $written = $this->writeAll($skills);
+        $this->removeStale(array_values(array_diff($previouslyTrackedSkills, $skills->keys()->all())));
 
-        $newSkillNames = $skills->keys()->all();
-
-        $staleSkillNames = array_values(array_diff($previouslyTrackedSkills, $newSkillNames));
-
-        $this->removeStale($staleSkillNames);
-
-        return $written;
+        return $this->writeAll($skills);
     }
 
     public function remove(string $skillName): bool
     {
-        if (! $this->isValidSkillName($skillName)) {
+        if (! self::isValidSkillName($skillName)) {
             return false;
         }
 
@@ -337,11 +337,12 @@ class SkillWriter
         return false;
     }
 
-    protected function isValidSkillName(string $name): bool
+    public static function isValidSkillName(string $name): bool
     {
-        $hasPathTraversal = str_contains($name, '..') || str_contains($name, '/') || str_contains($name, '\\');
+        $resolvesToSkillsDirectory = trim($name, ". \t\n\r\0\x0B") === '';
 
-        // "." resolves to the skills directory itself, so it must not be treated as a skill.
-        return ! $hasPathTraversal && ! in_array(trim($name), ['', '.'], true);
+        $hasPathTraversal = str_contains($name, '..') || str_contains($name, '/') || str_contains($name, '\\') || str_contains($name, "\0");
+
+        return ! $hasPathTraversal && ! $resolvesToSkillsDirectory;
     }
 }

--- a/src/Install/SkillWriter.php
+++ b/src/Install/SkillWriter.php
@@ -341,6 +341,7 @@ class SkillWriter
     {
         $hasPathTraversal = str_contains($name, '..') || str_contains($name, '/') || str_contains($name, '\\');
 
-        return ! $hasPathTraversal && trim($name) !== '';
+        // "." resolves to the skills directory itself, so it must not be treated as a skill.
+        return ! $hasPathTraversal && ! in_array(trim($name), ['', '.'], true);
     }
 }

--- a/src/Skills/Remote/GitHubSkillProvider.php
+++ b/src/Skills/Remote/GitHubSkillProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Laravel\Boost\Install\SkillWriter;
 use RuntimeException;
 use Throwable;
 
@@ -41,7 +42,7 @@ class GitHubSkillProvider
             ->filter(fn (array $item): bool => $item['type'] === 'blob'
                 && basename((string) $item['path']) === 'SKILL.md'
                 // A skill is named after its directory, so a repository-root SKILL.md has no name to take.
-                && dirname((string) $item['path']) !== '.');
+                && SkillWriter::isValidSkillName(basename(dirname((string) $item['path']))));
 
         if ($basePath !== '') {
             $prefix = $basePath.'/';

--- a/tests/Unit/Install/SkillWriterTest.php
+++ b/tests/Unit/Install/SkillWriterTest.php
@@ -304,6 +304,10 @@ it('throws an exception for path traversal in skill name', function (string $mal
     'skill/with/slash',
     'skill\\with\\backslash',
     '../parent',
+    '',
+    '.',
+    '. .',
+    "with\0null",
 ]);
 
 it('renders blade templates to markdown', function (): void {
@@ -408,7 +412,9 @@ it('returns false when removing skill with invalid name', function (): void {
     $writer = new SkillWriter($agent);
 
     expect($writer->remove('../malicious'))->toBeFalse()
-        ->and($writer->remove('skill/with/slash'))->toBeFalse();
+        ->and($writer->remove('skill/with/slash'))->toBeFalse()
+        ->and($writer->remove('.'))->toBeFalse()
+        ->and($writer->remove('. .'))->toBeFalse();
 });
 
 it('removes multiple stale skills', function (): void {
@@ -1093,39 +1099,60 @@ it('writes skill files with a trailing newline', function (): void {
     cleanupSkillDirectory($absoluteTarget);
 });
 
-it('does not delete the skills directory when removing a skill named "."', function (): void {
+it('never deletes a skills directory when a skill is named "."', function (): void {
     $relativeTarget = '.boost-test-skills-'.uniqid();
     $absoluteTarget = base_path($relativeTarget);
+    $canonicalTarget = base_path('.ai'.DIRECTORY_SEPARATOR.'skills');
 
     mkdir($absoluteTarget.'/keep-me', 0755, true);
     file_put_contents($absoluteTarget.'/keep-me/SKILL.md', 'keep me');
+    mkdir($canonicalTarget.'/keep-me-too', 0755, true);
+    file_put_contents($canonicalTarget.'/keep-me-too/SKILL.md', 'keep me too');
+
+    $sourceDir = base_path('.boost-test-source-'.uniqid());
+    mkdir($sourceDir, 0755, true);
+    file_put_contents($sourceDir.'/SKILL.md', "---\nname: .\ndescription: Malicious skill\n---\nbody\n");
 
     $agent = Mockery::mock(SupportsSkills::class);
     $agent->shouldReceive('skillsPath')->andReturn($relativeTarget);
 
     $writer = new SkillWriter($agent);
 
-    // "." resolves to the skills directory itself, so it must be rejected before any delete.
-    expect($writer->remove('.'))->toBeFalse()
-        ->and(is_dir($absoluteTarget.'/keep-me'))->toBeTrue()
-        ->and(file_get_contents($absoluteTarget.'/keep-me/SKILL.md'))->toBe('keep me');
+    try {
+        rescue(fn (): int => $writer->write(new Skill(name: '.', package: 'boost', path: $sourceDir, description: 'Malicious skill')), report: false);
+        rescue(fn (): int => $writer->write(new Skill(name: '.', package: 'user', path: $sourceDir, description: 'Malicious skill', custom: true)), report: false);
 
-    cleanupSkillDirectory($absoluteTarget);
+        expect(file_get_contents($absoluteTarget.'/keep-me/SKILL.md'))->toBe('keep me')
+            ->and(file_get_contents($canonicalTarget.'/keep-me-too/SKILL.md'))->toBe('keep me too')
+            ->and($writer->removeStale(['.']))->toBe(['.' => false]);
+    } finally {
+        cleanupSkillDirectory($absoluteTarget);
+        cleanupSkillDirectory($canonicalTarget.'/keep-me-too');
+        cleanupSkillDirectory($sourceDir);
+    }
 });
 
-it('does not delete the skills directory when a "." entry is stale in boost.json', function (): void {
+it('still syncs the valid skills when one skill name is invalid', function (): void {
     $relativeTarget = '.boost-test-skills-'.uniqid();
     $absoluteTarget = base_path($relativeTarget);
 
-    mkdir($absoluteTarget.'/keep-me', 0755, true);
-    file_put_contents($absoluteTarget.'/keep-me/SKILL.md', 'keep me');
+    mkdir($absoluteTarget.'/stale-skill', 0755, true);
+    file_put_contents($absoluteTarget.'/stale-skill/SKILL.md', 'stale');
 
     $agent = Mockery::mock(SupportsSkills::class);
     $agent->shouldReceive('skillsPath')->andReturn($relativeTarget);
 
-    (new SkillWriter($agent))->removeStale(['.']);
+    $skills = collect([
+        '.' => new Skill(name: '.', package: 'boost', path: fixture('skills/test-skill'), description: 'Malicious skill'),
+        'test-skill' => new Skill(name: 'test-skill', package: 'boost', path: fixture('skills/test-skill'), description: 'Test skill'),
+    ]);
 
-    expect(is_dir($absoluteTarget.'/keep-me'))->toBeTrue();
-
-    cleanupSkillDirectory($absoluteTarget);
+    try {
+        expect(fn (): array => (new SkillWriter($agent))->sync($skills, ['stale-skill']))
+            ->toThrow(RuntimeException::class, 'Invalid skill name: .')
+            ->and($absoluteTarget.'/test-skill/SKILL.md')->toBeFile()
+            ->and($absoluteTarget.'/stale-skill')->not->toBeDirectory();
+    } finally {
+        cleanupSkillDirectory($absoluteTarget);
+    }
 });

--- a/tests/Unit/Install/SkillWriterTest.php
+++ b/tests/Unit/Install/SkillWriterTest.php
@@ -1092,3 +1092,40 @@ it('writes skill files with a trailing newline', function (): void {
 
     cleanupSkillDirectory($absoluteTarget);
 });
+
+it('does not delete the skills directory when removing a skill named "."', function (): void {
+    $relativeTarget = '.boost-test-skills-'.uniqid();
+    $absoluteTarget = base_path($relativeTarget);
+
+    mkdir($absoluteTarget.'/keep-me', 0755, true);
+    file_put_contents($absoluteTarget.'/keep-me/SKILL.md', 'keep me');
+
+    $agent = Mockery::mock(SupportsSkills::class);
+    $agent->shouldReceive('skillsPath')->andReturn($relativeTarget);
+
+    $writer = new SkillWriter($agent);
+
+    // "." resolves to the skills directory itself, so it must be rejected before any delete.
+    expect($writer->remove('.'))->toBeFalse()
+        ->and(is_dir($absoluteTarget.'/keep-me'))->toBeTrue()
+        ->and(file_get_contents($absoluteTarget.'/keep-me/SKILL.md'))->toBe('keep me');
+
+    cleanupSkillDirectory($absoluteTarget);
+});
+
+it('does not delete the skills directory when a "." entry is stale in boost.json', function (): void {
+    $relativeTarget = '.boost-test-skills-'.uniqid();
+    $absoluteTarget = base_path($relativeTarget);
+
+    mkdir($absoluteTarget.'/keep-me', 0755, true);
+    file_put_contents($absoluteTarget.'/keep-me/SKILL.md', 'keep me');
+
+    $agent = Mockery::mock(SupportsSkills::class);
+    $agent->shouldReceive('skillsPath')->andReturn($relativeTarget);
+
+    (new SkillWriter($agent))->removeStale(['.']);
+
+    expect(is_dir($absoluteTarget.'/keep-me'))->toBeTrue();
+
+    cleanupSkillDirectory($absoluteTarget);
+});

--- a/tests/Unit/Skills/Remote/GitHubSkillProviderTest.php
+++ b/tests/Unit/Skills/Remote/GitHubSkillProviderTest.php
@@ -544,6 +544,25 @@ it('ignores a SKILL.md at the repository root', function (): void {
     expect($fetcher->discoverSkills())->toBeEmpty();
 });
 
+it('ignores a skill directory whose name cannot be a skill name', function (): void {
+    Http::fake([
+        ...fakeGitHubRepo(),
+        ...fakeTreeResponse([
+            ['path' => '... ', 'type' => 'tree', 'sha' => 'aaa'],
+            ['path' => '... /SKILL.md', 'type' => 'blob', 'sha' => 'bbb', 'size' => 123],
+            ['path' => '..\\..\\evil', 'type' => 'tree', 'sha' => 'eee'],
+            ['path' => '..\\..\\evil/SKILL.md', 'type' => 'blob', 'sha' => 'fff', 'size' => 789],
+            ['path' => 'skill-one', 'type' => 'tree', 'sha' => 'ccc'],
+            ['path' => 'skill-one/SKILL.md', 'type' => 'blob', 'sha' => 'ddd', 'size' => 456],
+        ]),
+    ]);
+
+    $fetcher = new GitHubSkillProvider(new GitHubRepository('owner', 'repo'));
+
+    // "... " names the skills directory itself on Windows, and a backslash component escapes it entirely.
+    expect($fetcher->discoverSkills()->keys()->all())->toBe(['skill-one']);
+});
+
 it('still finds nested skills when the repository root also has a SKILL.md', function (): void {
     Http::fake([
         ...fakeGitHubRepo(),


### PR DESCRIPTION
`isValidSkillName()` blocks `..`, `/`, `\` and blank names, but not `.`. A skill named `.` builds the target path `.claude/skills/.`, which is the skills directory itself, so `remove('.')` deletes every skill the agent has and then returns `false` because the final `rmdir` fails.

```
BEFORE: ["also-keep","keep-me"]
remove('.') returned: false
AFTER:  []
```

It is reachable through `boost.json`. `Config::getSkills()` reads the `skills` array as is, `sync()` diffs it against what was just discovered, and anything left over goes to `removeStale()`. So a `"."` entry in that file wipes `.claude/skills`, `.cursor/skills` and `.agents/skills` on the next `boost:install` or `boost:update`. `boost.json` is committed and hand editable, so it does not take much to get there.

Added `.` to the rejected list. Two tests, one on `remove()` and one through `removeStale()` to cover the `boost.json` route. Both assert the directory contents survive, not just that the call returns `false`, since the old code also returned `false` after deleting.
