### PR TITLE
Stop normalizing blank lines outside the Boost guidelines block

### DIFF
--- a/src/Concerns/RendersBladeGuidelines.php
+++ b/src/Concerns/RendersBladeGuidelines.php
@@ -79,11 +79,9 @@ trait RendersBladeGuidelines
                 '/(?<!@)@scoped\(\s*(?P<paths>\[(?:[\s,]|\'[^\']*\'|"[^"]*")*\])\s*\)/s',
                 fn (array $matches): string => '___SCOPED_START_'.base64_encode((string) json_encode($this->parseScopedPaths($matches['paths']))).'___',
                 $markdown
-            );
+            ) ?? $markdown;
 
-            $marked = $marked === null ? null : preg_replace('/(?<!@)@endscoped/', '___SCOPED_END___', $marked);
-
-            return $marked ?? $markdown;
+            return preg_replace('/(?<!@)@endscoped/', '___SCOPED_END___', $marked) ?? $marked;
         });
     }
 

--- a/src/Concerns/RendersBladeGuidelines.php
+++ b/src/Concerns/RendersBladeGuidelines.php
@@ -6,6 +6,7 @@ namespace Laravel\Boost\Concerns;
 
 use Illuminate\Support\Facades\Blade;
 use Laravel\Boost\Install\GuidelineAssist;
+use Laravel\Boost\Support\Fences;
 use Laravel\Boost\Support\RenderFailures;
 
 trait RendersBladeGuidelines
@@ -73,36 +74,17 @@ trait RendersBladeGuidelines
 
     protected function markScopedBlocks(string $content): string
     {
-        $fences = [];
+        return Fences::outside($content, function (string $markdown): string {
+            $marked = preg_replace_callback(
+                '/(?<!@)@scoped\(\s*(?P<paths>\[(?:[\s,]|\'[^\']*\'|"[^"]*")*\])\s*\)/s',
+                fn (array $matches): string => '___SCOPED_START_'.base64_encode((string) json_encode($this->parseScopedPaths($matches['paths']))).'___',
+                $markdown
+            );
 
-        $marked = preg_replace_callback('/^ {0,3}(?<fence>`{3,}|~{3,})[^\n]*\n.*?(?:^ {0,3}\k<fence>[`~]*[ \t]*$|\z)/ms', function (array $matches) use (&$fences): string {
-            $placeholder = '___SCOPED_FENCE_'.count($fences).'___';
-            $fences[$placeholder] = $matches[0];
+            $marked = $marked === null ? null : preg_replace('/(?<!@)@endscoped/', '___SCOPED_END___', $marked);
 
-            return $placeholder;
-        }, $content);
-
-        if ($marked === null) {
-            return $content;
-        }
-
-        $marked = preg_replace_callback(
-            '/(?<!@)@scoped\(\s*(?P<paths>\[(?:[\s,]|\'[^\']*\'|"[^"]*")*\])\s*\)/s',
-            fn (array $matches): string => '___SCOPED_START_'.base64_encode((string) json_encode($this->parseScopedPaths($matches['paths']))).'___',
-            $marked
-        );
-
-        if ($marked === null) {
-            return $content;
-        }
-
-        $marked = preg_replace('/(?<!@)@endscoped/', '___SCOPED_END___', $marked);
-
-        if ($marked === null) {
-            return $content;
-        }
-
-        return str_replace(array_keys($fences), array_values($fences), $marked);
+            return $marked ?? $markdown;
+        });
     }
 
     /**

--- a/src/Install/GuidelineWriter.php
+++ b/src/Install/GuidelineWriter.php
@@ -77,7 +77,19 @@ class GuidelineWriter
             }
 
             // Normalize multiple blank lines to single blank lines
-            $newContent = preg_replace("/\n{3,}/", "\n\n", (string) $newContent);
+            $fences = [];
+
+            $masked = preg_replace_callback('/(?<fence>`{3,}|~{3,}).*?\k<fence>/s', function (array $matches) use (&$fences): string {
+                $placeholder = '___GUIDELINE_FENCE_'.count($fences).'___';
+                $fences[$placeholder] = $matches[0];
+
+                return $placeholder;
+            }, (string) $newContent);
+
+            if ($masked !== null) {
+                $masked = preg_replace("/\n{3,}/", "\n\n", $masked);
+                $newContent = str_replace(array_keys($fences), array_values($fences), (string) $masked);
+            }
 
             // Ensure file content ends with a newline
             if (! str_ends_with((string) $newContent, "\n")) {

--- a/src/Install/GuidelineWriter.php
+++ b/src/Install/GuidelineWriter.php
@@ -58,9 +58,7 @@ class GuidelineWriter
             $replaced = false;
 
             if (preg_match($pattern, $content)) {
-                // Replace ALL existing boost guidelines blocks in-place
-                // If the user added guidelines after ours then let's
-                // make sure we keep the flow.
+                // Replace our block in-place so user content around it keeps its position.
                 $newContent = preg_replace_callback($pattern, fn (array $m): string => $replacement, $content, 1);
                 $replaced = true;
             } else {
@@ -74,21 +72,6 @@ class GuidelineWriter
                 $existingContent = rtrim($content);
                 $separatingNewlines = empty($existingContent) ? '' : "\n\n===\n\n";
                 $newContent = $frontMatter.$existingContent.$separatingNewlines.$replacement;
-            }
-
-            // Normalize multiple blank lines to single blank lines
-            $fences = [];
-
-            $masked = preg_replace_callback('/(?<fence>`{3,}|~{3,}).*?\k<fence>/s', function (array $matches) use (&$fences): string {
-                $placeholder = '___GUIDELINE_FENCE_'.count($fences).'___';
-                $fences[$placeholder] = $matches[0];
-
-                return $placeholder;
-            }, (string) $newContent);
-
-            if ($masked !== null) {
-                $masked = preg_replace("/\n{3,}/", "\n\n", $masked);
-                $newContent = str_replace(array_keys($fences), array_values($fences), (string) $masked);
             }
 
             // Ensure file content ends with a newline

--- a/src/Install/MarkdownFormatter.php
+++ b/src/Install/MarkdownFormatter.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Laravel\Boost\Install;
 
+use Laravel\Boost\Support\Fences;
+
 class MarkdownFormatter
 {
     /**
@@ -14,27 +16,14 @@ class MarkdownFormatter
         // Normalize line endings (CRLF → LF, CR → LF)
         $content = str_replace(["\r\n", "\r"], "\n", $content);
 
-        $fences = [];
+        // A "# " line inside a fence is code, not a heading.
+        return Fences::outside($content, function (string $markdown): string {
+            // Ensure blank line before and after markdown headings
+            $spaced = preg_replace('/(?<!\n)\n(#{1,4} )/m', "\n\n$1", $markdown);
+            $spaced = preg_replace('/^(#{1,4} .+)\n(?!\n)/m', "$1\n\n", (string) $spaced);
 
-        // A "# " line inside a fence is code, not a heading, so hide fences while spacing headings.
-        $masked = preg_replace_callback('/^ {0,3}(?<fence>`{3,}|~{3,})[^\n]*\n.*?(?:^ {0,3}\k<fence>[`~]*[ \t]*$|\z)/ms', function (array $matches) use (&$fences): string {
-            $placeholder = "\0".count($fences)."\0";
-            $fences[$placeholder] = $matches[0];
-
-            return $placeholder;
-        }, $content);
-
-        if ($masked === null) {
-            return $content;
-        }
-
-        // Ensure blank line before and after markdown headings
-        $masked = preg_replace('/(?<!\n)\n(#{1,4} )/m', "\n\n$1", $masked);
-        $masked = preg_replace('/^(#{1,4} .+)\n(?!\n)/m', "$1\n\n", (string) $masked);
-
-        // Collapse multiple consecutive empty lines into a single empty line
-        $masked = preg_replace('/\n{3,}/', "\n\n", (string) $masked);
-
-        return str_replace(array_keys($fences), array_values($fences), (string) $masked);
+            // Collapse multiple consecutive empty lines into a single empty line
+            return (string) preg_replace('/\n{3,}/', "\n\n", (string) $spaced);
+        });
     }
 }

--- a/src/Support/Fences.php
+++ b/src/Support/Fences.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Support;
+
+class Fences
+{
+    /**
+     * Fenced code blocks per CommonMark, so inline backtick runs are not paired.
+     */
+    private const PATTERN = '/^ {0,3}(?<fence>`{3,}|~{3,})[^\n]*\n.*?(?:^ {0,3}\k<fence>[`~]*[ \t]*$|\z)/ms';
+
+    /**
+     * Run a transformation over the markdown outside its fenced code blocks.
+     *
+     * @param  callable(string): string  $callback
+     */
+    public static function outside(string $content, callable $callback): string
+    {
+        $fences = [];
+
+        $masked = preg_replace_callback(self::PATTERN, function (array $matches) use (&$fences): string {
+            $placeholder = "\0".count($fences)."\0";
+            $fences[$placeholder] = $matches[0];
+
+            return $placeholder;
+        }, $content);
+
+        if ($masked === null) {
+            return $content;
+        }
+
+        return str_replace(array_keys($fences), array_values($fences), $callback($masked));
+    }
+}

--- a/tests/Unit/Install/GuidelineWriterTest.php
+++ b/tests/Unit/Install/GuidelineWriterTest.php
@@ -37,6 +37,40 @@ test('it creates directory when it does not exist', function (): void {
     rmdir($tempDir);
 });
 
+test('it leaves blank lines inside fenced code blocks alone when normalizing', function (): void {
+    $tempFile = tempnam(sys_get_temp_dir(), 'boost_test_');
+
+    $userContent = <<<'MD'
+    # My Project
+
+    ```python
+    def first():
+        pass
+
+
+    def second():
+        pass
+    ```
+    MD;
+
+    file_put_contents($tempFile, $userContent);
+
+    $agent = Mockery::mock(SupportsGuidelines::class);
+    $agent->shouldReceive('guidelinesPath')->andReturn($tempFile);
+    $agent->shouldReceive('frontmatter')->andReturn(false);
+    $agent->shouldReceive('transformGuidelines')->andReturnUsing(fn ($markdown) => $markdown);
+
+    $writer = new GuidelineWriter($agent);
+    $writer->write('boost guidelines');
+
+    $written = file_get_contents($tempFile);
+
+    expect($written)->toContain("def first():\n    pass\n\n\ndef second():")
+        ->toContain('boost guidelines');
+
+    unlink($tempFile);
+});
+
 test('it throws exception when directory creation fails', function (): void {
     // Use a path that cannot be created (root directory with insufficient permissions)
     $filePath = '/root/boost_test/test.md';

--- a/tests/Unit/Install/GuidelineWriterTest.php
+++ b/tests/Unit/Install/GuidelineWriterTest.php
@@ -37,11 +37,14 @@ test('it creates directory when it does not exist', function (): void {
     rmdir($tempDir);
 });
 
-test('it leaves blank lines inside fenced code blocks alone when normalizing', function (): void {
+test('it leaves existing user content untouched', function (): void {
     $tempFile = tempnam(sys_get_temp_dir(), 'boost_test_');
 
+    // A prose ``` run desynchronises naive fence pairing, and PEP 8 wants two blank lines here.
     $userContent = <<<'MD'
     # My Project
+
+    Use ``` to open a fence.
 
     ```python
     def first():
@@ -51,6 +54,9 @@ test('it leaves blank lines inside fenced code blocks alone when normalizing', f
     def second():
         pass
     ```
+
+
+    Notes above keep their spacing too.
     MD;
 
     file_put_contents($tempFile, $userContent);
@@ -63,9 +69,7 @@ test('it leaves blank lines inside fenced code blocks alone when normalizing', f
     $writer = new GuidelineWriter($agent);
     $writer->write('boost guidelines');
 
-    $written = file_get_contents($tempFile);
-
-    expect($written)->toContain("def first():\n    pass\n\n\ndef second():")
+    expect((string) file_get_contents($tempFile))->toStartWith($userContent)
         ->toContain('boost guidelines');
 
     unlink($tempFile);

--- a/tests/Unit/Install/GuidelineWriterTest.php
+++ b/tests/Unit/Install/GuidelineWriterTest.php
@@ -75,6 +75,40 @@ test('it leaves existing user content untouched', function (): void {
     unlink($tempFile);
 });
 
+test('it leaves user content around an existing block untouched when replacing', function (): void {
+    $tempFile = tempnam(sys_get_temp_dir(), 'boost_test_');
+
+    // The replace path runs on every boost:update, and PEP 8 wants two blank lines here.
+    $trailingContent = <<<'MD'
+
+
+        ```python
+        def first():
+            pass
+
+
+        def second():
+            pass
+        ```
+        MD;
+
+    file_put_contents($tempFile, "# My Project\n\n<laravel-boost-guidelines>\nold guidelines\n</laravel-boost-guidelines>".$trailingContent);
+
+    $agent = Mockery::mock(SupportsGuidelines::class);
+    $agent->shouldReceive('guidelinesPath')->andReturn($tempFile);
+    $agent->shouldReceive('frontmatter')->andReturn(false);
+    $agent->shouldReceive('transformGuidelines')->andReturnUsing(fn ($markdown) => $markdown);
+
+    $writer = new GuidelineWriter($agent);
+    $writer->write('updated guidelines');
+
+    expect((string) file_get_contents($tempFile))->toStartWith('# My Project')
+        ->toContain('updated guidelines')
+        ->toContain($trailingContent);
+
+    unlink($tempFile);
+});
+
 test('it throws exception when directory creation fails', function (): void {
     // Use a path that cannot be created (root directory with insufficient permissions)
     $filePath = '/root/boost_test/test.md';


### PR DESCRIPTION
`GuidelineWriter::write` ran `preg_replace("/\n{3,}/", "\n\n")` over the **whole target file**, not just the `<laravel-boost-guidelines>` block. Every byte of your hand-written `AGENTS.md`/`CLAUDE.md` got reformatted on every `boost:install` and `boost:update`, leaving a diff you never asked for. Boost was rewriting a file section it does not own.

The most visible casualty is fenced code: a sample with a deliberate double blank line (PEP 8 mandates two between top-level defs) gets silently squeezed. But the fence case is the symptom, not the bug.

## The fix

Delete the normalization instead of making it fence-aware. The Boost block is already normalized upstream:

```
GuidelineComposer::compose() -> MarkdownFormatter::format() -> /\n{3,}/ -> "\n\n"
                                        |
                                GuidelineWriter::write()   <- second squeeze, pure collateral damage
```

The writer's pass only ever touched content it had no claim to, so it goes away. `MarkdownFormatter` (fixed in #961) remains the single place blank lines are normalized, and it only sees content Boost is assembling.

Also extracts the fence-masking regex that #961 added into `Laravel\Boost\Support\Fences`, since `MarkdownFormatter` and `RendersBladeGuidelines` had copy-pasted it. After this PR there is exactly one fence-unaware normalizer left in `src/`, and it runs inside the mask.

## Behavior change

Files that already accumulated triple newlines from older Boost versions keep them. That is intentional: it is not our file.

Two things Boost still normalizes, both deliberate: `MarkdownFormatter` collapses blank lines in user `.ai/guidelines/*.md` prose outside fences (Boost is assembling that into its own block), and the writer still `rtrim()`s the file before appending its `===` separator.

## Tests

Two regression tests, both failing on main:

- append path (no existing block) - a user file with a Python fence and a prose ``` run survives byte for byte
- replace path (existing block) - the one that runs on every `boost:update`, and the one the old squeeze hit repeatedly

Re-file of #975, reviewed and re-tested individually.