### PR TITLE
Remove deprecated Rector skips

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -2,10 +2,8 @@
 
 declare(strict_types=1);
 
-use Rector\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector;
 use Rector\Config\RectorConfig;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
-use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -14,8 +12,6 @@ return RectorConfig::configure()
     ])
     ->withSkip([
         ReadOnlyPropertyRector::class,
-        EncapsedStringsToSprintfRector::class,
-        DisallowedEmptyRuleFixerRector::class,
     ])
     ->withPreparedSets(
         deadCode: true,


### PR DESCRIPTION
Remove two deprecated/unregistered Rector rules from withSkip():

EncapsedStringsToSprintfRector

DisallowedEmptyRuleFixerRector

These skipped rules are no longer registered by Rector, so keeping them in the config causes lint warnings without changing behavior.

Verification

composer test:types passes

composer test:lint no longer reports deprecated/unregistered Rector skip warnings

composer test:lint still exits with code 2 because Rector dry-run reports pre-existing unrelated style changes in 5 files