### PR TITLE
Re-key the search-docs query list after filtering

### DIFF
--- a/src/Mcp/Tools/SearchDocs.php
+++ b/src/Mcp/Tools/SearchDocs.php
@@ -68,7 +68,6 @@ class SearchDocs extends Tool
             return $rawQueries;
         }
 
-        // Re-key so a dropped query cannot turn the list into a JSON object.
         $queries = array_values(array_filter(
             array_map(trim(...), $rawQueries),
             fn (string $query): bool => $query !== '' && $query !== '*'

--- a/src/Mcp/Tools/SearchDocs.php
+++ b/src/Mcp/Tools/SearchDocs.php
@@ -68,10 +68,11 @@ class SearchDocs extends Tool
             return $rawQueries;
         }
 
-        $queries = array_filter(
+        // Re-key so a dropped query cannot turn the list into a JSON object.
+        $queries = array_values(array_filter(
             array_map(trim(...), $rawQueries),
             fn (string $query): bool => $query !== '' && $query !== '*'
-        );
+        ));
 
         try {
             $packagesCollection = $this->project->php()->packages()->concat($this->project->js()->packages());

--- a/tests/Feature/Mcp/Tools/SearchDocsTest.php
+++ b/tests/Feature/Mcp/Tools/SearchDocsTest.php
@@ -269,3 +269,21 @@ test('it caps token_limit at maximum of 1000000', function (): void {
 
     Http::assertSent(fn ($request): bool => $request->data()['token_limit'] === 1000000);
 });
+
+test('it sends the remaining queries as a list when some are filtered out', function (): void {
+    $project = Mockery::mock(ProjectManager::class);
+    mockProjectPackages($project, new PackageCollection([rosterPackage('laravel/framework', '11.0.0')]));
+
+    Http::fake([
+        'https://boost.laravel.com/api/docs' => Http::response('Documentation search results', 200),
+    ]);
+
+    $tool = new SearchDocs($project);
+    $response = $tool->handle(new Request(['queries' => ['*', 'middleware', '', 'routing']]));
+
+    expect($response)->isToolResult()->toolHasNoError();
+
+    // Dropping the first query must not turn "queries" into a JSON object.
+    Http::assertSent(fn ($request): bool => $request->data()['queries'] === ['middleware', 'routing']
+        && str_contains($request->body(), '"queries":["middleware","routing"]'));
+});


### PR DESCRIPTION
`SearchDocs` drops empty and `*` queries with `array_filter`, which keeps the original keys. so if the dropped one isnt last, `queries` stops being a json array and goes out as an object.

real body for `queries => ['*', 'middleware', '', 'routing']`:

```json
{"queries":{"1":"middleware","3":"routing"},"packages":[{"name":"laravel/framework","version":"11.x"}],"token_limit":3000,"format":"markdown"}
```

`packages` right next to it is fine because it already gets `->values()`, so the list shape is clearly what was intended here too.

worth saying i cant see what the docs api does with an object instead of an array, that ones on your side. but the schema declares `queries` as an array of strings and thats not what it sends.

fix is `array_values()` around the existing filter. test asserts both the decoded value and the literal `"queries":["middleware","routing"]` in the body, and it fails without the change.
