### PR TITLE
Skip versioned guideline discovery for packages without a major version

### DIFF
--- a/src/Install/GuidelineComposer.php
+++ b/src/Install/GuidelineComposer.php
@@ -218,7 +218,9 @@ class GuidelineComposer
                     $guidelineDir.'/core' => $this->resolveGuideline($vendorCorePath, $guidelineDir.'/core'),
                 ]);
 
-                $packageGuidelines = $this->guidelinesDir($guidelineDir.'/'.$package->major());
+                $packageGuidelines = $package->major() === null
+                    ? []
+                    : $this->guidelinesDir($guidelineDir.'/'.$package->major());
 
                 foreach ($packageGuidelines as $guideline) {
                     $suffix = $guideline['name'] === 'core' ? '' : '/'.$guideline['name'];

--- a/tests/Feature/Install/GuidelineComposerTest.php
+++ b/tests/Feature/Install/GuidelineComposerTest.php
@@ -28,6 +28,21 @@ beforeEach(function (): void {
     $this->composer = new GuidelineComposer($this->project, $this->herd);
 });
 
+test('versionless packages do not emit a duplicate versioned guideline', function (): void {
+    config(['boost.rules.enabled' => false]);
+
+    $packages = new PackageCollection([
+        rosterPackage('laravel/framework', ''),
+    ]);
+
+    mockProjectPackages($this->project, $packages);
+
+    $keys = $this->composer->guidelines()->keys()->all();
+
+    expect($keys)->toContain('laravel/core')
+        ->not->toContain('laravel/v');
+});
+
 test('includes Inertia React conditional guidelines based on version', function (string $version): void {
     config(['boost.rules.enabled' => false]);
 


### PR DESCRIPTION
a package installed from a branch (dev-main, dev-master, *) has no digits in its version, so roster normalizes it to an empty string and major() returns null. GuidelineComposer then builds the versioned guideline path with that null, which walks the package's whole guideline directory and re-emits the core guideline under a bogus v key, so the composed guidelines carry the same content twice.

fix skips versioned discovery when major() is null, the same guard SkillComposer already has.

repro on a real app: composer require livewire/livewire:dev-main, then boost:install with guidelines. on main CLAUDE.md ends up with both `=== livewire/core rules ===` and a duplicate `=== livewire/v rules ===` section with identical content, with this change only livewire/core.

re-file of #973, reviewed and re-tested individually.
