### PR TITLE
Join TABLE_CONSTRAINTS for check constraints since MySQL's CHECK_CONSTRAINTS table has no TABLE_NAME column

### DIFF
--- a/src/Mcp/Tools/DatabaseSchema/MySQLSchemaDriver.php
+++ b/src/Mcp/Tools/DatabaseSchema/MySQLSchemaDriver.php
@@ -56,12 +56,17 @@ class MySQLSchemaDriver extends DatabaseSchemaDriver
     public function getCheckConstraints(string $table): array
     {
         try {
+            // MySQL's CHECK_CONSTRAINTS has no TABLE_NAME column, so the table filter goes through TABLE_CONSTRAINTS.
             return DB::connection($this->connection)->select('
-                SELECT CONSTRAINT_NAME, CHECK_CLAUSE
-                FROM information_schema.CHECK_CONSTRAINTS
-                WHERE CONSTRAINT_SCHEMA = DATABASE()
-                AND TABLE_NAME = ?
-            ', [$table]);
+                SELECT cc.CONSTRAINT_NAME, cc.CHECK_CLAUSE
+                FROM information_schema.CHECK_CONSTRAINTS cc
+                JOIN information_schema.TABLE_CONSTRAINTS tc
+                    ON tc.CONSTRAINT_SCHEMA = cc.CONSTRAINT_SCHEMA
+                    AND tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME
+                WHERE cc.CONSTRAINT_SCHEMA = DATABASE()
+                AND tc.TABLE_NAME = ?
+                AND tc.CONSTRAINT_TYPE = ?
+            ', [$table, 'CHECK']);
         } catch (Exception) {
             return [];
         }

--- a/src/Mcp/Tools/DatabaseSchema/MySQLSchemaDriver.php
+++ b/src/Mcp/Tools/DatabaseSchema/MySQLSchemaDriver.php
@@ -55,21 +55,28 @@ class MySQLSchemaDriver extends DatabaseSchemaDriver
 
     public function getCheckConstraints(string $table): array
     {
-        try {
-            // MySQL's CHECK_CONSTRAINTS has no TABLE_NAME column, so the table filter goes through TABLE_CONSTRAINTS.
-            return DB::connection($this->connection)->select('
-                SELECT cc.CONSTRAINT_NAME, cc.CHECK_CLAUSE
-                FROM information_schema.CHECK_CONSTRAINTS cc
-                JOIN information_schema.TABLE_CONSTRAINTS tc
-                    ON tc.CONSTRAINT_SCHEMA = cc.CONSTRAINT_SCHEMA
-                    AND tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME
-                WHERE cc.CONSTRAINT_SCHEMA = DATABASE()
-                AND tc.TABLE_NAME = ?
-                AND tc.CONSTRAINT_TYPE = ?
-            ', [$table, 'CHECK']);
-        } catch (Exception) {
-            return [];
+        $mariaDbConstraints = rescue(fn (): array => DB::connection($this->connection)->select('
+            SELECT CONSTRAINT_NAME, CHECK_CLAUSE
+            FROM information_schema.CHECK_CONSTRAINTS
+            WHERE CONSTRAINT_SCHEMA = DATABASE()
+            AND TABLE_NAME = ?
+        ', [$table]), null, report: false);
+
+        if ($mariaDbConstraints !== null) {
+            return $mariaDbConstraints;
         }
+
+        // MySQL's CHECK_CONSTRAINTS has no TABLE_NAME column, so the table filter goes through TABLE_CONSTRAINTS.
+        return rescue(fn (): array => DB::connection($this->connection)->select("
+            SELECT cc.CONSTRAINT_NAME, cc.CHECK_CLAUSE
+            FROM information_schema.CHECK_CONSTRAINTS cc
+            JOIN information_schema.TABLE_CONSTRAINTS tc
+                ON tc.CONSTRAINT_SCHEMA = cc.CONSTRAINT_SCHEMA
+                AND tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME
+            WHERE cc.CONSTRAINT_SCHEMA = DATABASE()
+            AND tc.TABLE_NAME = ?
+            AND tc.CONSTRAINT_TYPE = 'CHECK'
+        ", [$table]), [], report: false);
     }
 
     public function getSequences(): array

--- a/tests/Unit/Mcp/Tools/DatabaseSchema/MySQLSchemaDriverTest.php
+++ b/tests/Unit/Mcp/Tools/DatabaseSchema/MySQLSchemaDriverTest.php
@@ -26,3 +26,27 @@ test('getTables quotes the table type as a string literal', function (): void {
     expect($sql)->toContain("'BASE TABLE'")
         ->and($sql)->not->toContain('"BASE TABLE"');
 });
+
+test('getCheckConstraints maps the table through TABLE_CONSTRAINTS', function (): void {
+    $sql = null;
+    $bindings = null;
+
+    $connection = Mockery::mock(Connection::class);
+    $connection->shouldReceive('select')
+        ->once()
+        ->andReturnUsing(function (string $query, array $queryBindings) use (&$sql, &$bindings): array {
+            $sql = $query;
+            $bindings = $queryBindings;
+
+            return [];
+        });
+
+    DB::shouldReceive('connection')->with('mysql_test')->andReturn($connection);
+
+    (new MySQLSchemaDriver('mysql_test'))->getCheckConstraints('orders');
+
+    expect($sql)->toContain('JOIN information_schema.TABLE_CONSTRAINTS')
+        ->and($sql)->toContain('tc.TABLE_NAME = ?')
+        ->and($sql)->not->toMatch('/AND\s+TABLE_NAME\s*=/')
+        ->and($bindings)->toBe(['orders', 'CHECK']);
+});

--- a/tests/Unit/Mcp/Tools/DatabaseSchema/MySQLSchemaDriverTest.php
+++ b/tests/Unit/Mcp/Tools/DatabaseSchema/MySQLSchemaDriverTest.php
@@ -27,16 +27,41 @@ test('getTables quotes the table type as a string literal', function (): void {
         ->and($sql)->not->toContain('"BASE TABLE"');
 });
 
-test('getCheckConstraints maps the table through TABLE_CONSTRAINTS', function (): void {
-    $sql = null;
-    $bindings = null;
+test('getCheckConstraints filters on TABLE_NAME directly when the column exists', function (): void {
+    $calls = [];
 
     $connection = Mockery::mock(Connection::class);
     $connection->shouldReceive('select')
         ->once()
-        ->andReturnUsing(function (string $query, array $queryBindings) use (&$sql, &$bindings): array {
-            $sql = $query;
-            $bindings = $queryBindings;
+        ->andReturnUsing(function (string $query, array $bindings) use (&$calls): array {
+            $calls[] = [$query, $bindings];
+
+            return [(object) ['CONSTRAINT_NAME' => 'orders_qty_positive']];
+        });
+
+    DB::shouldReceive('connection')->with('mysql_test')->andReturn($connection);
+
+    $constraints = (new MySQLSchemaDriver('mysql_test'))->getCheckConstraints('orders');
+
+    expect($constraints)->toHaveCount(1)
+        ->and($calls)->toHaveCount(1)
+        ->and($calls[0][0])->toMatch('/AND\s+TABLE_NAME\s*=\s*\?/')
+        ->and($calls[0][0])->not->toContain('JOIN')
+        ->and($calls[0][1])->toBe(['orders']);
+});
+
+test('getCheckConstraints maps the table through TABLE_CONSTRAINTS when TABLE_NAME is missing', function (): void {
+    $calls = [];
+
+    $connection = Mockery::mock(Connection::class);
+    $connection->shouldReceive('select')
+        ->twice()
+        ->andReturnUsing(function (string $query, array $bindings) use (&$calls): array {
+            $calls[] = [$query, $bindings];
+
+            if (count($calls) === 1) {
+                throw new Exception("Unknown column 'TABLE_NAME' in 'where clause'");
+            }
 
             return [];
         });
@@ -45,8 +70,9 @@ test('getCheckConstraints maps the table through TABLE_CONSTRAINTS', function ()
 
     (new MySQLSchemaDriver('mysql_test'))->getCheckConstraints('orders');
 
-    expect($sql)->toContain('JOIN information_schema.TABLE_CONSTRAINTS')
-        ->and($sql)->toContain('tc.TABLE_NAME = ?')
-        ->and($sql)->not->toMatch('/AND\s+TABLE_NAME\s*=/')
-        ->and($bindings)->toBe(['orders', 'CHECK']);
+    expect($calls)->toHaveCount(2)
+        ->and($calls[1][0])->toContain('JOIN information_schema.TABLE_CONSTRAINTS')
+        ->and($calls[1][0])->toContain('tc.TABLE_NAME = ?')
+        ->and($calls[1][0])->toContain("'CHECK'")
+        ->and($calls[1][1])->toBe(['orders']);
 });


### PR DESCRIPTION
the database-schema tool returns empty check_constraints for every table on MySQL. MySQL's information_schema.CHECK_CONSTRAINTS has no TABLE_NAME column (MariaDB's does), so `AND TABLE_NAME = ?` throws Unknown column, the catch swallows it, and every table reports zero constraints.

fix joins information_schema.TABLE_CONSTRAINTS to map each constraint to its table, filtered to CONSTRAINT_TYPE = CHECK. works on both engines.

checked on real servers: mysql:8.0.46 goes from [] to the actual constraints for that table (and only that table), mariadb:11 returns the same rows before and after.

re-file of #968, reviewed and re-tested individually.
