### PR TITLE
Read the standard mcp_config_path config key for Junie instead of the never-documented mcp_path

### DIFF
--- a/src/Install/Agents/Junie.php
+++ b/src/Install/Agents/Junie.php
@@ -59,7 +59,7 @@ class Junie extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSk
 
     public function mcpConfigPath(): string
     {
-        return config('boost.agents.junie.mcp_path', '.junie/mcp/mcp.json');
+        return config('boost.agents.junie.mcp_config_path', '.junie/mcp/mcp.json');
     }
 
     /** {@inheritDoc} */

--- a/tests/Unit/Install/Agents/JunieTest.php
+++ b/tests/Unit/Install/Agents/JunieTest.php
@@ -20,3 +20,17 @@ test('httpMcpServerConfig returns npx mcp-remote config', function (): void {
         'args' => ['-y', 'mcp-remote', 'https://nightwatch.laravel.com/mcp'],
     ]);
 });
+
+it('returns default mcp config path', function (): void {
+    $agent = new Junie($this->strategyFactory);
+
+    expect($agent->mcpConfigPath())->toBe('.junie/mcp/mcp.json');
+});
+
+it('returns configured mcp config path', function (): void {
+    config()->set('boost.agents.junie.mcp_config_path', '../.junie/mcp/mcp.json');
+
+    $agent = new Junie($this->strategyFactory);
+
+    expect($agent->mcpConfigPath())->toBe('../.junie/mcp/mcp.json');
+});


### PR DESCRIPTION
Junie is the only agent reading its mcp path from boost.agents.junie.mcp_path, the other 11 agents all read mcp_config_path. so anyone overriding junie the way every other agent works gets silently ignored and the file always lands at the default .junie/mcp/mcp.json

tried it on a fresh app with boost.agents.junie.mcp_config_path set to .junie/custom/mcp.json, on main boost:install --mcp ignores it and writes .junie/mcp/mcp.json, with this change it writes .junie/custom/mcp.json

one line, just renames the key to match the rest

re-file of #967, reviewed and re-tested individually
