### PR TITLE
Quote the MySQL table type as a string literal so schema reads work under ANSI_QUOTES

### DIFF
--- a/src/Mcp/Tools/DatabaseSchema/MySQLSchemaDriver.php
+++ b/src/Mcp/Tools/DatabaseSchema/MySQLSchemaDriver.php
@@ -75,13 +75,13 @@ class MySQLSchemaDriver extends DatabaseSchemaDriver
     public function getTables(): array
     {
         try {
-            return DB::connection($this->connection)->select('
+            return DB::connection($this->connection)->select("
                 SELECT TABLE_NAME as name
                 FROM information_schema.TABLES
                 WHERE TABLE_SCHEMA = DATABASE()
-                AND TABLE_TYPE = "BASE TABLE"
+                AND TABLE_TYPE = 'BASE TABLE'
                 ORDER BY TABLE_NAME
-            ');
+            ");
         } catch (Exception) {
             return [];
         }

--- a/tests/Unit/Mcp/Tools/DatabaseSchema/MySQLSchemaDriverTest.php
+++ b/tests/Unit/Mcp/Tools/DatabaseSchema/MySQLSchemaDriverTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Connection;
+use Illuminate\Support\Facades\DB;
+use Laravel\Boost\Mcp\Tools\DatabaseSchema\MySQLSchemaDriver;
+
+test('getTables quotes the table type as a string literal', function (): void {
+    $sql = null;
+
+    $connection = Mockery::mock(Connection::class);
+    $connection->shouldReceive('select')
+        ->once()
+        ->andReturnUsing(function (string $query) use (&$sql): array {
+            $sql = $query;
+
+            return [];
+        });
+
+    DB::shouldReceive('connection')->with('mysql_test')->andReturn($connection);
+
+    (new MySQLSchemaDriver('mysql_test'))->getTables();
+
+    // Double quotes are identifiers, not strings, when the server runs with ANSI_QUOTES.
+    expect($sql)->toContain("'BASE TABLE'")
+        ->and($sql)->not->toContain('"BASE TABLE"');
+});


### PR DESCRIPTION
`getTables()` compares `TABLE_TYPE` against `"BASE TABLE"`. With `ANSI_QUOTES` in `sql_mode` those double quotes are an identifier rather than a string, so the query throws and the `catch (Exception)` right below it turns that into an empty table list.

MySQL 9.2.0, same two table database:

```
ANSI_QUOTES on,  "BASE TABLE"  ->  ERROR 1054 Unknown column 'BASE TABLE' in 'where clause'
ANSI_QUOTES on,  'BASE TABLE'  ->  posts, users
```

driver level before and after:

| sql_mode | `getTables()` today | with the fix |
|---|---|---|
| `ANSI_QUOTES` | 0 tables | 2 tables |
| default | 2 tables | 2 tables |

`getTables()` is the only source of the table list for both summary and full mode so the whole schema comes back empty. `ANSI` resolves to `REAL_AS_FLOAT,PIPES_AS_CONCAT,ANSI_QUOTES,IGNORE_SPACE,ONLY_FULL_GROUP_BY,ANSI` so that spelling hits it too. The PostgreSQL driver next to it already uses single quotes.
