### PR TITLE
Map check constraints through TABLE_CONSTRAINTS so they work on MySQL

### DIFF
--- a/src/Mcp/Tools/DatabaseSchema/MySQLSchemaDriver.php
+++ b/src/Mcp/Tools/DatabaseSchema/MySQLSchemaDriver.php
@@ -56,12 +56,18 @@ class MySQLSchemaDriver extends DatabaseSchemaDriver
     public function getCheckConstraints(string $table): array
     {
         try {
+            // MySQL's CHECK_CONSTRAINTS table has no TABLE_NAME column (MariaDB's does),
+            // so the table mapping must come from TABLE_CONSTRAINTS on both engines.
             return DB::connection($this->connection)->select('
-                SELECT CONSTRAINT_NAME, CHECK_CLAUSE
-                FROM information_schema.CHECK_CONSTRAINTS
-                WHERE CONSTRAINT_SCHEMA = DATABASE()
-                AND TABLE_NAME = ?
-            ', [$table]);
+                SELECT cc.CONSTRAINT_NAME, cc.CHECK_CLAUSE
+                FROM information_schema.CHECK_CONSTRAINTS cc
+                JOIN information_schema.TABLE_CONSTRAINTS tc
+                    ON tc.CONSTRAINT_SCHEMA = cc.CONSTRAINT_SCHEMA
+                    AND tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME
+                WHERE cc.CONSTRAINT_SCHEMA = DATABASE()
+                AND tc.TABLE_NAME = ?
+                AND tc.CONSTRAINT_TYPE = ?
+            ', [$table, 'CHECK']);
         } catch (Exception) {
             return [];
         }

--- a/tests/Unit/Mcp/Tools/DatabaseSchema/MySQLSchemaDriverTest.php
+++ b/tests/Unit/Mcp/Tools/DatabaseSchema/MySQLSchemaDriverTest.php
@@ -26,3 +26,29 @@ test('getTables quotes the table type as a string literal', function (): void {
     expect($sql)->toContain("'BASE TABLE'")
         ->and($sql)->not->toContain('"BASE TABLE"');
 });
+
+test('getCheckConstraints maps the table through TABLE_CONSTRAINTS', function (): void {
+    $sql = null;
+    $bindings = null;
+
+    $connection = Mockery::mock(Connection::class);
+    $connection->shouldReceive('select')
+        ->once()
+        ->andReturnUsing(function (string $query, array $queryBindings) use (&$sql, &$bindings): array {
+            $sql = $query;
+            $bindings = $queryBindings;
+
+            return [];
+        });
+
+    DB::shouldReceive('connection')->with('mysql_test')->andReturn($connection);
+
+    (new MySQLSchemaDriver('mysql_test'))->getCheckConstraints('orders');
+
+    // MySQL's CHECK_CONSTRAINTS has no TABLE_NAME column, so filtering on it
+    // there raises Unknown column and every table reports zero constraints.
+    expect($sql)->toContain('JOIN information_schema.TABLE_CONSTRAINTS')
+        ->and($sql)->toContain('tc.TABLE_NAME = ?')
+        ->and($sql)->not->toMatch('/AND\s+TABLE_NAME\s*=/')
+        ->and($bindings)->toBe(['orders', 'CHECK']);
+});


### PR DESCRIPTION
`database-schema` reports zero check constraints for every table on MySQL, always. the query filters `information_schema.CHECK_CONSTRAINTS` by `TABLE_NAME`, but that column only exists on mariadb. mysql 8.0's `CHECK_CONSTRAINTS` has exactly four columns (`CONSTRAINT_CATALOG`, `CONSTRAINT_SCHEMA`, `CONSTRAINT_NAME`, `CHECK_CLAUSE`), the table mapping lives in `TABLE_CONSTRAINTS`. the `catch (Exception)` in `getCheckConstraints` swallows the error so nothing ever surfaces, and on mariadb the same code works, which is probably why nobody noticed.

reproduced on real servers. mysql 8.0.46, `CREATE TABLE orders (total INT, CONSTRAINT chk_total CHECK (total >= 0))`, then the query from main:

```
ERROR 1054 (42S22): Unknown column 'TABLE_NAME' in 'where clause'
```

so the tool hands the agent `"check_constraints": []` for every table and it happily writes inserts that violate them.

the fix joins `TABLE_CONSTRAINTS` on `(CONSTRAINT_SCHEMA, CONSTRAINT_NAME)` and filters `tc.TABLE_NAME` + `tc.CONSTRAINT_TYPE = 'CHECK'`. same query verified on both engines:

mysql 8.0.46:

```
CONSTRAINT_NAME	CHECK_CLAUSE
chk_total	(`total` >= 0)
```

mariadb 11.8.8:

```
CONSTRAINT_NAME	CHECK_CLAUSE
chk_total	`total` >= 0
```

docs reference: https://dev.mysql.com/doc/refman/8.0/en/information-schema-check-constraints-table.html

separate from #958, which only touched `getTables()`. added a unit test in the same capture-the-sql style pinning the join and bindings.
