### PR TITLE
Fix non-GitHub SSH remote validation

### DIFF
--- a/src/Skills/Remote/GitHubRepository.php
+++ b/src/Skills/Remote/GitHubRepository.php
@@ -48,31 +48,11 @@ class GitHubRepository
      */
     private static function normalizeUrl(string $input): array
     {
-        $isUrl = Str::startsWith($input, ['http://', 'https://']);
-
-        $isSshUrl = Str::startsWith($input, 'ssh://');
-        $isScpUrl = preg_match('~^[^@/:]+@[^:]+:.+$~', $input) === 1;
-
-        if ($isSshUrl || $isScpUrl) {
-            if ($isScpUrl) {
-                preg_match('~^(?:[^@/:]+@)?(?<host>[^:]+):(?<path>.+)$~', $input, $matches);
-                $host = $matches['host'] ?? '';
-                $path = $matches['path'] ?? '';
-            } else {
-                $parsed = parse_url($input);
-                $host = $parsed['host'] ?? '';
-                $path = ltrim($parsed['path'] ?? '', '/');
-            }
-            $isGitHubHost = $host === 'github.com' || Str::endsWith($host, '.github.com');
-
-            if (! $isGitHubHost) {
-                throw new InvalidArgumentException('Only GitHub URLs are supported.');
-            }
-
-            return [Str::replaceEnd('.git', '', $path), ''];
+        if (preg_match('~^(?:[^@/:]+@)?(?<host>[^:]+):(?!//)(?<path>.+)$~', $input, $matches) === 1) {
+            $input = 'ssh://'.$matches['host'].'/'.$matches['path'];
         }
 
-        if (! $isUrl) {
+        if (! Str::startsWith($input, ['http://', 'https://', 'ssh://'])) {
             return [$input, ''];
         }
 
@@ -85,7 +65,7 @@ class GitHubRepository
             throw new InvalidArgumentException('Only GitHub URLs are supported.');
         }
 
-        $path = Str::of($parsed['path'] ?? '')->trim('/')->toString();
+        $path = Str::of($parsed['path'] ?? '')->trim('/')->replaceEnd('.git', '')->toString();
 
         // ponytail: a branch name containing a slash is indistinguishable from the path after it.
         if (preg_match('#^(?P<repository>[^/]+/[^/]+)/(?:tree|blob)/(?P<branch>[^/]+)/?(?P<path>.*)$#', $path, $matches) === 1) {

--- a/src/Skills/Remote/GitHubRepository.php
+++ b/src/Skills/Remote/GitHubRepository.php
@@ -50,6 +50,28 @@ class GitHubRepository
     {
         $isUrl = Str::startsWith($input, ['http://', 'https://']);
 
+        $isSshUrl = Str::startsWith($input, 'ssh://');
+        $isScpUrl = preg_match('~^[^@/:]+@[^:]+:.+$~', $input) === 1;
+
+        if ($isSshUrl || $isScpUrl) {
+            if ($isScpUrl) {
+                preg_match('~^(?:[^@/:]+@)?(?<host>[^:]+):(?<path>.+)$~', $input, $matches);
+                $host = $matches['host'] ?? '';
+                $path = $matches['path'] ?? '';
+            } else {
+                $parsed = parse_url($input);
+                $host = $parsed['host'] ?? '';
+                $path = ltrim($parsed['path'] ?? '', '/');
+            }
+            $isGitHubHost = $host === 'github.com' || Str::endsWith($host, '.github.com');
+
+            if (! $isGitHubHost) {
+                throw new InvalidArgumentException('Only GitHub URLs are supported.');
+            }
+
+            return [Str::replaceEnd('.git', '', $path), ''];
+        }
+
         if (! $isUrl) {
             return [$input, ''];
         }

--- a/tests/Unit/Skills/Remote/GitHubRepositoryTest.php
+++ b/tests/Unit/Skills/Remote/GitHubRepositoryTest.php
@@ -18,6 +18,10 @@ it('parses valid repository input', function (string $input, string $owner, stri
     'HTTP GitHub URL' => ['http://github.com/owner/repo', 'owner', 'repo', ''],
     'GitHub SSH URL' => ['git@github.com:owner/repo.git', 'owner', 'repo', ''],
     'GitHub SSH URL scheme' => ['ssh://git@github.com/owner/repo.git', 'owner', 'repo', ''],
+    'GitHub SSH URL with port' => ['ssh://git@github.com:22/owner/repo.git', 'owner', 'repo', ''],
+    'GitHub SSH URL with leading slash and trailing slash' => ['git@github.com:/owner/repo.git/', 'owner', 'repo', ''],
+    'GitHub SSH URL with path' => ['git@github.com:owner/repo/skills/my-skill', 'owner', 'repo', 'skills/my-skill'],
+    'GitHub HTTPS clone URL' => ['https://github.com/owner/repo.git', 'owner', 'repo', ''],
     'GitHub URL with tree/branch' => ['https://github.com/owner/repo/tree/main/skills', 'owner', 'repo', 'skills'],
     'GitHub URL with tree/branch and nested path' => ['https://github.com/owner/repo/tree/feature-branch/path/to/skills', 'owner', 'repo', 'path/to/skills'],
     'complex branch names in tree URLs' => ['https://github.com/owner/repo/tree/feature/my-branch/skills', 'owner', 'repo', 'my-branch/skills'],
@@ -41,6 +45,7 @@ it('throws for invalid input', function (string $input, string $message): void {
     'Bitbucket URL' => ['https://bitbucket.org/owner/repo', 'Only GitHub URLs are supported'],
     'Bitbucket SSH URL' => ['git@bitbucket.org:owner/repo.git', 'Only GitHub URLs are supported'],
     'Bitbucket SSH URL scheme' => ['ssh://git@bitbucket.org/owner/repo.git', 'Only GitHub URLs are supported'],
+    'SSH URL with slash in host' => ['git@evil.com/x.github.com:owner/repo', 'Only GitHub URLs are supported'],
 ]);
 
 it('returns full name from fullName method', function (): void {

--- a/tests/Unit/Skills/Remote/GitHubRepositoryTest.php
+++ b/tests/Unit/Skills/Remote/GitHubRepositoryTest.php
@@ -16,6 +16,8 @@ it('parses valid repository input', function (string $input, string $owner, stri
     'full GitHub URL' => ['https://github.com/owner/repo', 'owner', 'repo', ''],
     'GitHub URL with trailing slash' => ['https://github.com/owner/repo/', 'owner', 'repo', ''],
     'HTTP GitHub URL' => ['http://github.com/owner/repo', 'owner', 'repo', ''],
+    'GitHub SSH URL' => ['git@github.com:owner/repo.git', 'owner', 'repo', ''],
+    'GitHub SSH URL scheme' => ['ssh://git@github.com/owner/repo.git', 'owner', 'repo', ''],
     'GitHub URL with tree/branch' => ['https://github.com/owner/repo/tree/main/skills', 'owner', 'repo', 'skills'],
     'GitHub URL with tree/branch and nested path' => ['https://github.com/owner/repo/tree/feature-branch/path/to/skills', 'owner', 'repo', 'path/to/skills'],
     'complex branch names in tree URLs' => ['https://github.com/owner/repo/tree/feature/my-branch/skills', 'owner', 'repo', 'my-branch/skills'],
@@ -37,6 +39,8 @@ it('throws for invalid input', function (string $input, string $message): void {
     'empty repo' => ['owner/', 'Invalid repository format'],
     'GitLab URL' => ['https://gitlab.com/owner/repo', 'Only GitHub URLs are supported'],
     'Bitbucket URL' => ['https://bitbucket.org/owner/repo', 'Only GitHub URLs are supported'],
+    'Bitbucket SSH URL' => ['git@bitbucket.org:owner/repo.git', 'Only GitHub URLs are supported'],
+    'Bitbucket SSH URL scheme' => ['ssh://git@bitbucket.org/owner/repo.git', 'Only GitHub URLs are supported'],
 ]);
 
 it('returns full name from fullName method', function (): void {


### PR DESCRIPTION
Closes #982

## Summary

- accept GitHub SCP-style and `ssh://` remote URLs
- reject SSH remotes whose host is not GitHub
- keep existing HTTPS, branch, and nested skill-path handling unchanged

## Root cause

Non-GitHub SSH remotes were treated as plain `owner/repository` strings. That allowed them to reach the GitHub API and fail later with a misleading 404 instead of reporting that the host is unsupported.

## User impact

Users now get an immediate, accurate validation error for unsupported SSH hosts. Existing GitHub SSH forms such as `git@github.com:owner/repo.git` and `ssh://git@github.com/owner/repo.git` continue to work.

## Validation

- `vendor/bin/pest tests/Unit/Skills/Remote/GitHubRepositoryTest.php` - 32 passed, 79 assertions
- `vendor/bin/phpstan analyse src/Skills/Remote/GitHubRepository.php --no-progress` - passed
- full Pest suite - 1,012 passed; 8 unrelated WSL/configuration failures; 1 todo; 10 skipped
- `git diff --check` - passed

The full-suite failures involve existing `wsl.exe` and configuration expectations and do not touch the changed files.

## AI disclosure

This change was prepared with OpenAI Codex assistance and reviewed and validated locally by the contributor.
