### PR TITLE
Register the browser-logs route only when the browser logs watcher is enabled

### DIFF
--- a/src/BoostServiceProvider.php
+++ b/src/BoostServiceProvider.php
@@ -61,9 +61,9 @@ class BoostServiceProvider extends ServiceProvider
 
         $this->registerPublishing();
         $this->registerCommands();
-        $this->registerRoutes();
 
         if (config('boost.browser_logs_watcher', true)) {
+            $this->registerRoutes();
             $this->registerBrowserLogger();
             $this->callAfterResolving('blade.compiler', $this->registerBladeDirectives(...));
             $this->hookIntoResponses($router);

--- a/tests/Feature/BrowserLogsRouteRegistrationTest.php
+++ b/tests/Feature/BrowserLogsRouteRegistrationTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class BrowserLogsRouteRegistrationTest extends TestCase
+{
+    protected function defineEnvironment($app)
+    {
+        parent::defineEnvironment($app);
+
+        $app['config']->set('boost.browser_logs_watcher', false);
+    }
+
+    public function test_browser_logs_route_is_not_registered_when_the_watcher_is_disabled(): void
+    {
+        $this->postJson('/_boost/browser-logs', ['logs' => []])->assertNotFound();
+    }
+}


### PR DESCRIPTION
registerRoutes() runs outside the browser_logs_watcher guard but registerBrowserLogger() runs inside it so turning the watcher off still leaves POST /_boost/browser-logs registered with no `browser` log channel behind it. any POST to it 500s and drops a laravel.EMERGENCY entry with a full stack trace into laravel.log

tried it on a fresh laravel app with BOOST_BROWSER_LOGS_WATCHER=false, route:list still shows the route and posting to it returns 500 plus "Unable to create configured logger. Using emergency logger." in laravel.log every time. with this change the route is gone and the same POST just 404s, watcher back on and it registers like before

fix is moving registerRoutes() into the existing config check

re-file of #974, reviewed and re-tested individually
