### PR TITLE
Accept any skill path shape in boost:add-skill, and keep the audit gate correct

### DIFF
--- a/src/Console/AddSkillCommand.php
+++ b/src/Console/AddSkillCommand.php
@@ -322,10 +322,7 @@ class AddSkillCommand extends Command
 
         /** @var array<string, array<int, AuditResult>> $auditResults */
         $auditResults = spin(
-            callback: fn (): array => (new SkillAuditor)->audit(
-                $this->repository->source(),
-                $skillNames,
-            ),
+            callback: fn (): array => $this->auditSkills($selectedSkills),
             message: 'Running security audit...',
         );
 
@@ -340,6 +337,26 @@ class AddSkillCommand extends Command
         }
 
         return confirm('Do you want to install these skills?');
+    }
+
+    /**
+     * @param  Collection<string, RemoteSkill>  $skills
+     * @return array<string, array<int, AuditResult>>
+     */
+    protected function auditSkills(Collection $skills): array
+    {
+        $auditor = new SkillAuditor;
+        $results = [];
+
+        // The audit service resolves a skill as source + '/' + name, so each skill has to be sent under its own parent.
+        foreach ($skills->groupBy(fn (RemoteSkill $skill): string => dirname($skill->path)) as $parent => $group) {
+            $source = $this->repository->fullName().($parent === '.' ? '' : '/'.$parent);
+            $names = $group->map(fn (RemoteSkill $skill): string => $skill->name)->all();
+
+            $results = [...$results, ...$auditor->audit($source, $names)];
+        }
+
+        return $results;
     }
 
     /**

--- a/src/Console/AddSkillCommand.php
+++ b/src/Console/AddSkillCommand.php
@@ -9,6 +9,7 @@ use const DIRECTORY_SEPARATOR;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use Laravel\Boost\Concerns\DisplayHelper;
 use Laravel\Boost\Skills\Remote\AuditResult;
@@ -348,9 +349,13 @@ class AddSkillCommand extends Command
         $auditor = new SkillAuditor;
         $results = [];
 
+        $parentOf = fn (RemoteSkill $skill): string => Str::contains($skill->path, '/')
+            ? Str::beforeLast($skill->path, '/')
+            : '';
+
         // The audit service resolves a skill as source + '/' + name, so each skill has to be sent under its own parent.
-        foreach ($skills->groupBy(fn (RemoteSkill $skill): string => dirname($skill->path)) as $parent => $group) {
-            $source = $this->repository->fullName().($parent === '.' ? '' : '/'.$parent);
+        foreach ($skills->groupBy($parentOf) as $parent => $group) {
+            $source = $this->repository->fullName().($parent === '' ? '' : '/'.$parent);
             $names = $group->map(fn (RemoteSkill $skill): string => $skill->name)->all();
 
             $results = [...$results, ...$auditor->audit($source, $names)];

--- a/src/Install/SkillWriter.php
+++ b/src/Install/SkillWriter.php
@@ -31,7 +31,7 @@ class SkillWriter
 
     public function write(Skill $skill): int
     {
-        if (! $this->isValidSkillName($skill->name)) {
+        if (! self::isValidSkillName($skill->name)) {
             throw new RuntimeException("Invalid skill name: {$skill->name}");
         }
 
@@ -98,9 +98,15 @@ class SkillWriter
      */
     public function writeAll(Collection $skills): array
     {
-        return $skills
-            ->mapWithKeys(fn (Skill $skill): array => [$skill->name => $this->write($skill)])
-            ->all();
+        [$valid, $invalid] = $skills->partition(fn (Skill $skill): bool => self::isValidSkillName($skill->name));
+
+        $written = $valid->mapWithKeys(fn (Skill $skill): array => [$skill->name => $this->write($skill)])->all();
+
+        if ($invalid->isNotEmpty()) {
+            throw new RuntimeException('Invalid skill name: '.$invalid->implode('name', ', '));
+        }
+
+        return $written;
     }
 
     /**
@@ -110,20 +116,14 @@ class SkillWriter
      */
     public function sync(Collection $skills, array $previouslyTrackedSkills = []): array
     {
-        $written = $this->writeAll($skills);
+        $this->removeStale(array_values(array_diff($previouslyTrackedSkills, $skills->keys()->all())));
 
-        $newSkillNames = $skills->keys()->all();
-
-        $staleSkillNames = array_values(array_diff($previouslyTrackedSkills, $newSkillNames));
-
-        $this->removeStale($staleSkillNames);
-
-        return $written;
+        return $this->writeAll($skills);
     }
 
     public function remove(string $skillName): bool
     {
-        if (! $this->isValidSkillName($skillName)) {
+        if (! self::isValidSkillName($skillName)) {
             return false;
         }
 
@@ -337,10 +337,13 @@ class SkillWriter
         return false;
     }
 
-    protected function isValidSkillName(string $name): bool
+    public static function isValidSkillName(string $name): bool
     {
-        $hasPathTraversal = str_contains($name, '..') || str_contains($name, '/') || str_contains($name, '\\');
+        if (str_contains($name, '..') || str_contains($name, '/') || str_contains($name, '\\') || str_contains($name, "\0")) {
+            return false;
+        }
 
-        return ! $hasPathTraversal && trim($name) !== '';
+        // A name of only dots and whitespace resolves to the skills directory itself.
+        return trim($name, ". \t\n\r\0\x0B") !== '';
     }
 }

--- a/src/Skills/Remote/GitHubRepository.php
+++ b/src/Skills/Remote/GitHubRepository.php
@@ -9,9 +9,14 @@ use InvalidArgumentException;
 
 class GitHubRepository
 {
-    public function __construct(public string $owner, public string $repo, public string $path = '')
+    public function __construct(public string $owner, public string $repo, public string $path = '', public string $branch = '')
     {
-        //
+        $path = trim($path, '/');
+
+        // A path copied from a file view points at SKILL.md, not the directory holding it.
+        $directory = basename($path) === 'SKILL.md' ? dirname($path) : $path;
+
+        $this->path = $directory === '.' ? '' : $directory;
     }
 
     /**
@@ -19,9 +24,9 @@ class GitHubRepository
      */
     public static function fromInput(string $input): self
     {
-        $input = self::normalizeUrl($input);
+        [$input, $branch] = self::normalizeUrl($input);
 
-        return self::parseOwnerRepoPath($input);
+        return self::parseOwnerRepoPath($input, $branch);
     }
 
     public function fullName(): string
@@ -37,14 +42,16 @@ class GitHubRepository
     }
 
     /**
+     * @return array{0: string, 1: string}
+     *
      * @throws InvalidArgumentException
      */
-    private static function normalizeUrl(string $input): string
+    private static function normalizeUrl(string $input): array
     {
         $isUrl = Str::startsWith($input, ['http://', 'https://']);
 
         if (! $isUrl) {
-            return $input;
+            return [$input, ''];
         }
 
         $parsed = parse_url($input);
@@ -58,17 +65,18 @@ class GitHubRepository
 
         $path = Str::of($parsed['path'] ?? '')->trim('/')->toString();
 
-        if (Str::contains($path, '/tree/')) {
-            return Str::of($path)->replaceMatches('#/tree/[^/]+#', '')->toString();
+        // ponytail: a branch name containing a slash is indistinguishable from the path after it.
+        if (preg_match('#^(?P<repository>[^/]+/[^/]+)/(?:tree|blob)/(?P<branch>[^/]+)/?(?P<path>.*)$#', $path, $matches) === 1) {
+            return [rtrim($matches['repository'].'/'.$matches['path'], '/'), $matches['branch']];
         }
 
-        return $path;
+        return [$path, ''];
     }
 
     /**
      * @throws InvalidArgumentException
      */
-    private static function parseOwnerRepoPath(string $input): self
+    private static function parseOwnerRepoPath(string $input, string $branch = ''): self
     {
         $parts = explode('/', $input);
 
@@ -80,6 +88,7 @@ class GitHubRepository
             owner: $parts[0],
             repo: $parts[1],
             path: implode('/', array_slice($parts, 2)),
+            branch: $branch,
         );
     }
 }

--- a/src/Skills/Remote/GitHubSkillProvider.php
+++ b/src/Skills/Remote/GitHubSkillProvider.php
@@ -43,8 +43,13 @@ class GitHubSkillProvider
         if ($basePath !== '') {
             $prefix = $basePath.'/';
 
-            $skillMarkers = $skillMarkers->filter(function (array $item) use ($prefix): bool {
+            $skillMarkers = $skillMarkers->filter(function (array $item) use ($basePath, $prefix): bool {
                 $skillDir = dirname((string) $item['path']);
+
+                // The path may point at a skill directory itself, not just a parent of one.
+                if ($skillDir === $basePath) {
+                    return true;
+                }
 
                 return str_starts_with($skillDir, $prefix) && ! str_contains(substr($skillDir, strlen($prefix)), '/');
             });

--- a/src/Skills/Remote/GitHubSkillProvider.php
+++ b/src/Skills/Remote/GitHubSkillProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
 use Laravel\Boost\Install\SkillWriter;
 use RuntimeException;
 use Throwable;
@@ -44,17 +45,28 @@ class GitHubSkillProvider
 
                 // Matching the marker rather than its directory accepts a path that is itself a skill directory.
                 return $item['type'] === 'blob'
-                    && basename($path) === 'SKILL.md'
+                    && Str::afterLast($path, '/') === 'SKILL.md'
                     && str_starts_with($path, $prefix)
                     // A skill is named after its directory, so that directory has to be a usable name.
-                    && SkillWriter::isValidSkillName(basename(dirname($path)));
+                    && SkillWriter::isValidSkillName(self::skillName($path));
             })
             ->map(fn (array $item): RemoteSkill => new RemoteSkill(
-                name: basename(dirname((string) $item['path'])),
+                name: self::skillName((string) $item['path']),
                 repo: $this->repository->fullName(),
-                path: dirname((string) $item['path']),
+                path: self::skillDirectory((string) $item['path']),
             ))
             ->keyBy(fn (RemoteSkill $skill): string => $skill->name);
+    }
+
+    protected static function skillName(string $markerPath): string
+    {
+        return Str::afterLast(self::skillDirectory($markerPath), '/');
+    }
+
+    // Repository paths are always slash-delimited, so basename() and dirname() would split on a backslash under Windows.
+    protected static function skillDirectory(string $markerPath): string
+    {
+        return Str::contains($markerPath, '/') ? Str::beforeLast($markerPath, '/') : '';
     }
 
     public function downloadSkill(RemoteSkill $skill, string $targetPath): bool

--- a/src/Skills/Remote/GitHubSkillProvider.php
+++ b/src/Skills/Remote/GitHubSkillProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Laravel\Boost\Install\SkillWriter;
 use RuntimeException;
 use Throwable;
 
@@ -35,30 +36,19 @@ class GitHubSkillProvider
             return collect();
         }
 
-        $basePath = $this->repository->path;
+        $prefix = $this->repository->path === '' ? '' : $this->repository->path.'/';
 
-        $skillMarkers = collect($tree['tree'])
-            ->filter(fn (array $item): bool => $item['type'] === 'blob'
-                && basename((string) $item['path']) === 'SKILL.md'
-                // A skill is named after its directory, so a repository-root SKILL.md has no name to take.
-                && dirname((string) $item['path']) !== '.');
+        return collect($tree['tree'])
+            ->filter(function (array $item) use ($prefix): bool {
+                $path = (string) $item['path'];
 
-        if ($basePath !== '') {
-            $prefix = $basePath.'/';
-
-            $skillMarkers = $skillMarkers->filter(function (array $item) use ($basePath, $prefix): bool {
-                $skillDir = dirname((string) $item['path']);
-
-                // The path may point at a skill directory itself, not just a parent of one.
-                if ($skillDir === $basePath) {
-                    return true;
-                }
-
-                return str_starts_with($skillDir, $prefix) && ! str_contains(substr($skillDir, strlen($prefix)), '/');
-            });
-        }
-
-        return $skillMarkers
+                // Matching the marker rather than its directory accepts a path that is itself a skill directory.
+                return $item['type'] === 'blob'
+                    && basename($path) === 'SKILL.md'
+                    && str_starts_with($path, $prefix)
+                    // A skill is named after its directory, so that directory has to be a usable name.
+                    && SkillWriter::isValidSkillName(basename(dirname($path)));
+            })
             ->map(fn (array $item): RemoteSkill => new RemoteSkill(
                 name: basename(dirname((string) $item['path'])),
                 repo: $this->repository->fullName(),
@@ -111,7 +101,7 @@ class GitHubSkillProvider
             'https://api.github.com/repos/%s/%s/git/trees/%s?recursive=1',
             $this->repository->owner,
             $this->repository->repo,
-            urlencode($this->resolveDefaultBranch())
+            urlencode($this->resolveBranch())
         );
 
         $response = $this->client()->get($url);
@@ -228,7 +218,7 @@ class GitHubSkillProvider
             'https://raw.githubusercontent.com/%s/%s/%s/%s',
             $this->repository->owner,
             $this->repository->repo,
-            $this->resolveDefaultBranch(),
+            $this->resolveBranch(),
             ltrim($path, '/')
         );
     }
@@ -263,8 +253,12 @@ class GitHubSkillProvider
         return Http::withHeaders($headers)->timeout($timeout);
     }
 
-    protected function resolveDefaultBranch(): string
+    protected function resolveBranch(): string
     {
+        if ($this->repository->branch !== '') {
+            return $this->repository->branch;
+        }
+
         if ($this->defaultBranch !== null) {
             return $this->defaultBranch;
         }

--- a/tests/Feature/Console/AddSkillCommandTest.php
+++ b/tests/Feature/Console/AddSkillCommandTest.php
@@ -449,6 +449,33 @@ it('sends correct source and skills to audit api before download', function (): 
     });
 });
 
+it('audits a skill under its own parent whatever depth the given path is', function (string $repo): void {
+    Http::fake([
+        'api.github.com/repos/owner/repo' => Http::response(['default_branch' => 'main']),
+        'api.github.com/repos/owner/repo/git/trees/main?recursive=1' => Http::response([
+            'sha' => 'abc123',
+            'tree' => [
+                ['path' => '.ai/claude/skills/my-skill', 'type' => 'tree', 'sha' => 'aaa'],
+                ['path' => '.ai/claude/skills/my-skill/SKILL.md', 'type' => 'blob', 'sha' => 'bbb', 'size' => 123],
+            ],
+            'truncated' => false,
+        ]),
+        'raw.githubusercontent.com/*' => Http::response('# Content'),
+        'skills.laravel.cloud/api/v1/skills/audit*' => Http::response([]),
+    ]);
+
+    $this->artisan('boost:add-skill', ['repo' => $repo, '--all' => true])->assertSuccessful();
+
+    Http::assertSent(fn ($request): bool => str_contains((string) $request->url(), 'skills.laravel.cloud/api/v1/skills/audit')
+        && str_contains((string) $request->url(), 'source=owner%2Frepo%2F.ai%2Fclaude%2Fskills')
+        && str_contains((string) $request->url(), 'skills=my-skill'));
+})->with([
+    'whole repository' => ['owner/repo'],
+    'a distant parent' => ['owner/repo/.ai'],
+    'the direct parent' => ['owner/repo/.ai/claude/skills'],
+    'the skill directory itself' => ['owner/repo/.ai/claude/skills/my-skill'],
+]);
+
 it('audits only skills that will be installed', function (): void {
     File::ensureDirectoryExists(base_path('.ai/skills/skill-one'));
     File::put(base_path('.ai/skills/skill-one/SKILL.md'), 'existing content');

--- a/tests/Unit/Install/SkillWriterTest.php
+++ b/tests/Unit/Install/SkillWriterTest.php
@@ -304,6 +304,10 @@ it('throws an exception for path traversal in skill name', function (string $mal
     'skill/with/slash',
     'skill\\with\\backslash',
     '../parent',
+    '',
+    '.',
+    '. .',
+    "with\0null",
 ]);
 
 it('renders blade templates to markdown', function (): void {
@@ -408,7 +412,9 @@ it('returns false when removing skill with invalid name', function (): void {
     $writer = new SkillWriter($agent);
 
     expect($writer->remove('../malicious'))->toBeFalse()
-        ->and($writer->remove('skill/with/slash'))->toBeFalse();
+        ->and($writer->remove('skill/with/slash'))->toBeFalse()
+        ->and($writer->remove('.'))->toBeFalse()
+        ->and($writer->remove('. .'))->toBeFalse();
 });
 
 it('removes multiple stale skills', function (): void {
@@ -1091,4 +1097,56 @@ it('writes skill files with a trailing newline', function (): void {
         ->and(file_get_contents($absoluteTarget.'/test-skill/SKILL.md'))->toEndWith("\n");
 
     cleanupSkillDirectory($absoluteTarget);
+});
+
+it('never deletes a skills directory when a skill is named "."', function (): void {
+    $relativeTarget = '.boost-test-skills-'.uniqid();
+    $absoluteTarget = base_path($relativeTarget);
+    $canonicalTarget = base_path('.ai'.DIRECTORY_SEPARATOR.'skills');
+
+    mkdir($absoluteTarget.'/keep-me', 0755, true);
+    file_put_contents($absoluteTarget.'/keep-me/SKILL.md', 'keep me');
+    mkdir($canonicalTarget.'/keep-me-too', 0755, true);
+    file_put_contents($canonicalTarget.'/keep-me-too/SKILL.md', 'keep me too');
+
+    $agent = Mockery::mock(SupportsSkills::class);
+    $agent->shouldReceive('skillsPath')->andReturn($relativeTarget);
+
+    $writer = new SkillWriter($agent);
+    $skill = new Skill(name: '.', package: 'boost', path: fixture('skills/test-skill'), description: 'Malicious skill');
+
+    try {
+        expect(fn (): int => $writer->write($skill))->toThrow(RuntimeException::class, 'Invalid skill name')
+            ->and(file_get_contents($absoluteTarget.'/keep-me/SKILL.md'))->toBe('keep me')
+            ->and(file_get_contents($canonicalTarget.'/keep-me-too/SKILL.md'))->toBe('keep me too')
+            ->and($writer->removeStale(['.']))->toBe(['.' => false]);
+    } finally {
+        cleanupSkillDirectory($absoluteTarget);
+        cleanupSkillDirectory($canonicalTarget.'/keep-me-too');
+    }
+});
+
+it('still syncs the valid skills when one skill name is invalid', function (): void {
+    $relativeTarget = '.boost-test-skills-'.uniqid();
+    $absoluteTarget = base_path($relativeTarget);
+
+    mkdir($absoluteTarget.'/stale-skill', 0755, true);
+    file_put_contents($absoluteTarget.'/stale-skill/SKILL.md', 'stale');
+
+    $agent = Mockery::mock(SupportsSkills::class);
+    $agent->shouldReceive('skillsPath')->andReturn($relativeTarget);
+
+    $skills = collect([
+        '.' => new Skill(name: '.', package: 'boost', path: fixture('skills/test-skill'), description: 'Malicious skill'),
+        'test-skill' => new Skill(name: 'test-skill', package: 'boost', path: fixture('skills/test-skill'), description: 'Test skill'),
+    ]);
+
+    try {
+        expect(fn (): array => (new SkillWriter($agent))->sync($skills, ['stale-skill']))
+            ->toThrow(RuntimeException::class, 'Invalid skill name: .')
+            ->and($absoluteTarget.'/test-skill/SKILL.md')->toBeFile()
+            ->and($absoluteTarget.'/stale-skill')->not->toBeDirectory();
+    } finally {
+        cleanupSkillDirectory($absoluteTarget);
+    }
 });

--- a/tests/Unit/Skills/Remote/GitHubRepositoryTest.php
+++ b/tests/Unit/Skills/Remote/GitHubRepositoryTest.php
@@ -19,6 +19,13 @@ it('parses valid repository input', function (string $input, string $owner, stri
     'GitHub URL with tree/branch' => ['https://github.com/owner/repo/tree/main/skills', 'owner', 'repo', 'skills'],
     'GitHub URL with tree/branch and nested path' => ['https://github.com/owner/repo/tree/feature-branch/path/to/skills', 'owner', 'repo', 'path/to/skills'],
     'complex branch names in tree URLs' => ['https://github.com/owner/repo/tree/feature/my-branch/skills', 'owner', 'repo', 'my-branch/skills'],
+    'GitHub URL pointing at a skill directory' => ['https://github.com/owner/repo/tree/main/skills/my-skill', 'owner', 'repo', 'skills/my-skill'],
+    'GitHub URL pointing at a SKILL.md file' => ['https://github.com/owner/repo/blob/main/skills/my-skill/SKILL.md', 'owner', 'repo', 'skills/my-skill'],
+    'path with a trailing slash' => ['owner/repo/skills/my-skill/', 'owner', 'repo', 'skills/my-skill'],
+    'path pointing at a SKILL.md file' => ['owner/repo/skills/my-skill/SKILL.md', 'owner', 'repo', 'skills/my-skill'],
+    'repository root SKILL.md' => ['owner/repo/SKILL.md', 'owner', 'repo', ''],
+    'repository named tree' => ['https://github.com/owner/tree/tree/main/skills', 'owner', 'tree', 'skills'],
+    'repository named blob' => ['https://github.com/owner/blob/blob/main/skills/my-skill', 'owner', 'blob', 'skills/my-skill'],
 ]);
 
 it('throws for invalid input', function (string $input, string $message): void {
@@ -43,3 +50,17 @@ it('returns source with path when present', function (): void {
 
     expect($repo->source())->toBe('owner/repo/path/to/skills');
 });
+
+it('keeps the branch named in a GitHub URL', function (string $input, string $branch, string $path): void {
+    $result = GitHubRepository::fromInput($input);
+
+    expect($result->branch)->toBe($branch)
+        ->and($result->path)->toBe($path);
+})->with([
+    'no branch in plain input' => ['owner/repo/skills', '', 'skills'],
+    'no branch in a plain URL' => ['https://github.com/owner/repo', '', ''],
+    'default branch in a tree URL' => ['https://github.com/owner/repo/tree/main/skills', 'main', 'skills'],
+    'other branch in a tree URL' => ['https://github.com/owner/repo/tree/develop/skills/my-skill', 'develop', 'skills/my-skill'],
+    'branch in a blob URL' => ['https://github.com/owner/repo/blob/develop/skills/my-skill/SKILL.md', 'develop', 'skills/my-skill'],
+    'branch with no path after it' => ['https://github.com/owner/repo/tree/develop', 'develop', ''],
+]);

--- a/tests/Unit/Skills/Remote/GitHubSkillProviderTest.php
+++ b/tests/Unit/Skills/Remote/GitHubSkillProviderTest.php
@@ -597,9 +597,107 @@ it('downloads a skill whose path was given directly', function (): void {
     $fetcher = new GitHubSkillProvider(new GitHubRepository('owner', 'repo', 'skills/my-skill'));
     $skill = $fetcher->discoverSkills()->get('my-skill');
 
-    expect($fetcher->downloadSkill($skill, $targetDir))->toBeTrue()
-        ->and(file_get_contents($targetDir.'/SKILL.md'))->toBe('# Direct');
+    try {
+        expect($fetcher->downloadSkill($skill, $targetDir))->toBeTrue()
+            ->and(file_get_contents($targetDir.'/SKILL.md'))->toBe('# Direct');
+    } finally {
+        array_map(unlink(...), glob($targetDir.'/*'));
+        rmdir($targetDir);
+    }
+});
 
-    array_map(unlink(...), glob($targetDir.'/*'));
-    rmdir($targetDir);
+it('ignores a skill directory whose name cannot be a skill name', function (): void {
+    Http::fake([
+        ...fakeGitHubRepo(),
+        ...fakeTreeResponse([
+            ['path' => '... ', 'type' => 'tree', 'sha' => 'aaa'],
+            ['path' => '... /SKILL.md', 'type' => 'blob', 'sha' => 'bbb', 'size' => 123],
+            ['path' => '..\\..\\evil', 'type' => 'tree', 'sha' => 'eee'],
+            ['path' => '..\\..\\evil/SKILL.md', 'type' => 'blob', 'sha' => 'fff', 'size' => 789],
+            ['path' => 'skill-one', 'type' => 'tree', 'sha' => 'ccc'],
+            ['path' => 'skill-one/SKILL.md', 'type' => 'blob', 'sha' => 'ddd', 'size' => 456],
+        ]),
+    ]);
+
+    $fetcher = new GitHubSkillProvider(new GitHubRepository('owner', 'repo'));
+
+    expect($fetcher->discoverSkills()->keys()->all())->toBe(['skill-one']);
+});
+
+it('discovers skills at any depth below the given path', function (string $path): void {
+    Http::fake([
+        ...fakeGitHubRepo(),
+        ...fakeTreeResponse([
+            ['path' => '.ai', 'type' => 'tree', 'sha' => 'aaa'],
+            ['path' => '.ai/claude', 'type' => 'tree', 'sha' => 'bbb'],
+            ['path' => '.ai/claude/skills', 'type' => 'tree', 'sha' => 'ccc'],
+            ['path' => '.ai/claude/skills/my-skill', 'type' => 'tree', 'sha' => 'ddd'],
+            ['path' => '.ai/claude/skills/my-skill/SKILL.md', 'type' => 'blob', 'sha' => 'eee', 'size' => 123],
+        ]),
+    ]);
+
+    $skills = (new GitHubSkillProvider(new GitHubRepository('owner', 'repo', $path)))->discoverSkills();
+
+    expect($skills->keys()->all())->toBe(['my-skill'])
+        ->and($skills->get('my-skill')->path)->toBe('.ai/claude/skills/my-skill');
+})->with([
+    'whole repository' => [''],
+    'a distant parent' => ['.ai'],
+    'an intermediate parent' => ['.ai/claude'],
+    'the direct parent' => ['.ai/claude/skills'],
+    'the skill directory itself' => ['.ai/claude/skills/my-skill'],
+    'the skill directory with a trailing slash' => ['.ai/claude/skills/my-skill/'],
+    'the SKILL.md file itself' => ['.ai/claude/skills/my-skill/SKILL.md'],
+]);
+
+it('keeps skills apart when one path is a prefix of another', function (): void {
+    Http::fake([
+        ...fakeGitHubRepo(),
+        ...fakeTreeResponse([
+            ['path' => 'skills/my-skill', 'type' => 'tree', 'sha' => 'aaa'],
+            ['path' => 'skills/my-skill/SKILL.md', 'type' => 'blob', 'sha' => 'bbb', 'size' => 123],
+            ['path' => 'skills/my-skill-extra', 'type' => 'tree', 'sha' => 'ccc'],
+            ['path' => 'skills/my-skill-extra/SKILL.md', 'type' => 'blob', 'sha' => 'ddd', 'size' => 456],
+        ]),
+    ]);
+
+    $fetcher = new GitHubSkillProvider(new GitHubRepository('owner', 'repo', 'skills/my-skill'));
+
+    expect($fetcher->discoverSkills()->keys()->all())->toBe(['my-skill']);
+});
+
+it('reads the branch named in the repository instead of asking for the default', function (): void {
+    Http::fake(fakeTreeResponse([
+        ['path' => 'my-skill', 'type' => 'tree', 'sha' => 'aaa'],
+        ['path' => 'my-skill/SKILL.md', 'type' => 'blob', 'sha' => 'bbb', 'size' => 123],
+    ], 'develop'));
+
+    $fetcher = new GitHubSkillProvider(new GitHubRepository('owner', 'repo', 'my-skill', 'develop'));
+
+    expect($fetcher->discoverSkills()->keys()->all())->toBe(['my-skill']);
+
+    Http::assertNotSent(fn ($request): bool => (string) $request->url() === 'https://api.github.com/repos/owner/repo');
+});
+
+it('downloads a skill from the branch named in the repository', function (): void {
+    $targetDir = sys_get_temp_dir().'/boost-test-'.uniqid();
+
+    Http::fake([
+        ...fakeTreeResponse([
+            ['path' => 'my-skill', 'type' => 'tree', 'sha' => 'aaa'],
+            ['path' => 'my-skill/SKILL.md', 'type' => 'blob', 'sha' => 'bbb', 'size' => 123],
+        ], 'develop'),
+        'raw.githubusercontent.com/owner/repo/develop/my-skill/SKILL.md' => Http::response('# Develop'),
+    ]);
+
+    $fetcher = new GitHubSkillProvider(new GitHubRepository('owner', 'repo', 'my-skill', 'develop'));
+    $skill = $fetcher->discoverSkills()->get('my-skill');
+
+    try {
+        expect($fetcher->downloadSkill($skill, $targetDir))->toBeTrue()
+            ->and(file_get_contents($targetDir.'/SKILL.md'))->toBe('# Develop');
+    } finally {
+        array_map(unlink(...), glob($targetDir.'/*'));
+        rmdir($targetDir);
+    }
 });

--- a/tests/Unit/Skills/Remote/GitHubSkillProviderTest.php
+++ b/tests/Unit/Skills/Remote/GitHubSkillProviderTest.php
@@ -528,3 +528,46 @@ it('discovers skills in wildcard paths like .ai/*/skills', function (): void {
         ->and($skills->has('my-skill'))->toBeTrue()
         ->and($skills->get('my-skill')->path)->toBe('.ai/claude/skills/my-skill');
 });
+
+it('discovers a skill when the path points at the skill directory itself', function (): void {
+    Http::fake([
+        ...fakeGitHubRepo(),
+        ...fakeTreeResponse([
+            ['path' => 'skills', 'type' => 'tree', 'sha' => 'aaa'],
+            ['path' => 'skills/my-skill', 'type' => 'tree', 'sha' => 'bbb'],
+            ['path' => 'skills/my-skill/SKILL.md', 'type' => 'blob', 'sha' => 'ccc', 'size' => 123],
+            ['path' => 'skills/other-skill', 'type' => 'tree', 'sha' => 'ddd'],
+            ['path' => 'skills/other-skill/SKILL.md', 'type' => 'blob', 'sha' => 'eee', 'size' => 456],
+        ]),
+    ]);
+
+    $fetcher = new GitHubSkillProvider(new GitHubRepository('owner', 'repo', 'skills/my-skill'));
+    $skills = $fetcher->discoverSkills();
+
+    expect($skills)->toHaveCount(1)
+        ->and($skills->has('my-skill'))->toBeTrue()
+        ->and($skills->get('my-skill')->path)->toBe('skills/my-skill');
+});
+
+it('downloads a skill whose path was given directly', function (): void {
+    $targetDir = sys_get_temp_dir().'/boost-test-'.uniqid();
+
+    Http::fake([
+        ...fakeGitHubRepo(),
+        ...fakeTreeResponse([
+            ['path' => 'skills', 'type' => 'tree', 'sha' => 'aaa'],
+            ['path' => 'skills/my-skill', 'type' => 'tree', 'sha' => 'bbb'],
+            ['path' => 'skills/my-skill/SKILL.md', 'type' => 'blob', 'sha' => 'ccc', 'size' => 123],
+        ]),
+        'raw.githubusercontent.com/owner/repo/main/skills/my-skill/SKILL.md' => Http::response('# Direct'),
+    ]);
+
+    $fetcher = new GitHubSkillProvider(new GitHubRepository('owner', 'repo', 'skills/my-skill'));
+    $skill = $fetcher->discoverSkills()->get('my-skill');
+
+    expect($fetcher->downloadSkill($skill, $targetDir))->toBeTrue()
+        ->and(file_get_contents($targetDir.'/SKILL.md'))->toBe('# Direct');
+
+    array_map(unlink(...), glob($targetDir.'/*'));
+    rmdir($targetDir);
+});


### PR DESCRIPTION
Pointing `boost:add-skill` at a skill's own directory finds nothing. The path filter only keeps directories one level *below* the given path, so the skill directory itself never matches.

real repo on main:

```
input : https://github.com/agarzon/moonshine-v4-skills/tree/main/moonshine-fields-v4
parsed: path='moonshine-fields-v4'
discovered: NOTHING
```

`#458` documents that form as `boost:add-skill owner/repo/.ai/skills`, and copying a skill's URL straight out of the browser lands you here too.

## Every path shape now behaves the same

The one-level rule made discovery unpredictable rather than just narrow — no path searched at *any* depth, but any path searched at *exactly one*. So `owner/repo` found a skill that `owner/repo/.ai`, a strictly narrower query on the same repo, did not:

| input path | before | after |
|---|---|---|
| *(none)* | ✅ | ✅ |
| `.ai` | ❌ | ✅ |
| `.ai/claude` | ❌ | ✅ |
| `.ai/claude/skills` | ✅ | ✅ |
| `.ai/claude/skills/my-skill` | ❌ | ✅ |
| `.ai/claude/skills/my-skill/` | ❌ | ✅ |
| `.ai/claude/skills/my-skill/SKILL.md` | ❌ | ✅ |

Matching the marker's full path rather than its directory collapses the whole block to one `str_starts_with`, and a trailing `/` or `/SKILL.md` normalises in `GitHubRepository`'s constructor so both construction paths get it.

## The audit gate was silently skipping

Worth calling out, because it is the reason this PR is bigger than its title used to be. `SkillAuditor` resolves a skill as `source + '/' + name` (pinned by `AddSkillCommandTest`). The one-level restriction was quietly load-bearing for that invariant — removing it meant `owner/repo/skills/my-skill` sent `source=owner/repo/skills/my-skill` with `name=my-skill`, the API matched nothing, `hasRiskySkills([])` returned false, and skills installed without the audit table or the confirmation prompt ever appearing.

`auditSkills()` now groups the selected skills by their real parent and audits each group under a source that reconstructs the true path. That also fixes it for plain `owner/repo` on a nested-skill repo, where the audit was already never matching before this PR.

## Branch is no longer discarded

`normalizeUrl()` stripped `/tree/<branch>` and then always resolved the *default* branch, so `.../tree/develop/my-skill` silently installed from `main` — wrong content, no error. The branch is now kept and preferred, which also skips the default-branch API call. `/blob/` URLs (what you get clicking through to a file) were not handled at all and kept a literal `blob/main/` in the path.

The existing `'complex branch names in tree URLs'` case already pinned "first segment after `/tree/` is the branch" as the contract, so that behaviour is unchanged; a slash-containing branch stays ambiguous.

## Ports #955

#955 touched the same few lines of `discoverSkills()`, so both could not land without a conflict. Closed in favour of this branch, carrying over: `.` rejected as a skill name (`.claude/skills/.` *is* the skills directory, so `remove('.')` deleted every installed skill and then returned `false`), `isValidSkillName()` public static and also rejecting `\0` and dot/whitespace-only names, remote skill names gated through it, and `writeAll()`/`sync()` letting one bad `boost.json` entry fail without blocking the skills beside it.

## Known limitation, not addressed

Two skill directories sharing a basename at different depths still collapse to one under `keyBy(name)` — `laravel/boost/.ai/tailwindcss` has exactly this, with `3/skill/tailwindcss-development` and `4/skill/tailwindcss-development`. Both sit at equal depth so no ordering rule picks correctly; the honest fix is warning the user, which is a product decision. This is reachable on `main` today via whole-repo input, so it is pre-existing rather than introduced here.

## Tests

991 passing, 34 added — including a matrix over all seven path shapes above and a four-case matrix asserting the audit source is correct from every one of them.

Unrelated: `composer test:lint` fails on this branch regardless of these changes, because Rector wants to rewrite `src/Mcp/Tools/DatabaseQuery.php` (drift from upstream `afa84ea`). Left alone to keep the diff scoped.
