### PR TITLE
Detect Livewire navigate requests by header presence since Livewire 3 sends an empty value

### DIFF
--- a/src/Middleware/InjectBoost.php
+++ b/src/Middleware/InjectBoost.php
@@ -36,7 +36,6 @@ class InjectBoost
 
     protected function shouldInject(Request $request, Response $response): bool
     {
-        // Livewire 3 sends the navigate header with an empty value, so only its presence is reliable.
         if ($request->headers->has('x-livewire-navigate')) {
             return false;
         }

--- a/src/Middleware/InjectBoost.php
+++ b/src/Middleware/InjectBoost.php
@@ -36,7 +36,8 @@ class InjectBoost
 
     protected function shouldInject(Request $request, Response $response): bool
     {
-        if ($request->headers->get('x-livewire-navigate') === '1') {
+        // Livewire 3 sends the navigate header with an empty value, so only its presence is reliable.
+        if ($request->headers->has('x-livewire-navigate')) {
             return false;
         }
 

--- a/tests/Feature/Middleware/InjectBoostTest.php
+++ b/tests/Feature/Middleware/InjectBoostTest.php
@@ -56,6 +56,19 @@ it('does not inject for special response types', function ($responseType, $respo
     }],
 ]);
 
+it('does not inject into Livewire navigate responses', function (string $headerValue): void {
+    $request = new Request;
+    $request->headers->set('X-Livewire-Navigate', $headerValue);
+
+    $response = new Response('<html><head><title>Test</title></head><body></body></html>', 200, ['Content-Type' => 'text/html']);
+    $result = (new InjectBoost)->handle($request, fn ($req) => $response);
+
+    expect($result->getContent())->not->toContain('browser-logger-active');
+})->with([
+    'Livewire 4 sends 1' => ['1'],
+    'Livewire 3 sends an empty value' => [''],
+]);
+
 it('does not inject when conditions are not met', function ($scenario, $responseFactory, $assertion): void {
     $response = $responseFactory();
     $result = createMiddlewareResponse($response);


### PR DESCRIPTION
the navigate guard from #734 never fires on Livewire 3. its navigate requests send X-Livewire-Navigate with an empty value (Livewire 4 sends '1'), so the `=== '1'` check misses them and the browser logger script gets injected into navigate responses anyway, which is what #734 was added to prevent.

fix checks for the header's presence instead of its value.

repro on a real app with artisan serve: a request with the empty header gets browser-logger-active on main and not with this change, plain page loads still get the script, and a '1' header is skipped both ways.

re-file of #969, reviewed and re-tested individually.
