### PR TITLE
chore: allow guzzle v8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "php": "^8.2",
-        "guzzlehttp/guzzle": "^7.9",
+        "guzzlehttp/guzzle": "^7.9|^8.0",
         "illuminate/console": "^11.45.3|^12.41.1|^13.0",
         "illuminate/contracts": "^11.45.3|^12.41.1|^13.0",
         "illuminate/routing": "^11.45.3|^12.41.1|^13.0",


### PR DESCRIPTION
Allows to use v8 of Guzzle while maintaining support for v7 as well, like added in Laravel v13.26 (https://github.com/laravel/framework/pull/60321). No changes are needed, the only direct dependency on Guzzle is in `GitHubSkillProvider` an the logic there is still compatible with Guzzle v8.