### PR TITLE
Skip versioned guideline discovery for packages without a major version

### DIFF
--- a/src/Install/GuidelineComposer.php
+++ b/src/Install/GuidelineComposer.php
@@ -218,7 +218,11 @@ class GuidelineComposer
                     $guidelineDir.'/core' => $this->resolveGuideline($vendorCorePath, $guidelineDir.'/core'),
                 ]);
 
-                $packageGuidelines = $this->guidelinesDir($guidelineDir.'/'.$package->major());
+                // A versionless package (dev-main, "*") has no major version, and
+                // appending null would walk the package's whole guideline root.
+                $packageGuidelines = $package->major() === null
+                    ? []
+                    : $this->guidelinesDir($guidelineDir.'/'.$package->major());
 
                 foreach ($packageGuidelines as $guideline) {
                     $suffix = $guideline['name'] === 'core' ? '' : '/'.$guideline['name'];

--- a/tests/Feature/Install/GuidelineComposerTest.php
+++ b/tests/Feature/Install/GuidelineComposerTest.php
@@ -28,6 +28,21 @@ beforeEach(function (): void {
     $this->composer = new GuidelineComposer($this->project, $this->herd);
 });
 
+test('versionless packages do not emit a duplicate versioned guideline', function (): void {
+    config(['boost.rules.enabled' => false]);
+
+    $packages = new PackageCollection([
+        rosterPackage('laravel/framework', ''),
+    ]);
+
+    mockProjectPackages($this->project, $packages);
+
+    $keys = $this->composer->guidelines()->keys()->all();
+
+    expect($keys)->toContain('laravel/core')
+        ->not->toContain('laravel/v');
+});
+
 test('includes Inertia React conditional guidelines based on version', function (string $version): void {
     config(['boost.rules.enabled' => false]);
 


### PR DESCRIPTION
`Package::major()` returns null when the version string has no digits (`dev-main`, `dev-master`, `*`, `latest`), and `getPackageGuidelines` interpolates it straight into the path, so `laravel/12` becomes `laravel/` and `guidelinesDir` walks the package's entire guideline root recursively.

concrete result with `"laravel/framework": "dev-master"` in the lockfile: the walk picks up `11/core`, `12/core` and the root `core`, they all collapse onto the key `laravel/v`, and the survivor is the same core file already emitted as `laravel/core`. the composed guidelines contain the laravel core section twice, once as `=== laravel/core rules ===` and once as `=== laravel/v rules ===`, and the install summary shows a meaningless `laravel/v` row. reproduced through `GuidelineComposer::guidelines()`, keys on main are `[..., laravel/core, laravel/v]`.

`SkillComposer` already guards this exact case (`$package->major() === null ? null : ...` on line 96), `GuidelineComposer` just doesnt. same guard added, regression test fails on main.
