### PR TITLE
Collapse Blade escape sequences in boostsnippet bodies since they never reach Blade

### DIFF
--- a/src/Concerns/RendersBladeGuidelines.php
+++ b/src/Concerns/RendersBladeGuidelines.php
@@ -63,6 +63,9 @@ trait RendersBladeGuidelines
             $lang = empty($matches['lang']) ? 'html' : $matches['lang'];
             $snippetContent = trim($matches['content']);
 
+            $snippetContent = preg_replace('/(?<!\w)@@(?=\w)/', '@', $snippetContent) ?? $snippetContent;
+            $snippetContent = str_replace('@{{', '{{', $snippetContent);
+
             $placeholder = '___BOOST_SNIPPET_'.count($this->storedSnippets).'___';
 
             $this->storedSnippets[$placeholder] = '<!-- '.$name.' -->'."\n".'```'.$lang."\n".$snippetContent."\n".'```'."\n\n";

--- a/tests/Unit/Concerns/RendersBladeGuidelinesTest.php
+++ b/tests/Unit/Concerns/RendersBladeGuidelinesTest.php
@@ -47,6 +47,27 @@ test('boostsnippet directive extracts name and content into fenced code block', 
         ->toContain('```');
 });
 
+test('boostsnippet collapses Blade escape sequences in the stored body', function (): void {
+    $content = <<<'BLADE'
+    @boostsnippet('Volt Example', 'php')
+    @@volt
+    <h1>Count: @{{ $count }}</h1>
+    @@endvolt
+    @endboostsnippet
+    BLADE;
+
+    $this->renderer->processSnippets($content);
+
+    $snippet = $this->renderer->getStoredSnippets()['___BOOST_SNIPPET_0___'];
+
+    expect($snippet)
+        ->toContain('@volt')
+        ->toContain('@endvolt')
+        ->toContain('Count: {{ $count }}')
+        ->not->toContain('@@volt')
+        ->not->toContain('@{{');
+});
+
 test('boostsnippet supports double quotes for name parameter', function (): void {
     $content = '@boostsnippet("Double Quoted")code@endboostsnippet';
 


### PR DESCRIPTION
skills that use @boostsnippet ship Blade escape sequences to users. snippet bodies get pulled out before Blade renders the file and restored raw after, so Blade never collapses @@ or @{{ inside them. the volt skill ships literal @@volt, @@endvolt and @{{ $count }}, and the livewire 4 skill ships @{{ $count }}, which is not valid Volt or Livewire code for the agent reading the skill.

fix collapses the two escapes in the stored body the same way Blade would, @@directive to @directive and @{{ to {{.

repro on a real app with livewire 4.4: boost:install --skills lands .claude/skills/livewire-development/SKILL.md with `Count: @{{ $count }}` on main and `Count: {{ $count }}` with this change.

re-file of #972, reviewed and re-tested individually.
