### PR TITLE
Leave fenced code blocks alone when normalizing blank lines in guideline files

### DIFF
--- a/src/Install/GuidelineWriter.php
+++ b/src/Install/GuidelineWriter.php
@@ -76,8 +76,21 @@ class GuidelineWriter
                 $newContent = $frontMatter.$existingContent.$separatingNewlines.$replacement;
             }
 
-            // Normalize multiple blank lines to single blank lines
-            $newContent = preg_replace("/\n{3,}/", "\n\n", (string) $newContent);
+            // Normalize multiple blank lines to single blank lines, leaving
+            // fenced code blocks alone since blank lines are significant there.
+            $fences = [];
+
+            $masked = preg_replace_callback('/(?<fence>`{3,}|~{3,}).*?\k<fence>/s', function (array $matches) use (&$fences): string {
+                $placeholder = '___GUIDELINE_FENCE_'.count($fences).'___';
+                $fences[$placeholder] = $matches[0];
+
+                return $placeholder;
+            }, (string) $newContent);
+
+            if ($masked !== null) {
+                $masked = preg_replace("/\n{3,}/", "\n\n", $masked);
+                $newContent = str_replace(array_keys($fences), array_values($fences), (string) $masked);
+            }
 
             // Ensure file content ends with a newline
             if (! str_ends_with((string) $newContent, "\n")) {

--- a/tests/Unit/Install/GuidelineWriterTest.php
+++ b/tests/Unit/Install/GuidelineWriterTest.php
@@ -37,6 +37,42 @@ test('it creates directory when it does not exist', function (): void {
     rmdir($tempDir);
 });
 
+test('it leaves blank lines inside fenced code blocks alone when normalizing', function (): void {
+    $tempFile = tempnam(sys_get_temp_dir(), 'boost_test_');
+
+    $userContent = <<<'MD'
+    # My Project
+
+    ```python
+    def first():
+        pass
+
+
+    def second():
+        pass
+    ```
+    MD;
+
+    file_put_contents($tempFile, $userContent);
+
+    $agent = Mockery::mock(SupportsGuidelines::class);
+    $agent->shouldReceive('guidelinesPath')->andReturn($tempFile);
+    $agent->shouldReceive('frontmatter')->andReturn(false);
+    $agent->shouldReceive('transformGuidelines')->andReturnUsing(fn ($markdown) => $markdown);
+
+    $writer = new GuidelineWriter($agent);
+    $writer->write('boost guidelines');
+
+    $written = file_get_contents($tempFile);
+
+    // PEP 8 mandates two blank lines between top-level functions; the
+    // normalization pass must not rewrite the user's code sample.
+    expect($written)->toContain("def first():\n    pass\n\n\ndef second():")
+        ->toContain('boost guidelines');
+
+    unlink($tempFile);
+});
+
 test('it throws exception when directory creation fails', function (): void {
     // Use a path that cannot be created (root directory with insufficient permissions)
     $filePath = '/root/boost_test/test.md';


### PR DESCRIPTION
`GuidelineWriter::write` runs `preg_replace("/\n{3,}/", "\n\n")` over the whole target file, not just the `<laravel-boost-guidelines>` block, and its not fence-aware. so if your `AGENTS.md`/`CLAUDE.md` has a fenced code sample with a deliberate double blank line (pep 8 mandates two blank lines between top level functions, for example), every `boost:install` or `boost:update` silently rewrites your own code sample and leaves a spurious diff in your repo.

same bug class as #961, which fixed the fence-unaware heading spacing in `MarkdownFormatter`, and the fix uses the same fence masking mechanism: mask ``` / ~~~ blocks with placeholders, collapse blank lines, restore. normalization outside fences behaves exactly as before.

regression test writes guidelines into a file whose existing content has a python fence with two blank lines, and asserts the fence survives byte for byte. fails on main.
