### PR TITLE
Keep the separating comma out of trailing comments when injecting MCP servers

### DIFF
--- a/src/Install/Mcp/FileWriter.php
+++ b/src/Install/Mcp/FileWriter.php
@@ -297,9 +297,10 @@ class FileWriter
     protected function findCommaInsertionPoint(string $content, int $openBracePos, int $closeBracePos): int
     {
         // Blank out comments (string-aware, offsets preserved) so the backwards
-        // scan cannot place the comma inside a trailing comment.
+        // scan cannot place the comma inside a trailing comment. Both quote
+        // styles are skipped, or a // inside a JSON5 string reads as a comment.
         $masked = preg_replace_callback(
-            '/"(?:\\\\.|[^"\\\\])*"|(\/\/[^\r\n]*)|(\/\*[\s\S]*?\*\/)/',
+            '/"(?:\\\\.|[^"\\\\])*"|\'(?:\\\\.|[^\'\\\\])*\'|(\/\/[^\r\n]*)|(\/\*[\s\S]*?\*\/)/',
             fn (array $match): string => ($match[1] ?? '') !== '' || ($match[2] ?? '') !== ''
                 ? str_repeat(' ', strlen($match[0]))
                 : $match[0],

--- a/src/Install/Mcp/FileWriter.php
+++ b/src/Install/Mcp/FileWriter.php
@@ -150,8 +150,15 @@ class FileWriter
         $commaPosition = $this->findCommaInsertionPoint($content, $openBracePos, $closeBracePos);
 
         if ($commaPosition !== -1) {
-            $newContent = substr_replace($content, ',', $commaPosition, 0);
-            $newContent = substr_replace($newContent, $serversJson, $commaPosition + 1, 0);
+            if (trim(substr($content, $commaPosition, $closeBracePos - $commaPosition)) === '') {
+                $newContent = substr_replace($content, ',', $commaPosition, 0);
+                $newContent = substr_replace($newContent, $serversJson, $commaPosition + 1, 0);
+            } else {
+                // A trailing comment sits between the last entry and the closing
+                // brace: keep it in place by adding the servers after it.
+                $newContent = substr_replace($content, $serversJson, $closeBracePos, 0);
+                $newContent = substr_replace($newContent, ',', $commaPosition, 0);
+            }
         } else {
             $newContent = substr_replace($content, $serversJson, $closeBracePos, 0);
         }
@@ -289,21 +296,22 @@ class FileWriter
 
     protected function findCommaInsertionPoint(string $content, int $openBracePos, int $closeBracePos): int
     {
+        // Blank out comments (string-aware, offsets preserved) so the backwards
+        // scan cannot place the comma inside a trailing comment.
+        $masked = preg_replace_callback(
+            '/"(?:\\\\.|[^"\\\\])*"|(\/\/[^\r\n]*)|(\/\*[\s\S]*?\*\/)/',
+            fn (array $match): string => ($match[1] ?? '') !== '' || ($match[2] ?? '') !== ''
+                ? str_repeat(' ', strlen($match[0]))
+                : $match[0],
+            $content
+        ) ?? $content;
+
         // Work backwards from closing brace to find last meaningful character
         for ($i = $closeBracePos - 1; $i > $openBracePos; $i--) {
-            $char = $content[$i];
+            $char = $masked[$i];
 
             // Skip whitespace and newlines
             if (in_array($char, [' ', "\t", "\n", "\r"], true)) {
-                continue;
-            }
-
-            // Skip comments (simple approach - if we hit //, skip to start of line)
-            if ($i > 0 && $content[$i - 1] === '/' && $char === '/') {
-                // Find start of this line
-                $lineStart = strrpos($content, "\n", $i - strlen($content)) ?: 0;
-                $i = $lineStart;
-
                 continue;
             }
 

--- a/src/Install/Mcp/FileWriter.php
+++ b/src/Install/Mcp/FileWriter.php
@@ -150,12 +150,11 @@ class FileWriter
         $commaPosition = $this->findCommaInsertionPoint($content, $openBracePos, $closeBracePos);
 
         if ($commaPosition !== -1) {
+            // Anything non-blank before the brace is a trailing comment: comma goes ahead of it, servers after it.
             if (trim(substr($content, $commaPosition, $closeBracePos - $commaPosition)) === '') {
                 $newContent = substr_replace($content, ',', $commaPosition, 0);
                 $newContent = substr_replace($newContent, $serversJson, $commaPosition + 1, 0);
             } else {
-                // A trailing comment sits between the last entry and the closing
-                // brace: keep it in place by adding the servers after it.
                 $newContent = substr_replace($content, $serversJson, $closeBracePos, 0);
                 $newContent = substr_replace($newContent, ',', $commaPosition, 0);
             }
@@ -296,9 +295,7 @@ class FileWriter
 
     protected function findCommaInsertionPoint(string $content, int $openBracePos, int $closeBracePos): int
     {
-        // Blank out comments (string-aware, offsets preserved) so the backwards
-        // scan cannot place the comma inside a trailing comment. Both quote
-        // styles are skipped, or a // inside a JSON5 string reads as a comment.
+        // Strings are matched only to skip them; comments become equal-length spaces so offsets still line up.
         $masked = preg_replace_callback(
             '/"(?:\\\\.|[^"\\\\])*"|\'(?:\\\\.|[^\'\\\\])*\'|(\/\/[^\r\n]*)|(\/\*[\s\S]*?\*\/)/',
             fn (array $match): string => ($match[1] ?? '') !== '' || ($match[2] ?? '') !== ''

--- a/tests/Unit/Install/Mcp/FileWriterTest.php
+++ b/tests/Unit/Install/Mcp/FileWriterTest.php
@@ -479,8 +479,6 @@ test('adds the comma outside a trailing comment in the servers object', function
         ])
         ->save();
 
-    // The separating comma must not be swallowed by the comment, or every
-    // server in the file stops parsing.
     $withoutComments = preg_replace('/\/\/[^\n]*/', '', $writtenContent);
 
     expect($result)->toBeTrue()

--- a/tests/Unit/Install/Mcp/FileWriterTest.php
+++ b/tests/Unit/Install/Mcp/FileWriterTest.php
@@ -492,6 +492,39 @@ test('adds the comma outside a trailing comment in the servers object', function
         );
 });
 
+test('does not read a // inside a single-quoted string as a comment', function (): void {
+    $writtenContent = '';
+
+    $singleQuotedUrl = <<<'JSON5'
+    {
+      'mcpServers': {
+        'remote': { 'url': 'https://example.test/sse' }
+      }
+    }
+    JSON5;
+
+    mockFileOperations(
+        fileExists: true,
+        content: $singleQuotedUrl,
+        capturedContent: $writtenContent
+    );
+
+    File::shouldReceive('size')->andReturn(200);
+
+    $result = (new FileWriter('/path/to/mcp.json'))
+        ->addServerConfig('boost', [
+            'command' => 'php',
+            'args' => ['artisan', 'boost:mcp'],
+        ])
+        ->save();
+
+    expect($result)->toBeTrue()
+        ->and($writtenContent)->toContain(
+            "'url': 'https://example.test/sse'", // URL survives untouched
+            '"boost"' // New server added
+        );
+});
+
 test('updates JSON5 file with only single-quoted strings', function (): void {
     $writtenContent = '';
     $singleQuotedJson5 = <<<'JSON5'

--- a/tests/Unit/Install/Mcp/FileWriterTest.php
+++ b/tests/Unit/Install/Mcp/FileWriterTest.php
@@ -451,6 +451,47 @@ test('preserves trailing commas when injecting into existing servers', function 
         );
 });
 
+test('adds the comma outside a trailing comment in the servers object', function (): void {
+    $writtenContent = '';
+
+    $contentWithTrailingComment = <<<'JSON5'
+    {
+      "mcpServers": {
+        "context7": {
+          "command": "npx"
+        } // docs lookup
+      }
+    }
+    JSON5;
+
+    mockFileOperations(
+        fileExists: true,
+        content: $contentWithTrailingComment,
+        capturedContent: $writtenContent
+    );
+
+    File::shouldReceive('size')->andReturn(200);
+
+    $result = (new FileWriter('/path/to/mcp.json'))
+        ->addServerConfig('boost', [
+            'command' => 'php',
+            'args' => ['artisan', 'boost:mcp'],
+        ])
+        ->save();
+
+    // The separating comma must not be swallowed by the comment, or every
+    // server in the file stops parsing.
+    $withoutComments = preg_replace('/\/\/[^\n]*/', '', $writtenContent);
+
+    expect($result)->toBeTrue()
+        ->and(json_decode((string) $withoutComments, true))->not->toBeNull()
+        ->and($writtenContent)->toContain(
+            '"boost"', // New server added
+            '"context7"', // Existing server preserved
+            '// docs lookup' // Comment preserved
+        );
+});
+
 test('updates JSON5 file with only single-quoted strings', function (): void {
     $writtenContent = '';
     $singleQuotedJson5 = <<<'JSON5'


### PR DESCRIPTION
if the last thing inside `mcpServers` before the closing brace is a `//` comment, `boost:install` writes the separating comma into the comment and corrupts the whole file.

repro on a fresh laravel app, `.cursor/mcp.json` has:

    "context7": {
      "command": "npx"
    } // docs lookup

after `php artisan boost:install --mcp -n`:

    } // docs lookup,
    "laravel-boost": {

the comma is commented out, the file no longer parses, every mcp server the user had stops loading, and a rerun doesnt repair it since the broken file already contains `"laravel-boost":`.

fix masks comments before finding the comma position (string-aware, so a `//` inside a `"url"` value doesnt count) and puts the new server block after the comment line. comment-free files produce byte-identical output to main. regression test fails on main, all 68 existing FileWriter tests still pass. previously #971, ci was green there.