### PR TITLE
Keep the separating comma out of trailing comments when injecting MCP servers

### DIFF
--- a/src/Install/Mcp/FileWriter.php
+++ b/src/Install/Mcp/FileWriter.php
@@ -150,8 +150,15 @@ class FileWriter
         $commaPosition = $this->findCommaInsertionPoint($content, $openBracePos, $closeBracePos);
 
         if ($commaPosition !== -1) {
-            $newContent = substr_replace($content, ',', $commaPosition, 0);
-            $newContent = substr_replace($newContent, $serversJson, $commaPosition + 1, 0);
+            if (trim(substr($content, $commaPosition, $closeBracePos - $commaPosition)) === '') {
+                $newContent = substr_replace($content, ',', $commaPosition, 0);
+                $newContent = substr_replace($newContent, $serversJson, $commaPosition + 1, 0);
+            } else {
+                // A trailing comment sits between the last entry and the closing
+                // brace: keep it in place by adding the servers after it.
+                $newContent = substr_replace($content, $serversJson, $closeBracePos, 0);
+                $newContent = substr_replace($newContent, ',', $commaPosition, 0);
+            }
         } else {
             $newContent = substr_replace($content, $serversJson, $closeBracePos, 0);
         }
@@ -289,21 +296,22 @@ class FileWriter
 
     protected function findCommaInsertionPoint(string $content, int $openBracePos, int $closeBracePos): int
     {
+        // Blank out comments (string-aware, offsets preserved) so the backwards
+        // scan cannot place the comma inside a trailing comment.
+        $masked = preg_replace_callback(
+            '/"(?:\\\\.|[^"\\\\])*"|(\/\/[^\r\n]*)|(\/\*[\s\S]*?\*\/)/',
+            fn (array $match): string => ($match[1] ?? '') !== '' || ($match[2] ?? '') !== ''
+                ? str_repeat(' ', strlen($match[0]))
+                : $match[0],
+            $content
+        ) ?? $content;
+
         // Work backwards from closing brace to find last meaningful character
         for ($i = $closeBracePos - 1; $i > $openBracePos; $i--) {
-            $char = $content[$i];
+            $char = $masked[$i];
 
             // Skip whitespace and newlines
             if (in_array($char, [' ', "\t", "\n", "\r"], true)) {
-                continue;
-            }
-
-            // Skip comments (simple approach - if we hit //, skip to start of line)
-            if ($i > 0 && $content[$i - 1] === '/' && $char === '/') {
-                // Find start of this line
-                $lineStart = strrpos($content, "\n", $i - strlen($content)) ?: 0;
-                $i = $lineStart;
-
                 continue;
             }
 

--- a/tests/Unit/Install/Mcp/FileWriterTest.php
+++ b/tests/Unit/Install/Mcp/FileWriterTest.php
@@ -451,6 +451,47 @@ test('preserves trailing commas when injecting into existing servers', function 
         );
 });
 
+test('adds the comma outside a trailing comment in the servers object', function (): void {
+    $writtenContent = '';
+
+    $contentWithTrailingComment = <<<'JSON5'
+    {
+      "mcpServers": {
+        "context7": {
+          "command": "npx"
+        } // docs lookup
+      }
+    }
+    JSON5;
+
+    mockFileOperations(
+        fileExists: true,
+        content: $contentWithTrailingComment,
+        capturedContent: $writtenContent
+    );
+
+    File::shouldReceive('size')->andReturn(200);
+
+    $result = (new FileWriter('/path/to/mcp.json'))
+        ->addServerConfig('boost', [
+            'command' => 'php',
+            'args' => ['artisan', 'boost:mcp'],
+        ])
+        ->save();
+
+    // The separating comma must not be swallowed by the comment, or every
+    // server in the file stops parsing.
+    $withoutComments = preg_replace('/\/\/[^\n]*/', '', $writtenContent);
+
+    expect($result)->toBeTrue()
+        ->and(json_decode((string) $withoutComments, true))->not->toBeNull()
+        ->and($writtenContent)->toContain(
+            '"boost"', // New server added
+            '"context7"', // Existing server preserved
+            '// docs lookup' // Comment preserved
+        );
+});
+
 test('updates JSON5 file with only single-quoted strings', function (): void {
     $writtenContent = '';
     $singleQuotedJson5 = <<<'JSON5'


### PR DESCRIPTION
if the last thing inside `mcpServers` before the closing brace is a `//` comment, `boost:install` corrupts the whole config file. `findCommaInsertionPoint` walks backwards from the closing brace, but its comment check only fires when it lands exactly on a `/`, and walking backwards through a comment you land on the comment's last character, so the comma gets inserted mid-comment.

repro through the real writer, input `.cursor/mcp.json`:

```jsonc
{
  "mcpServers": {
    "context7": {
      "command": "npx"
    } // docs lookup
  }
}
```

what main writes:

```jsonc
    } // docs lookup,
    "laravel-boost": {
```

the comma is commented out, the file no longer parses, and every mcp server the user had stops loading. rerunning `boost:install` doesnt repair it either, `serverExistsInContent` sees `"laravel-boost":` in the broken file and save() returns true without touching it.

`needsCommaBeforeClosingBrace` handles the same case correctly (it strips comments before checking), so the two helpers just disagreed about where a comment ends.

fix masks comments before the backwards scan, reusing the string-aware pattern `hasUnquotedComments` already uses so a `//` inside a `"url": "https://..."` value doesnt get treated as one. when a trailing comment sits between the last entry and the brace, the new server block now goes after the comment line, so the output is:

```jsonc
    }, // docs lookup

    "laravel-boost": {
```

comment-free files produce byte-identical output to main. added a regression test that fails on main with the exact repro above, all 68 existing FileWriter tests still pass.
