### PR TITLE
Collapse Blade escape sequences inside boostsnippet bodies

### DIFF
--- a/src/Concerns/RendersBladeGuidelines.php
+++ b/src/Concerns/RendersBladeGuidelines.php
@@ -63,6 +63,12 @@ trait RendersBladeGuidelines
             $lang = empty($matches['lang']) ? 'html' : $matches['lang'];
             $snippetContent = trim($matches['content']);
 
+            // Snippet bodies never reach Blade, so collapse Blade's escape
+            // sequences here the way Blade would: @@directive -> @directive,
+            // @{{ -> {{. Otherwise the escapes leak into the rendered output.
+            $snippetContent = preg_replace('/(?<!\w)@@(?=\w)/', '@', $snippetContent) ?? $snippetContent;
+            $snippetContent = str_replace('@{{', '{{', $snippetContent);
+
             $placeholder = '___BOOST_SNIPPET_'.count($this->storedSnippets).'___';
 
             $this->storedSnippets[$placeholder] = '<!-- '.$name.' -->'."\n".'```'.$lang."\n".$snippetContent."\n".'```'."\n\n";

--- a/tests/Unit/Concerns/RendersBladeGuidelinesTest.php
+++ b/tests/Unit/Concerns/RendersBladeGuidelinesTest.php
@@ -47,6 +47,27 @@ test('boostsnippet directive extracts name and content into fenced code block', 
         ->toContain('```');
 });
 
+test('boostsnippet collapses Blade escape sequences in the stored body', function (): void {
+    $content = <<<'BLADE'
+    @boostsnippet('Volt Example', 'php')
+    @@volt
+    <h1>Count: @{{ $count }}</h1>
+    @@endvolt
+    @endboostsnippet
+    BLADE;
+
+    $this->renderer->processSnippets($content);
+
+    $snippet = $this->renderer->getStoredSnippets()['___BOOST_SNIPPET_0___'];
+
+    expect($snippet)
+        ->toContain('@volt')
+        ->toContain('@endvolt')
+        ->toContain('Count: {{ $count }}')
+        ->not->toContain('@@volt')
+        ->not->toContain('@{{');
+});
+
 test('boostsnippet supports double quotes for name parameter', function (): void {
     $content = '@boostsnippet("Double Quoted")code@endboostsnippet';
 


### PR DESCRIPTION
`@boostsnippet` bodies get lifted into placeholders before Blade runs and spliced back after, so Blade never sees them. that means docs-style escapes inside a snippet never collapse, and the shipped output contains raw `@@volt` and `@{{ $count }}`.

whats actually installed today in `.claude/skills/volt-development/SKILL.md` (rendered from `.ai/volt/skill/volt-development/SKILL.blade.php`):

```
@@volt
...
    <h1>Count: @{{ $count }} (Double: @{{ $this->double }})</h1>
...
@@endvolt
```

thats invalid volt syntax being taught to the agent, and the same file's prose says `@volt` with a single @, so it contradicts itself. also hits `livewire-development/SKILL.md` (`@{{ $count }}`) and the `upgrade-livewire-v4` mcp prompt (`@@persist`, `@@island(...)`, `@@foreach`, a bunch of `@{{ ... }}`).

fix collapses the two escape forms when storing the snippet, the same way blade would: `@@directive` -> `@directive` (only when directive-shaped, `x@@y` stays put) and `@{{` -> `{{`. every `@@`/`@{{` in the repo's `.ai/` tree and prompts sits inside a snippet and is meant to collapse, i checked them all.

after the fix the same section renders:

```
@volt
...
    <h1>Count: {{ $count }} (Double: {{ $this->double }})</h1>
...
@endvolt
```

the suite already treats leaked `@{{` as wrong for the `@verbatim` path (`SkillWriterTest.php:368`), the snippet path just wasnt covered. added a regression test that fails on main.
