### PR TITLE
Stop detecting Antigravity from the shared .agents directory

### DIFF
--- a/src/Install/Agents/Antigravity.php
+++ b/src/Install/Agents/Antigravity.php
@@ -35,8 +35,9 @@ class Antigravity extends Agent implements SupportsGuidelines, SupportsMcp, Supp
 
     public function projectDetectionConfig(): array
     {
+        // The bare .agents directory is not Antigravity-specific: Boost itself
+        // creates it when installing skills for Amp, Codex, OpenCode, or Zed.
         return [
-            'paths' => ['.agents'],
             'files' => ['.agents/mcp_config.json'],
         ];
     }

--- a/tests/Unit/Install/Agents/AntigravityTest.php
+++ b/tests/Unit/Install/Agents/AntigravityTest.php
@@ -67,13 +67,41 @@ it('returns configured skills path', function (): void {
     expect($agent->skillsPath())->toBe('.custom/skills');
 });
 
-it('projectDetectionConfig detects .agents path and mcp_config.json file', function (): void {
+it('projectDetectionConfig only uses the Antigravity-specific mcp_config.json', function (): void {
     $agent = new Antigravity($this->strategyFactory);
 
     expect($agent->projectDetectionConfig())->toBe([
-        'paths' => ['.agents'],
         'files' => ['.agents/mcp_config.json'],
     ]);
+});
+
+it('detectInProject returns false when only .agents/skills exists', function (): void {
+    $agent = new Antigravity(new DetectionStrategyFactory(app()));
+    $tempDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'boost_antigravity_'.uniqid();
+    mkdir($tempDir.DIRECTORY_SEPARATOR.'.agents'.DIRECTORY_SEPARATOR.'skills', 0755, true);
+
+    try {
+        expect($agent->detectInProject($tempDir))->toBeFalse();
+    } finally {
+        rmdir($tempDir.DIRECTORY_SEPARATOR.'.agents'.DIRECTORY_SEPARATOR.'skills');
+        rmdir($tempDir.DIRECTORY_SEPARATOR.'.agents');
+        rmdir($tempDir);
+    }
+});
+
+it('detectInProject returns true when .agents/mcp_config.json exists', function (): void {
+    $agent = new Antigravity(new DetectionStrategyFactory(app()));
+    $tempDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'boost_antigravity_'.uniqid();
+    mkdir($tempDir.DIRECTORY_SEPARATOR.'.agents', 0755, true);
+    touch($tempDir.DIRECTORY_SEPARATOR.'.agents'.DIRECTORY_SEPARATOR.'mcp_config.json');
+
+    try {
+        expect($agent->detectInProject($tempDir))->toBeTrue();
+    } finally {
+        unlink($tempDir.DIRECTORY_SEPARATOR.'.agents'.DIRECTORY_SEPARATOR.'mcp_config.json');
+        rmdir($tempDir.DIRECTORY_SEPARATOR.'.agents');
+        rmdir($tempDir);
+    }
 });
 
 it('system detection uses command -v on Darwin', function (): void {


### PR DESCRIPTION
`.agents` isnt an antigravity-specific signal. amp, codex, opencode and zed all install their skills into `.agents/skills`, so boost itself creates that directory, and after that antigravity shows up as a project-installed agent on every rerun.

concrete case: fresh app, `boost:install`, pick codex + skills. that writes `.agents/skills/...`. rerun `boost:install -n` and antigravity is now in the agent selection automatically, project-detected agents become the non-interactive defaults (`InstallCommand::selectAgents`), so boost configures an IDE that was never installed or selected. interactive reruns get it pre-checked in the multiselect too.

same bug class as #831/#832, which dropped `AGENTS.md` from codex/opencode project detection because other agents write that file. the fix here is the same shape: keep `.agents/mcp_config.json` as the antigravity signal (nothing else writes that path) and drop the bare `.agents` path check.

updated the pinning test and added regression tests both ways: `.agents/skills` alone should not detect, `.agents/mcp_config.json` should.
