### PR TITLE
Declare search-docs read-only so agents in plan mode stop re-asking for it

### DIFF
--- a/src/Mcp/Tools/SearchDocs.php
+++ b/src/Mcp/Tools/SearchDocs.php
@@ -11,10 +11,12 @@ use Laravel\Boost\Concerns\MakesHttpRequests;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
 use Laravel\Roster\Package;
 use Laravel\Roster\ProjectManager;
 use Throwable;
 
+#[IsReadOnly]
 class SearchDocs extends Tool
 {
     use MakesHttpRequests;

--- a/tests/Feature/Mcp/Tools/SearchDocsTest.php
+++ b/tests/Feature/Mcp/Tools/SearchDocsTest.php
@@ -287,3 +287,9 @@ test('it sends the remaining queries as a list when some are filtered out', func
     Http::assertSent(fn ($request): bool => $request->data()['queries'] === ['middleware', 'routing']
         && str_contains($request->body(), '"queries":["middleware","routing"]'));
 });
+
+test('it advertises itself as a read-only tool', function (): void {
+    $tool = new SearchDocs(Mockery::mock(ProjectManager::class));
+
+    expect($tool->toArray()['annotations'])->toBe(['readOnlyHint' => true]);
+});


### PR DESCRIPTION
`search-docs` is the only pure read among Boost's tools that does not carry `#[IsReadOnly]`, so it advertises no `readOnlyHint` in `tools/list`. This PR adds the annotation, plus a test.

### The problem

Agent clients gate MCP tools on `readOnlyHint` while the user is planning. Claude Code forces an `ask` for any MCP tool not marked read-only when the session is in plan mode — and it resolves that ask *before* it consults the user's allow rules.

The effect is a permission prompt on **every** `search-docs` call in plan mode. The dialog still offers "Yes, and don't ask again", and choosing it writes the allow rule correctly to `.claude/settings.local.json`:

```json
{ "permissions": { "allow": ["mcp__laravel-boost__search-docs"] } }
```

…but that rule is never reached, so the prompt comes back on the next call, and the loop never ends. Since Boost's own guidelines tell the agent to reach for `search-docs` before most Laravel-ecosystem changes, this fires constantly during exactly the workflow plan mode exists for.

Current `tools/list` output — 8 of 10 tools are annotated, `search-docs` is the odd one out:

```
application-info     -> {"readOnlyHint": true}
browser-logs         -> {"readOnlyHint": true}
database-connections -> {"readOnlyHint": true}
database-query       -> {"readOnlyHint": true}
database-schema      -> {"readOnlyHint": true}
get-absolute-url     -> {"readOnlyHint": true}
last-error           -> {"readOnlyHint": true}
read-log-entries     -> {"readOnlyHint": true}
record-rule          -> {}
search-docs          -> {}
```

After this change `search-docs` reports `{"readOnlyHint": true}`, matching its siblings.

### Why this is safe

The annotation is simply accurate. `SearchDocs::handle()` issues one outbound HTTP request to the hosted docs API and returns the response; it writes nothing, touches no local state, and runs no user code. Nothing about the tool's behaviour changes — only the metadata it reports.

`record-rule` and `tinker` are deliberately left alone; both mutate.

### Tests

Added to `tests/Feature/Mcp/Tools/SearchDocsTest.php`:

```php
test('it advertises itself as a read-only tool', function (): void {
    $tool = new SearchDocs(Mockery::mock(ProjectManager::class));

    expect($tool->toArray()['annotations'])->toBe(['readOnlyHint' => true]);
});
```

Verified it fails on `main` and passes with the annotation. Full suite passes locally: 1038 passed, 10 skipped, 1 todo. Pint clean.
