### PR TITLE
Report the database driver name as database_engine instead of the connection name

### DIFF
--- a/src/Mcp/Tools/ApplicationInfo.php
+++ b/src/Mcp/Tools/ApplicationInfo.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Mcp\Tools;
 
+use Illuminate\Support\Facades\DB;
 use Laravel\Boost\Support\PackageRegistry;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
@@ -33,7 +34,7 @@ class ApplicationInfo extends Tool
         return Response::json([
             'php_version' => PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION,
             'laravel_version' => app()->version(),
-            'database_engine' => config('database.default'),
+            'database_engine' => DB::connection()->getDriverName(),
             'packages' => $this->project->php()->packages()
                 ->concat($this->project->js()->packages())
                 ->map(fn (Package $package): array => [

--- a/tests/Feature/Mcp/Tools/ApplicationInfoTest.php
+++ b/tests/Feature/Mcp/Tools/ApplicationInfoTest.php
@@ -24,7 +24,7 @@ test('it returns application info with packages', function (): void {
         ->toolJsonContentToMatchArray([
             'php_version' => PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION,
             'laravel_version' => app()->version(),
-            'database_engine' => config('database.default'),
+            'database_engine' => 'sqlite',
             'packages' => [
                 [
                     'roster_name' => 'LARAVEL',
@@ -40,6 +40,23 @@ test('it returns application info with packages', function (): void {
         ]);
 });
 
+test('it reports the driver name when the default connection has a custom name', function (): void {
+    config()->set('database.connections.tenant', config('database.connections.testing'));
+    config()->set('database.default', 'tenant');
+
+    $project = Mockery::mock(ProjectManager::class);
+    mockProjectPackages($project, new PackageCollection([]));
+
+    $tool = new ApplicationInfo($project);
+    $response = $tool->handle(new Request([]));
+
+    expect($response)->isToolResult()
+        ->toolHasNoError()
+        ->toolJsonContent(function (array $data): void {
+            expect($data['database_engine'])->toBe('sqlite');
+        });
+});
+
 test('it returns application info with no packages', function (): void {
     $project = Mockery::mock(ProjectManager::class);
     mockProjectPackages($project, new PackageCollection([]));
@@ -52,7 +69,7 @@ test('it returns application info with no packages', function (): void {
         ->toolJsonContentToMatchArray([
             'php_version' => PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION,
             'laravel_version' => app()->version(),
-            'database_engine' => config('database.default'),
+            'database_engine' => 'sqlite',
             'packages' => [],
         ]);
 });


### PR DESCRIPTION
application-info returns config('database.default') as database_engine which is the connection name not the engine. they only match when the connection happens to be named after its driver, rename the default connection and the tool reports that name as the engine to every agent that calls it

tried it on a fresh app with the default connection named landlord (sqlite driver, spatie multitenancy style naming), on main application-info says "database_engine": "landlord" and with this change it says "sqlite"

DB::connection()->getDriverName() is what database-schema already uses for its engine field and database-connections already labels config('database.default') as default_connection so this just brings application-info in line. getDriverName() reads the driver off the config, it doesnt open a connection

re-file of #970, reviewed and re-tested individually
