### PR TITLE
Register the browser-logs route only when the watcher is enabled

### DIFF
--- a/src/BoostServiceProvider.php
+++ b/src/BoostServiceProvider.php
@@ -61,9 +61,9 @@ class BoostServiceProvider extends ServiceProvider
 
         $this->registerPublishing();
         $this->registerCommands();
-        $this->registerRoutes();
 
         if (config('boost.browser_logs_watcher', true)) {
+            $this->registerRoutes();
             $this->registerBrowserLogger();
             $this->callAfterResolving('blade.compiler', $this->registerBladeDirectives(...));
             $this->hookIntoResponses($router);

--- a/tests/Feature/BrowserLogsRouteRegistrationTest.php
+++ b/tests/Feature/BrowserLogsRouteRegistrationTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class BrowserLogsRouteRegistrationTest extends TestCase
+{
+    protected function defineEnvironment($app)
+    {
+        parent::defineEnvironment($app);
+
+        $app['config']->set('boost.browser_logs_watcher', false);
+    }
+
+    public function test_browser_logs_route_is_not_registered_when_the_watcher_is_disabled(): void
+    {
+        // With the watcher off the `browser` log channel is never defined, so a
+        // registered route would 500 on Log::channel('browser') instead of 404ing.
+        $this->postJson('/_boost/browser-logs', ['logs' => []])->assertNotFound();
+    }
+}


### PR DESCRIPTION
`registerRoutes()` runs unconditionally but `registerBrowserLogger()` (which defines the `browser` log channel) is behind `boost.browser_logs_watcher`. so with `BOOST_BROWSER_LOGS_WATCHER=false` the `POST /_boost/browser-logs` endpoint still exists, and its handler resolves `Log::channel('browser')` on a channel that was never defined.

that doesnt 500 like youd expect. LogManager catches the `Log [browser] is not defined.` exception and hands back the emergency logger, so the request returns 200 and every posted payload gets written into `storage/logs/laravel.log`, plus an `Unable to create configured logger. Using emergency logger.` error per request. verified with a feature test on main: post to the endpoint with the watcher off, response is 200 and the exception above is raised behind the scenes.

net effect, the off switch doesnt turn the endpoint off. anything still posting there (a tab holding the injected script from before the flag flip, or anyone who knows the url) pollutes laravel.log through a flag that says the feature is disabled.

moved `registerRoutes()` into the same conditional, so the endpoint 404s when the watcher is off. added a regression test that fails on main.
