### PR TITLE
Stop detecting Antigravity from the shared .agents directory that Boost itself creates for other agents' skills

### DIFF
--- a/src/Install/Agents/Antigravity.php
+++ b/src/Install/Agents/Antigravity.php
@@ -35,8 +35,8 @@ class Antigravity extends Agent implements SupportsGuidelines, SupportsMcp, Supp
 
     public function projectDetectionConfig(): array
     {
-        // The bare .agents directory proves nothing: Boost creates it when installing skills for other agents.
         return [
+            'paths' => ['.gemini'],
             'files' => ['.agents/mcp_config.json'],
         ];
     }

--- a/src/Install/Agents/Antigravity.php
+++ b/src/Install/Agents/Antigravity.php
@@ -35,8 +35,8 @@ class Antigravity extends Agent implements SupportsGuidelines, SupportsMcp, Supp
 
     public function projectDetectionConfig(): array
     {
+        // The bare .agents directory proves nothing: Boost creates it when installing skills for other agents.
         return [
-            'paths' => ['.agents'],
             'files' => ['.agents/mcp_config.json'],
         ];
     }

--- a/tests/Unit/Install/Agents/AntigravityTest.php
+++ b/tests/Unit/Install/Agents/AntigravityTest.php
@@ -67,13 +67,41 @@ it('returns configured skills path', function (): void {
     expect($agent->skillsPath())->toBe('.custom/skills');
 });
 
-it('projectDetectionConfig detects .agents path and mcp_config.json file', function (): void {
+it('projectDetectionConfig only uses the Antigravity-specific mcp_config.json', function (): void {
     $agent = new Antigravity($this->strategyFactory);
 
     expect($agent->projectDetectionConfig())->toBe([
-        'paths' => ['.agents'],
         'files' => ['.agents/mcp_config.json'],
     ]);
+});
+
+it('detectInProject returns false when only .agents/skills exists', function (): void {
+    $agent = new Antigravity(new DetectionStrategyFactory(app()));
+    $tempDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'boost_antigravity_'.uniqid();
+    mkdir($tempDir.DIRECTORY_SEPARATOR.'.agents'.DIRECTORY_SEPARATOR.'skills', 0755, true);
+
+    try {
+        expect($agent->detectInProject($tempDir))->toBeFalse();
+    } finally {
+        rmdir($tempDir.DIRECTORY_SEPARATOR.'.agents'.DIRECTORY_SEPARATOR.'skills');
+        rmdir($tempDir.DIRECTORY_SEPARATOR.'.agents');
+        rmdir($tempDir);
+    }
+});
+
+it('detectInProject returns true when .agents/mcp_config.json exists', function (): void {
+    $agent = new Antigravity(new DetectionStrategyFactory(app()));
+    $tempDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'boost_antigravity_'.uniqid();
+    mkdir($tempDir.DIRECTORY_SEPARATOR.'.agents', 0755, true);
+    touch($tempDir.DIRECTORY_SEPARATOR.'.agents'.DIRECTORY_SEPARATOR.'mcp_config.json');
+
+    try {
+        expect($agent->detectInProject($tempDir))->toBeTrue();
+    } finally {
+        unlink($tempDir.DIRECTORY_SEPARATOR.'.agents'.DIRECTORY_SEPARATOR.'mcp_config.json');
+        rmdir($tempDir.DIRECTORY_SEPARATOR.'.agents');
+        rmdir($tempDir);
+    }
 });
 
 it('system detection uses command -v on Darwin', function (): void {

--- a/tests/Unit/Install/Agents/AntigravityTest.php
+++ b/tests/Unit/Install/Agents/AntigravityTest.php
@@ -67,15 +67,16 @@ it('returns configured skills path', function (): void {
     expect($agent->skillsPath())->toBe('.custom/skills');
 });
 
-it('projectDetectionConfig only uses the Antigravity-specific mcp_config.json', function (): void {
+it('only uses the antigravity specific mcp_config.json', function (): void {
     $agent = new Antigravity($this->strategyFactory);
 
     expect($agent->projectDetectionConfig())->toBe([
+        'paths' => ['.gemini'],
         'files' => ['.agents/mcp_config.json'],
     ]);
 });
 
-it('detectInProject returns false when only .agents/skills exists', function (): void {
+it('returns false when only .agents/skills exists', function (): void {
     $agent = new Antigravity(new DetectionStrategyFactory(app()));
     $tempDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'boost_antigravity_'.uniqid();
     mkdir($tempDir.DIRECTORY_SEPARATOR.'.agents'.DIRECTORY_SEPARATOR.'skills', 0755, true);
@@ -84,21 +85,6 @@ it('detectInProject returns false when only .agents/skills exists', function ():
         expect($agent->detectInProject($tempDir))->toBeFalse();
     } finally {
         rmdir($tempDir.DIRECTORY_SEPARATOR.'.agents'.DIRECTORY_SEPARATOR.'skills');
-        rmdir($tempDir.DIRECTORY_SEPARATOR.'.agents');
-        rmdir($tempDir);
-    }
-});
-
-it('detectInProject returns true when .agents/mcp_config.json exists', function (): void {
-    $agent = new Antigravity(new DetectionStrategyFactory(app()));
-    $tempDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'boost_antigravity_'.uniqid();
-    mkdir($tempDir.DIRECTORY_SEPARATOR.'.agents', 0755, true);
-    touch($tempDir.DIRECTORY_SEPARATOR.'.agents'.DIRECTORY_SEPARATOR.'mcp_config.json');
-
-    try {
-        expect($agent->detectInProject($tempDir))->toBeTrue();
-    } finally {
-        unlink($tempDir.DIRECTORY_SEPARATOR.'.agents'.DIRECTORY_SEPARATOR.'mcp_config.json');
         rmdir($tempDir.DIRECTORY_SEPARATOR.'.agents');
         rmdir($tempDir);
     }


### PR DESCRIPTION
boost:install thinks Antigravity is in the project for anyone who installed skills for Amp, Codex, OpenCode or Zed. those four all default their skills path to .agents/skills, so installing skills for any of them creates .agents/, and Antigravity's project detection matches on the bare .agents directory. same false positive class as #831/#832.

fix drops the paths entry and detects on .agents/mcp_config.json only, which is the file Antigravity actually writes.

repro on a real app: with only .agents/skills present, detectInProject returns true on main and false with this change, and a real .agents/mcp_config.json still detects.

re-file of #966, reviewed and re-tested individually.
