### PR TITLE
Read the standard mcp_config_path config key for Junie

### DIFF
--- a/src/Install/Agents/Junie.php
+++ b/src/Install/Agents/Junie.php
@@ -59,7 +59,7 @@ class Junie extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSk
 
     public function mcpConfigPath(): string
     {
-        return config('boost.agents.junie.mcp_path', '.junie/mcp/mcp.json');
+        return config('boost.agents.junie.mcp_config_path', '.junie/mcp/mcp.json');
     }
 
     /** {@inheritDoc} */

--- a/tests/Unit/Install/Agents/JunieTest.php
+++ b/tests/Unit/Install/Agents/JunieTest.php
@@ -20,3 +20,17 @@ test('httpMcpServerConfig returns npx mcp-remote config', function (): void {
         'args' => ['-y', 'mcp-remote', 'https://nightwatch.laravel.com/mcp'],
     ]);
 });
+
+it('returns default mcp config path', function (): void {
+    $agent = new Junie($this->strategyFactory);
+
+    expect($agent->mcpConfigPath())->toBe('.junie/mcp/mcp.json');
+});
+
+it('returns configured mcp config path', function (): void {
+    config()->set('boost.agents.junie.mcp_config_path', '../.junie/mcp/mcp.json');
+
+    $agent = new Junie($this->strategyFactory);
+
+    expect($agent->mcpConfigPath())->toBe('../.junie/mcp/mcp.json');
+});


### PR DESCRIPTION
junie is the only agent reading `boost.agents.junie.mcp_path`. the other 11 mcp-capable agents all read `mcp_config_path`, and junie itself already uses the standard names for `guidelines_path` and `skills_path`.

how it happened: #626 gave junie a configurable `mcp_path`, then #729 standardised on `mcp_config_path` across all agents but skipped junie since it already had an override under the old name. `mcp_path` never made it into any docs or config file, that line is its only occurrence in the repo.

the failure is silent and asymmetric: in the monorepo setup #729 was built for, setting `boost.agents.junie.mcp_config_path` works for every agent except junie, which quietly keeps writing to the default `.junie/mcp/mcp.json` and the IDE never sees the server.

switched the key and added the missing `mcpConfigPath` coverage to JunieTest.
