### PR TITLE
Fix entity decoding in fenced code blocks

### DIFF
--- a/src/Concerns/RendersBladeGuidelines.php
+++ b/src/Concerns/RendersBladeGuidelines.php
@@ -51,9 +51,42 @@ trait RendersBladeGuidelines
             return '';
         }
 
+        $rendered = str_replace(
+            $placeholders['`'],
+            '`',
+            $rendered,
+        );
+
+        $fencedCodeBlocks = [];
+
+        $rendered = preg_replace_callback(
+            '/(?<fence>`{3,}|~{3,}).*?\k<fence>/s',
+            function (array $matches) use (&$fencedCodeBlocks): string {
+                $placeholder = '___FENCED_CODE_BLOCK_'.count($fencedCodeBlocks).'___';
+
+                $fencedCodeBlocks[$placeholder] = $matches[0];
+
+                return $placeholder;
+            },
+            $rendered,
+        );
+
         $rendered = html_entity_decode($rendered, ENT_QUOTES | ENT_HTML5);
 
-        return str_replace(array_values($placeholders), array_keys($placeholders), $rendered);
+        $rendered = str_replace(
+            array_keys($fencedCodeBlocks),
+            array_values($fencedCodeBlocks),
+            $rendered,
+        );
+
+        $remainingPlaceholders = $placeholders;
+        unset($remainingPlaceholders['`']);
+
+        return str_replace(
+            array_values($remainingPlaceholders),
+            array_keys($remainingPlaceholders),
+            $rendered,
+        );
     }
 
     protected function processBoostSnippets(string $content): string

--- a/src/Concerns/RendersBladeGuidelines.php
+++ b/src/Concerns/RendersBladeGuidelines.php
@@ -36,6 +36,13 @@ trait RendersBladeGuidelines
             '<x-' => '___BLADE_COMPONENT_OPEN___',
         ];
 
+        // Hiding literal ampersands in fenced code before rendering leaves only Blade's own escaping to decode.
+        $content = preg_replace_callback(
+            '/(?<fence>`{3,}|~{3,}).*?\k<fence>/s',
+            fn (array $matches): string => str_replace('&', '___AMPERSAND___', $matches[0]),
+            $content,
+        ) ?? $content;
+
         $content = str_replace(array_keys($placeholders), array_values($placeholders), $content);
 
         $rendered = rescue(
@@ -52,42 +59,10 @@ trait RendersBladeGuidelines
             return '';
         }
 
-        $rendered = str_replace(
-            $placeholders['`'],
-            '`',
-            $rendered,
-        );
-
-        $fencedCodeBlocks = [];
-
-        $rendered = preg_replace_callback(
-            '/(?<fence>`{3,}|~{3,}).*?\k<fence>/s',
-            function (array $matches) use (&$fencedCodeBlocks): string {
-                $placeholder = '___FENCED_CODE_BLOCK_'.count($fencedCodeBlocks).'___';
-
-                $fencedCodeBlocks[$placeholder] = $matches[0];
-
-                return $placeholder;
-            },
-            $rendered,
-        );
-
         $rendered = html_entity_decode($rendered, ENT_QUOTES | ENT_HTML5);
+        $rendered = str_replace('___AMPERSAND___', '&', $rendered);
 
-        $rendered = str_replace(
-            array_keys($fencedCodeBlocks),
-            array_values($fencedCodeBlocks),
-            $rendered,
-        );
-
-        $remainingPlaceholders = $placeholders;
-        unset($remainingPlaceholders['`']);
-
-        return str_replace(
-            array_values($remainingPlaceholders),
-            array_keys($remainingPlaceholders),
-            $rendered,
-        );
+        return str_replace(array_values($placeholders), array_keys($placeholders), $rendered);
     }
 
     protected function processBoostSnippets(string $content): string

--- a/tests/Fixtures/entities-in-code-blocks.blade.php
+++ b/tests/Fixtures/entities-in-code-blocks.blade.php
@@ -1,0 +1,9 @@
+```php
+$this->assertStringContainsString('&lt;script&gt;', $content);
+```
+
+Run {{ 'php artisan tinker --execute "User::count()"' }} to check.
+
+```bash
+php artisan tinker --execute {{ '"$a < $b && $c"' }}
+```

--- a/tests/Unit/Concerns/RendersBladeGuidelinesTest.php
+++ b/tests/Unit/Concerns/RendersBladeGuidelinesTest.php
@@ -158,6 +158,20 @@ test('all common html entities are decoded', function (): void {
         ->not->toContain('&gt;');
 });
 
+test('html entities inside fenced code blocks are preserved', function (): void {
+    $this->mock(GuidelineAssist::class);
+
+    $content = <<<'MARKDOWN'
+```php
+$this->assertStringContainsString('&lt;script&gt;', $content);
+```
+MARKDOWN;
+
+    $result = $this->renderer->render($content, '/path/to/guide.blade.php');
+
+    expect($result)->toBe($content);
+});
+
 test('renderBladeFile returns empty string for non-existent file', function (): void {
     $result = $this->renderer->renderFile('/non/existent/guideline.blade.php');
 

--- a/tests/Unit/Concerns/RendersBladeGuidelinesTest.php
+++ b/tests/Unit/Concerns/RendersBladeGuidelinesTest.php
@@ -158,7 +158,7 @@ test('all common html entities are decoded', function (): void {
         ->not->toContain('&gt;');
 });
 
-test('html entities inside fenced code blocks are preserved', function (): void {
+test('html entities written literally inside fenced code blocks are preserved', function (): void {
     $this->mock(GuidelineAssist::class);
 
     $content = <<<'MARKDOWN'
@@ -170,6 +170,34 @@ MARKDOWN;
     $result = $this->renderer->render($content, '/path/to/guide.blade.php');
 
     expect($result)->toBe($content);
+});
+
+test('html entities from blade expressions inside fenced code blocks are decoded', function (): void {
+    $this->mock(GuidelineAssist::class);
+
+    $content = <<<'MARKDOWN'
+```bash
+php artisan tinker --execute {{ '"$a < $b && $c"' }}
+```
+MARKDOWN;
+
+    $result = $this->renderer->render($content, '/path/to/guide.blade.php');
+
+    expect($result)->toContain('--execute "$a < $b && $c"')
+        ->not->toContain('&quot;')
+        ->not->toContain('&lt;')
+        ->not->toContain('&amp;');
+});
+
+test('renderBladeFile preserves literal entities while decoding blade output', function (): void {
+    $this->mock(GuidelineAssist::class);
+
+    $result = $this->renderer->renderFile(fixture('entities-in-code-blocks.blade.php'));
+
+    expect($result)
+        ->toContain("assertStringContainsString('&lt;script&gt;', \$content)")
+        ->toContain('Run php artisan tinker --execute "User::count()" to check.')
+        ->toContain('--execute "$a < $b && $c"');
 });
 
 test('renderBladeFile returns empty string for non-existent file', function (): void {


### PR DESCRIPTION
Fixes the entity-decoding portion of #992.

This change preserves HTML entities inside fenced code blocks while keeping the existing entity decoding behavior for Blade-rendered Markdown outside code fences.

It also adds a regression test covering the reported `<script>` escaping example.
