### PR TITLE
Point the last-error tool description at the correct browser-logs tool name

### DIFF
--- a/src/Mcp/Tools/LastError.php
+++ b/src/Mcp/Tools/LastError.php
@@ -46,7 +46,7 @@ class LastError extends Tool
     /**
      * The tool's description.
      */
-    protected string $description = 'Get details of the last error/exception created in this application on the backend. Use browser-log tool for browser errors.';
+    protected string $description = 'Get details of the last error/exception created in this application on the backend. Use browser-logs tool for browser errors.';
 
     /**
      * Handle the tool request.

--- a/tests/Feature/Mcp/Tools/LastErrorTest.php
+++ b/tests/Feature/Mcp/Tools/LastErrorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
+use Laravel\Boost\Mcp\Tools\BrowserLogs;
 use Laravel\Boost\Mcp\Tools\LastError;
 use Laravel\Mcp\Request;
 
@@ -240,4 +241,8 @@ LOG;
         ->toolHasNoError()
         ->toolTextContains('ERROR', 'This is the actual error')
         ->toolTextDoesNotContain('This is an info message', 'This is a warning message');
+});
+
+it('points at the registered browser logs tool name', function (): void {
+    expect((new LastError)->description())->toContain((new BrowserLogs)->name());
 });


### PR DESCRIPTION
The `last-error` description tells the agent to use the `browser-log` tool. The registered name is `browser-logs`.

```
BrowserLogs registered name : browser-logs
LastError description       : ... Use browser-log tool for browser errors.
```

`browser-log` appears nowhere else in `src/` so there's nothing under that name to call. `laravel/mcp` derives the name from `Str::kebab(class_basename($this))`, so the test asserts the description contains `(new BrowserLogs)->name()` instead of a hardcoded string.
