### PR TITLE
Report the database driver as database_engine in application-info

### DIFF
--- a/src/Mcp/Tools/ApplicationInfo.php
+++ b/src/Mcp/Tools/ApplicationInfo.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Mcp\Tools;
 
+use Illuminate\Support\Facades\DB;
 use Laravel\Boost\Support\PackageRegistry;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
@@ -33,7 +34,7 @@ class ApplicationInfo extends Tool
         return Response::json([
             'php_version' => PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION,
             'laravel_version' => app()->version(),
-            'database_engine' => config('database.default'),
+            'database_engine' => DB::connection()->getDriverName(),
             'packages' => $this->project->php()->packages()
                 ->concat($this->project->js()->packages())
                 ->map(fn (Package $package): array => [

--- a/tests/Feature/Mcp/Tools/ApplicationInfoTest.php
+++ b/tests/Feature/Mcp/Tools/ApplicationInfoTest.php
@@ -24,7 +24,7 @@ test('it returns application info with packages', function (): void {
         ->toolJsonContentToMatchArray([
             'php_version' => PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION,
             'laravel_version' => app()->version(),
-            'database_engine' => config('database.default'),
+            'database_engine' => 'sqlite',
             'packages' => [
                 [
                     'roster_name' => 'LARAVEL',
@@ -40,6 +40,23 @@ test('it returns application info with packages', function (): void {
         ]);
 });
 
+test('it reports the driver name when the default connection has a custom name', function (): void {
+    config()->set('database.connections.tenant', config('database.connections.testing'));
+    config()->set('database.default', 'tenant');
+
+    $project = Mockery::mock(ProjectManager::class);
+    mockProjectPackages($project, new PackageCollection([]));
+
+    $tool = new ApplicationInfo($project);
+    $response = $tool->handle(new Request([]));
+
+    expect($response)->isToolResult()
+        ->toolHasNoError()
+        ->toolJsonContent(function (array $data): void {
+            expect($data['database_engine'])->toBe('sqlite');
+        });
+});
+
 test('it returns application info with no packages', function (): void {
     $project = Mockery::mock(ProjectManager::class);
     mockProjectPackages($project, new PackageCollection([]));
@@ -52,7 +69,7 @@ test('it returns application info with no packages', function (): void {
         ->toolJsonContentToMatchArray([
             'php_version' => PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION,
             'laravel_version' => app()->version(),
-            'database_engine' => config('database.default'),
+            'database_engine' => 'sqlite',
             'packages' => [],
         ]);
 });


### PR DESCRIPTION
`application-info` returns `config('database.default')` as `database_engine`, but thats the connection *name*, not the driver. it only looks right on stock installs because the default connection names happen to match the driver names.

any app with `DB_CONNECTION=tenant` (or `landlord`, `primary`, `read`, whatever) where the connection's driver is `pgsql` gets `"database_engine": "tenant"` in the tool the description tells agents to call on every new chat. no usable dialect signal. boost's own `DatabaseSchema` already does this correctly via `getDriverName()` (`DatabaseSchema.php:104`), and the test suite itself runs on a connection literally named `testing`, so on main the tool reports `"database_engine": "testing"` in this repo's own tests.

switched to `DB::connection()->getDriverName()`, pinned the existing expectations to `'sqlite'` instead of mirroring the implementation, and added a regression test with a custom-named default connection that fails on main.
