### PR TITLE
Add configurable skills path

### DIFF
--- a/config/boost.php
+++ b/config/boost.php
@@ -50,16 +50,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Excluded Skills
+    | Skills
     |--------------------------------------------------------------------------
+    |
+    | The path option defines where project skills are stored. It may be
+    | customized when your project uses a different skills directory.
     |
     | Any skills listed here will not be installed or synced to your agents
     | by boost:install and boost:update, e.g. "fluxui-development". Your
-    | own skills within the ".ai/skills" directory are never excluded.
+    | own skills within the configured directory are never excluded.
     |
     */
 
     'skills' => [
+        'path' => env('BOOST_SKILLS_PATH', '.ai/skills'),
         'exclude' => [],
     ],
 

--- a/src/Console/AddSkillCommand.php
+++ b/src/Console/AddSkillCommand.php
@@ -51,8 +51,6 @@ class AddSkillCommand extends Command
     /** @var Collection<string, RemoteSkill> */
     protected Collection $availableSkills;
 
-    protected string $defaultSkillsPath = '.ai/skills';
-
     public function __construct(private readonly Terminal $terminal)
     {
         parent::__construct();
@@ -266,7 +264,7 @@ class AddSkillCommand extends Command
 
     protected function skillTargetPath(RemoteSkill $skill): string
     {
-        return base_path($this->defaultSkillsPath.DIRECTORY_SEPARATOR.$skill->name);
+        return base_path(config('boost.skills.path').DIRECTORY_SEPARATOR.$skill->name);
     }
 
     /**

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -521,7 +521,7 @@ class InstallCommand extends Command
                 return;
             }
 
-            $provider->downloadSkill($skill, base_path('.ai/skills/'.$this->cloud->skillName()));
+            $provider->downloadSkill($skill, base_path(config('boost.skills.path').DIRECTORY_SEPARATOR.$this->cloud->skillName()));
         } catch (Exception $exception) {
             $this->warn('Failed to download Cloud skill: '.$exception->getMessage());
             $this->line('You can install it later with: php artisan boost:add-skill '.$this->cloud->skillRepo());

--- a/src/Console/UpdateCommand.php
+++ b/src/Console/UpdateCommand.php
@@ -30,7 +30,7 @@ class UpdateCommand extends Command
         }
 
         $guidelines = $config->getGuidelines();
-        $hasSkills = ! $this->option('ignore-skills') && ($config->hasSkills() || is_dir(base_path('.ai/skills')));
+        $hasSkills = ! $this->option('ignore-skills') && ($config->hasSkills() || is_dir(base_path(config('boost.skills.path'))));
 
         if (! $guidelines && ! $hasSkills) {
             return self::SUCCESS;

--- a/src/Install/Skill.php
+++ b/src/Install/Skill.php
@@ -28,7 +28,7 @@ class Skill
     public function displayName(): string
     {
         return $this->custom
-            ? '.ai/'.$this->name.'*'
+            ? config('boost.skills.path').'/'.$this->name.'*'
             : $this->name;
     }
 }

--- a/src/Install/SkillComposer.php
+++ b/src/Install/SkillComposer.php
@@ -134,7 +134,7 @@ class SkillComposer
      */
     protected function discoverExplicitUserSkills(): Collection
     {
-        $path = base_path('.ai/skills');
+        $path = base_path(config('boost.skills.path'));
 
         if (! is_dir($path)) {
             return collect();

--- a/src/Install/SkillWriter.php
+++ b/src/Install/SkillWriter.php
@@ -36,7 +36,7 @@ class SkillWriter
         }
 
         $targetPath = base_path($this->agent->skillsPath().DIRECTORY_SEPARATOR.$skill->name);
-        $canonicalPath = base_path('.ai'.DIRECTORY_SEPARATOR.'skills'.DIRECTORY_SEPARATOR.$skill->name);
+        $canonicalPath = base_path(config('boost.skills.path').DIRECTORY_SEPARATOR.$skill->name);
         $existed = $this->pathExists($targetPath);
 
         if (! $skill->custom) {

--- a/tests/Feature/Console/AddSkillCommandTest.php
+++ b/tests/Feature/Console/AddSkillCommandTest.php
@@ -113,6 +113,37 @@ it('installs all skills with --all option', function (): void {
     $this->assertFileContains(['# SKILL Content'], '.ai/skills/skill-one/SKILL.md');
 });
 
+it('installs skills in the configured skills path', function (): void {
+    config(['boost.skills.path' => '.custom/skills']);
+
+    Http::fake([
+        'api.github.com/repos/owner/repo/git/trees/main?recursive=1' => Http::response([
+            'sha' => 'abc123',
+            'tree' => [
+                ['path' => 'skill-one', 'type' => 'tree', 'sha' => 'def'],
+                ['path' => 'skill-one/SKILL.md', 'type' => 'blob', 'sha' => 'ghi', 'size' => 123],
+            ],
+            'truncated' => false,
+        ]),
+        'raw.githubusercontent.com/*' => Http::response(<<<'YAML'
+            ---
+            name: skill-one
+            description: First skill
+            ---
+            # SKILL Content
+            YAML),
+    ]);
+
+    $this->artisan('boost:add-skill', [
+        'repo' => 'owner/repo',
+        '--all' => true,
+    ])->assertSuccessful();
+
+    $this->assertFilenameExists('.custom/skills/skill-one/SKILL.md');
+
+    File::deleteDirectory(base_path('.custom'));
+});
+
 it('installs specific skills with --skill option', function (): void {
     Http::fake([
         'api.github.com/repos/owner/repo/git/trees/main?recursive=1' => Http::response([

--- a/tests/Feature/Install/SkillComposerTest.php
+++ b/tests/Feature/Install/SkillComposerTest.php
@@ -381,3 +381,31 @@ test('frontmatter parsing ignores HTML comments injected by third-party packages
         ->toHaveKey('name', 'pest-testing')
         ->toHaveKey('description', 'Write and run tests with Pest');
 });
+
+test('discovers explicit user skills from the configured skills path', function (): void {
+    $packages = new PackageCollection([
+        rosterPackage('laravel/framework', '11.0.0'),
+    ]);
+
+    mockProjectPackages($this->project, $packages);
+
+    $skillsPath = '.custom/skills';
+    $skillDir = base_path($skillsPath.'/custom-skill');
+    config(['boost.skills.path' => $skillsPath]);
+    @mkdir($skillDir, 0755, true);
+    file_put_contents($skillDir.'/SKILL.md', "---\nname: custom-skill\ndescription: A custom skill\n---\n\n# Content\n");
+
+    try {
+        $skill = (new SkillComposer($this->project))->skills()->get('custom-skill');
+
+        expect($skill)
+            ->not->toBeNull()
+            ->path->toBe($skillDir)
+            ->custom->toBeTrue();
+    } finally {
+        @unlink($skillDir.'/SKILL.md');
+        @rmdir($skillDir);
+        @rmdir(base_path($skillsPath));
+        @rmdir(base_path('.custom'));
+    }
+});

--- a/tests/Unit/Install/SkillTest.php
+++ b/tests/Unit/Install/SkillTest.php
@@ -75,7 +75,7 @@ it('displays name without asterisk when not custom', function (): void {
     expect($skill->displayName())->toBe('building-livewire-components');
 });
 
-it('displays name with .ai/ prefix and asterisk when custom', function (): void {
+it('displays configured skills path with asterisk when custom', function (): void {
     $skill = new Skill(
         name: 'my-custom-skill',
         package: 'user',
@@ -84,5 +84,19 @@ it('displays name with .ai/ prefix and asterisk when custom', function (): void 
         custom: true,
     );
 
-    expect($skill->displayName())->toBe('.ai/my-custom-skill*');
+    expect($skill->displayName())->toBe('.ai/skills/my-custom-skill*');
+});
+
+it('displays custom skills with the configured path', function (): void {
+    config(['boost.skills.path' => '.custom/skills']);
+
+    $skill = new Skill(
+        name: 'my-custom-skill',
+        package: 'user',
+        path: '/path/to/custom',
+        description: 'Custom skill',
+        custom: true,
+    );
+
+    expect($skill->displayName())->toBe('.custom/skills/my-custom-skill*');
 });

--- a/tests/Unit/Install/SkillWriterTest.php
+++ b/tests/Unit/Install/SkillWriterTest.php
@@ -64,6 +64,37 @@ it('writes skill to a target directory', function (): void {
     cleanupSkillDirectory($absoluteTarget);
 });
 
+it('uses the configured path for canonical skills', function (): void {
+    $sourceDir = fixture('skills/test-skill');
+    $relativeTarget = '.boost-test-skills-'.uniqid();
+    $absoluteTarget = base_path($relativeTarget);
+    $skillsPath = '.custom/skills-'.uniqid();
+    $canonicalSkillPath = base_path($skillsPath.'/custom-skill');
+    config(['boost.skills.path' => $skillsPath]);
+
+    $agent = Mockery::mock(SupportsSkills::class);
+    $agent->shouldReceive('skillsPath')->andReturn($relativeTarget);
+
+    $skill = new Skill(
+        name: 'custom-skill',
+        package: 'boost',
+        path: $sourceDir,
+        description: 'Custom skill',
+        custom: true,
+    );
+
+    $writer = new SkillWriter($agent);
+    $result = $writer->write($skill);
+
+    expect($result)->toBe(SkillWriter::SUCCESS)
+        ->and($canonicalSkillPath)->toBeDirectory()
+        ->and($canonicalSkillPath.'/SKILL.md')->toBeFile();
+
+    cleanupSkillDirectory($absoluteTarget);
+    cleanupSkillDirectory($canonicalSkillPath);
+    cleanupSkillDirectory(base_path($skillsPath));
+});
+
 it('updates existing canonical skills when installing non-custom skills', function (): void {
     $sourceDir = fixture('skills/test-skill');
     $relativeTarget = '.boost-test-skills-'.uniqid();


### PR DESCRIPTION
## Summary
- add `boost.skills.path` configuration with `.ai/skills` as the default
- use the configured path for discovery, syncing, add-skill, Cloud skills, and update detection
- add coverage for custom paths

## Tests
- `vendor/bin/phpstan --memory-limit=-1`
- focused Pest tests: 122 passed
- full Pest suite reaches a pre-existing `ArchTest` premature PHP process termination