### PR TITLE
Detect Livewire navigate requests by header presence

### DIFF
--- a/src/Middleware/InjectBoost.php
+++ b/src/Middleware/InjectBoost.php
@@ -36,7 +36,9 @@ class InjectBoost
 
     protected function shouldInject(Request $request, Response $response): bool
     {
-        if ($request->headers->get('x-livewire-navigate') === '1') {
+        // Livewire 3 sends the header with an empty value; Livewire 4 sends '1'.
+        // Only the header's presence marks a navigate request.
+        if ($request->headers->has('x-livewire-navigate')) {
             return false;
         }
 

--- a/tests/Feature/Middleware/InjectBoostTest.php
+++ b/tests/Feature/Middleware/InjectBoostTest.php
@@ -56,6 +56,19 @@ it('does not inject for special response types', function ($responseType, $respo
     }],
 ]);
 
+it('does not inject into Livewire navigate responses', function (string $headerValue): void {
+    $request = new Request;
+    $request->headers->set('X-Livewire-Navigate', $headerValue);
+
+    $response = new Response('<html><head><title>Test</title></head><body></body></html>', 200, ['Content-Type' => 'text/html']);
+    $result = (new InjectBoost)->handle($request, fn ($req) => $response);
+
+    expect($result->getContent())->not->toContain('browser-logger-active');
+})->with([
+    'Livewire 4 sends 1' => ['1'],
+    'Livewire 3 sends an empty value' => [''],
+]);
+
 it('does not inject when conditions are not met', function ($scenario, $responseFactory, $assertion): void {
     $response = $responseFactory();
     $result = createMiddlewareResponse($response);


### PR DESCRIPTION
the `wire:navigate` guard from #734 checks `x-livewire-navigate === '1'`, but livewire 3 sends the header with an empty value. its right there in the two sources:

livewire 3.x, `js/plugins/navigate/fetch.js`:

```js
headers: { 'X-Livewire-Navigate': '' }
```

livewire 4, `js/request/index.js`:

```js
'X-Livewire-Navigate': '1', // This '1' value means nothing, but it stops Cloudflare from stripping the header...
```

symfony's HeaderBag gives back `''` for a present-but-empty header, `'' === '1'` is false, so on every livewire 3 app the guard is dead code and the logger script gets injected into each navigate response. livewire 4's own comment says the `'1'` means nothing, presence is the signal, so the check is now `$request->headers->has(...)`.

worst case on main is with a CSP nonce: `Vite::cspNonce()` bakes a fresh nonce into the script tag per request, livewire's head merging sees a tag that doesnt match the one in `document.head`, appends it, and the console methods get wrapped a second time, so every log line starts POSTing twice.

there was no test on this guard, added one covering both header values. the livewire 3 case fails on main, the livewire 4 case passes.
