### PR TITLE
Align action examples to use handle()

### DIFF
--- a/.ai/laravel/skill/laravel-best-practices/rules/routing.md
+++ b/.ai/laravel/skill/laravel-best-practices/rules/routing.md
@@ -97,7 +97,7 @@ Controllers should coordinate HTTP input, authorization, validation, an applicat
 ```php
 public function store(StorePostRequest $request, CreatePostAction $create): RedirectResponse
 {
-    $post = $create->execute($request->validated());
+    $post = $create->handle($request->validated());
 
     return redirect()->route('posts.show', $post);
 }


### PR DESCRIPTION
The `architecture.md` rule defines the example action with `handle()`, but `routing.md` still calls `$create->execute(...)`. This PR aligns `routing.md` with `handle()` so both rules describe the same convention.