### PR TITLE
Add zcode agent support

### DIFF
--- a/src/BoostManager.php
+++ b/src/BoostManager.php
@@ -18,6 +18,7 @@ use Laravel\Boost\Install\Agents\Junie;
 use Laravel\Boost\Install\Agents\Kiro;
 use Laravel\Boost\Install\Agents\OpenCode;
 use Laravel\Boost\Install\Agents\Pi;
+use Laravel\Boost\Install\Agents\ZCode;
 use Laravel\Boost\Install\Agents\Zed;
 
 class BoostManager
@@ -36,6 +37,7 @@ class BoostManager
         'kiro' => Kiro::class,
         'opencode' => OpenCode::class,
         'pi' => Pi::class,
+        'zcode' => ZCode::class,
         'zed' => Zed::class,
     ];
 

--- a/src/Install/Agents/Agent.php
+++ b/src/Install/Agents/Agent.php
@@ -113,7 +113,8 @@ abstract class Agent
         return false;
     }
 
-    public function mcpConfigKey(): string
+    /** @return string|array<int, string> */
+    public function mcpConfigKey(): string|array
     {
         return 'mcpServers';
     }

--- a/src/Install/Agents/Amp.php
+++ b/src/Install/Agents/Amp.php
@@ -47,9 +47,10 @@ class Amp extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSkil
         return config('boost.agents.amp.mcp_config_path', base_path('.amp/settings.json'));
     }
 
-    public function mcpConfigKey(): string
+    /** {@inheritDoc} */
+    public function mcpConfigKey(): array
     {
-        return 'amp.mcpServers';
+        return ['amp.mcpServers'];
     }
 
     /** {@inheritDoc} */

--- a/src/Install/Agents/ZCode.php
+++ b/src/Install/Agents/ZCode.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laravel\Boost\Install\Agents;
+
+use Laravel\Boost\Contracts\SupportsGuidelines;
+use Laravel\Boost\Contracts\SupportsMcp;
+use Laravel\Boost\Contracts\SupportsSkills;
+use Laravel\Boost\Install\Enums\McpInstallationStrategy;
+use Laravel\Boost\Install\Enums\Platform;
+
+class ZCode extends Agent implements SupportsGuidelines, SupportsMcp, SupportsSkills
+{
+    public function name(): string
+    {
+        return 'zcode';
+    }
+
+    public function displayName(): string
+    {
+        return 'ZCode';
+    }
+
+    public function systemDetectionConfig(Platform $platform): array
+    {
+        return match ($platform) {
+            Platform::Darwin, Platform::Linux => [
+                'paths' => ['~/.zcode'],
+            ],
+            Platform::Windows => [
+                'paths' => ['%USERPROFILE%\\.zcode'],
+            ],
+        };
+    }
+
+    public function projectDetectionConfig(): array
+    {
+        return [
+            'paths' => ['.zcode'],
+            'files' => ['.zcode/config.json'],
+        ];
+    }
+
+    public function guidelinesPath(): string
+    {
+        return config('boost.agents.zcode.guidelines_path', 'AGENTS.md');
+    }
+
+    public function mcpInstallationStrategy(): McpInstallationStrategy
+    {
+        return McpInstallationStrategy::FILE;
+    }
+
+    public function mcpConfigPath(): string
+    {
+        return config('boost.agents.zcode.mcp_config_path', '.zcode/config.json');
+    }
+
+    public function mcpConfigKey(): string
+    {
+        return 'mcp.servers';
+    }
+
+    public function skillsPath(): string
+    {
+        return config('boost.agents.zcode.skills_path', '.zcode/skills');
+    }
+}

--- a/src/Install/Mcp/FileWriter.php
+++ b/src/Install/Mcp/FileWriter.php
@@ -10,7 +10,8 @@ use stdClass;
 
 class FileWriter
 {
-    protected string $configKey = 'mcpServers';
+    /** @var string|array<int, string> */
+    protected string|array $configKey = 'mcpServers';
 
     protected array $serversToAdd = [];
 
@@ -21,11 +22,22 @@ class FileWriter
         //
     }
 
-    public function configKey(string $key): self
+    /**
+     * @param  string|array<int, string>  $key
+     */
+    public function configKey(string|array $key): self
     {
         $this->configKey = $key;
 
         return $this;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function configKeySegments(): array
+    {
+        return is_array($this->configKey) ? $this->configKey : explode('.', $this->configKey);
     }
 
     /**
@@ -91,34 +103,38 @@ class FileWriter
 
     protected function updateJson5File(string $content): bool
     {
-        $configKeyPattern = '/["\']'.preg_quote($this->configKey, '/').'["\']\\s*:\\s*\\{/';
+        $segments = $this->configKeySegments();
+        $openBracePos = null;
+        $closeBracePos = null;
 
-        if (preg_match($configKeyPattern, $content, $matches, PREG_OFFSET_CAPTURE)) {
-            return $this->injectIntoExistingConfigKey($content, $matches);
+        // Walk the configKey one segment at a time, narrowing to each segment's braces
+        foreach ($segments as $index => $segment) {
+            $segmentPattern = '/["\']'.preg_quote($segment, '/').'["\']\\s*:\\s*\\{/';
+            $searchPos = $openBracePos === null ? 0 : $openBracePos + 1;
+
+            if (! preg_match($segmentPattern, $content, $matches, PREG_OFFSET_CAPTURE, $searchPos)
+                || ($closeBracePos !== null && $matches[0][1] >= $closeBracePos)) {
+                return $this->injectNewConfigKey($content, $openBracePos, array_slice($segments, $index));
+            }
+
+            $openBracePos = strpos($content, '{', $matches[0][1]);
+
+            if ($openBracePos === false) {
+                return false;
+            }
+
+            $closeBracePos = $this->findMatchingClosingBrace($content, $openBracePos);
+
+            if ($closeBracePos === false) {
+                return false;
+            }
         }
 
-        return $this->injectNewConfigKey($content);
+        return $this->injectIntoExistingConfigKey($content, $openBracePos, $closeBracePos);
     }
 
-    protected function injectIntoExistingConfigKey(string $content, array $matches): bool
+    protected function injectIntoExistingConfigKey(string $content, int $openBracePos, int $closeBracePos): bool
     {
-        // $matches[0][1] contains the position of the configKey pattern match
-        $configKeyStart = $matches[0][1];
-
-        // Find the opening brace of the configKey object
-        $openBracePos = strpos($content, '{', $configKeyStart);
-
-        if ($openBracePos === false) {
-            return false;
-        }
-
-        // Find the matching closing brace for this configKey object
-        $closeBracePos = $this->findMatchingClosingBrace($content, $openBracePos);
-
-        if ($closeBracePos === false) {
-            return false;
-        }
-
         // Filter out servers that already exist
         $serversToAdd = $this->filterExistingServers($content, $openBracePos, $closeBracePos);
 
@@ -187,9 +203,12 @@ class FileWriter
         return preg_match($quotedPattern, $content) || preg_match($unquotedPattern, $content);
     }
 
-    protected function injectNewConfigKey(string $content): bool
+    /**
+     * @param  array<int, string>  $segments
+     */
+    protected function injectNewConfigKey(string $content, ?int $openBracePos, array $segments): bool
     {
-        $openBracePos = strpos($content, '{');
+        $openBracePos ??= strpos($content, '{');
 
         if ($openBracePos === false) {
             return false;
@@ -201,8 +220,11 @@ class FileWriter
             $serverJsonParts[] = $this->generateServerJson($key, $serverConfig);
         }
 
-        $serversJson = implode(',', $serverJsonParts);
-        $configKeySection = '"'.$this->configKey.'": {'.$serversJson.'}';
+        $configKeySection = implode(',', $serverJsonParts);
+
+        foreach (array_reverse($segments) as $segment) {
+            $configKeySection = '"'.$segment.'": {'.$configKeySection.'}';
+        }
 
         $needsComma = $this->needsCommaAfterBrace($content, $openBracePos);
         $injection = $configKeySection.($needsComma ? ',' : '');
@@ -424,12 +446,18 @@ class FileWriter
             $config = (object) $config;
         }
 
-        if (! isset($config->{$this->configKey}) || ! is_object($config->{$this->configKey})) {
-            $config->{$this->configKey} = new stdClass;
+        $target = $config;
+
+        foreach ($this->configKeySegments() as $segment) {
+            if (! isset($target->{$segment}) || ! is_object($target->{$segment})) {
+                $target->{$segment} = new stdClass;
+            }
+
+            $target = $target->{$segment};
         }
 
         foreach ($this->serversToAdd as $key => $serverConfig) {
-            $config->{$this->configKey}->{$key} = $serverConfig;
+            $target->{$key} = $serverConfig;
         }
     }
 

--- a/src/Install/Mcp/TomlFileWriter.php
+++ b/src/Install/Mcp/TomlFileWriter.php
@@ -19,9 +19,10 @@ class TomlFileWriter
         //
     }
 
-    public function configKey(string $key): self
+    /** @param string|array<int, string> $key */
+    public function configKey(string|array $key): self
     {
-        $this->configKey = $key;
+        $this->configKey = is_array($key) ? implode('.', $key) : $key;
 
         return $this;
     }

--- a/tests/Unit/BoostManagerTest.php
+++ b/tests/Unit/BoostManagerTest.php
@@ -15,6 +15,7 @@ use Laravel\Boost\Install\Agents\Junie;
 use Laravel\Boost\Install\Agents\Kiro;
 use Laravel\Boost\Install\Agents\OpenCode;
 use Laravel\Boost\Install\Agents\Pi;
+use Laravel\Boost\Install\Agents\ZCode;
 use Laravel\Boost\Install\Agents\Zed;
 use Tests\Unit\Install\ExampleAgent;
 
@@ -36,6 +37,7 @@ it('returns default agents', function (): void {
         'zed' => Zed::class,
         'pi' => Pi::class,
         'grok_build' => GrokBuild::class,
+        'zcode' => ZCode::class,
     ]);
 });
 
@@ -44,7 +46,7 @@ it('returns agents sorted alphabetically by key', function (): void {
     $manager->registerAgent('boostbot', ExampleAgent::class);
 
     expect(array_keys($manager->getAgents()))->toBe([
-        'amp', 'antigravity', 'boostbot', 'claude_code', 'codex', 'copilot', 'cursor', 'factory', 'grok_build', 'junie', 'kiro', 'opencode', 'pi', 'zed',
+        'amp', 'antigravity', 'boostbot', 'claude_code', 'codex', 'copilot', 'cursor', 'factory', 'grok_build', 'junie', 'kiro', 'opencode', 'pi', 'zcode', 'zed',
     ]);
 });
 

--- a/tests/Unit/Install/Agents/ZCodeTest.php
+++ b/tests/Unit/Install/Agents/ZCodeTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Install\Agents;
+
+use Illuminate\Support\Facades\File;
+use Laravel\Boost\Install\Agents\ZCode;
+use Laravel\Boost\Install\Detection\DetectionStrategyFactory;
+use Laravel\Boost\Install\Enums\McpInstallationStrategy;
+use Laravel\Boost\Install\Enums\Platform;
+use Mockery;
+
+beforeEach(function (): void {
+    $this->strategyFactory = Mockery::mock(DetectionStrategyFactory::class);
+});
+
+test('returns correct name', function (): void {
+    $agent = new ZCode($this->strategyFactory);
+
+    expect($agent->name())->toBe('zcode');
+});
+
+test('returns correct display name', function (): void {
+    $agent = new ZCode($this->strategyFactory);
+
+    expect($agent->displayName())->toBe('ZCode');
+});
+
+test('uses FILE-based MCP installation strategy', function (): void {
+    $agent = new ZCode($this->strategyFactory);
+
+    expect($agent->mcpInstallationStrategy())->toBe(McpInstallationStrategy::FILE);
+});
+
+test('returns correct MCP config path', function (): void {
+    $agent = new ZCode($this->strategyFactory);
+
+    expect($agent->mcpConfigPath())->toBe('.zcode/config.json');
+});
+
+test('returns configured MCP config path', function (): void {
+    config()->set('boost.agents.zcode.mcp_config_path', '.custom/zcode.json');
+
+    $agent = new ZCode($this->strategyFactory);
+
+    expect($agent->mcpConfigPath())->toBe('.custom/zcode.json');
+});
+
+test('returns correct MCP config key', function (): void {
+    $agent = new ZCode($this->strategyFactory);
+
+    expect($agent->mcpConfigKey())->toBe('mcp.servers');
+});
+
+test('builds MCP server config with empty env', function (): void {
+    $agent = new ZCode($this->strategyFactory);
+
+    $config = $agent->mcpServerConfig('php', ['artisan', 'boost:mcp']);
+
+    expect($config)->toBe([
+        'command' => 'php',
+        'args' => ['artisan', 'boost:mcp'],
+        'env' => [],
+    ]);
+});
+
+test('builds MCP server config with env when provided', function (): void {
+    $agent = new ZCode($this->strategyFactory);
+
+    $config = $agent->mcpServerConfig('php', ['artisan'], ['APP_ENV' => 'local']);
+
+    expect($config)->toBe([
+        'command' => 'php',
+        'args' => ['artisan'],
+        'env' => ['APP_ENV' => 'local'],
+    ]);
+});
+
+test('httpMcpServerConfig returns type and url config', function (): void {
+    $agent = new ZCode($this->strategyFactory);
+
+    expect($agent->httpMcpServerConfig('https://nightwatch.laravel.com/mcp'))->toBe([
+        'type' => 'http',
+        'url' => 'https://nightwatch.laravel.com/mcp',
+    ]);
+});
+
+test('projectDetectionConfig only uses .zcode dir and config.json', function (): void {
+    $agent = new ZCode($this->strategyFactory);
+
+    expect($agent->projectDetectionConfig())->toBe([
+        'paths' => ['.zcode'],
+        'files' => ['.zcode/config.json'],
+    ]);
+});
+
+test('detectInProject returns false when only AGENTS.md exists', function (): void {
+    $agent = new ZCode(new DetectionStrategyFactory(app()));
+    $tempDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'boost_zcode_'.uniqid();
+    mkdir($tempDir);
+    touch($tempDir.DIRECTORY_SEPARATOR.'AGENTS.md');
+
+    try {
+        expect($agent->detectInProject($tempDir))->toBeFalse();
+    } finally {
+        unlink($tempDir.DIRECTORY_SEPARATOR.'AGENTS.md');
+        rmdir($tempDir);
+    }
+});
+
+test('returns correct guidelines path', function (): void {
+    $agent = new ZCode($this->strategyFactory);
+
+    expect($agent->guidelinesPath())->toBe('AGENTS.md');
+});
+
+test('returns configured guidelines path', function (): void {
+    config()->set('boost.agents.zcode.guidelines_path', '.custom/AGENTS.md');
+
+    $agent = new ZCode($this->strategyFactory);
+
+    expect($agent->guidelinesPath())->toBe('.custom/AGENTS.md');
+});
+
+test('returns correct skills path', function (): void {
+    $agent = new ZCode($this->strategyFactory);
+
+    expect($agent->skillsPath())->toBe('.zcode/skills');
+});
+
+test('returns configured skills path', function (): void {
+    config()->set('boost.agents.zcode.skills_path', '.custom/skills');
+
+    $agent = new ZCode($this->strategyFactory);
+
+    expect($agent->skillsPath())->toBe('.custom/skills');
+});
+
+test('system detection uses ~/.zcode on Darwin', function (): void {
+    $agent = new ZCode($this->strategyFactory);
+
+    expect($agent->systemDetectionConfig(Platform::Darwin))->toBe([
+        'paths' => ['~/.zcode'],
+    ]);
+});
+
+test('system detection uses ~/.zcode on Linux', function (): void {
+    $agent = new ZCode($this->strategyFactory);
+
+    expect($agent->systemDetectionConfig(Platform::Linux))->toBe([
+        'paths' => ['~/.zcode'],
+    ]);
+});
+
+test('system detection uses USERPROFILE on Windows', function (): void {
+    $agent = new ZCode($this->strategyFactory);
+
+    expect($agent->systemDetectionConfig(Platform::Windows))->toBe([
+        'paths' => ['%USERPROFILE%\\.zcode'],
+    ]);
+});
+
+test('installMcp creates nested JSON config file', function (): void {
+    $agent = new ZCode($this->strategyFactory);
+    $capturedContent = '';
+
+    File::shouldReceive('ensureDirectoryExists')
+        ->once()
+        ->with('.zcode');
+
+    File::shouldReceive('exists')
+        ->once()
+        ->with('.zcode/config.json')
+        ->andReturn(false);
+
+    File::shouldReceive('put')
+        ->once()
+        ->with(Mockery::any(), Mockery::capture($capturedContent))
+        ->andReturn(true);
+
+    $result = $agent->installMcp('laravel-boost', 'php', ['artisan', 'boost:mcp']);
+
+    $decoded = json_decode((string) $capturedContent, true);
+
+    expect($result)->toBeTrue()
+        ->and($decoded['mcp']['servers']['laravel-boost']['command'])->toBe('php')
+        ->and($decoded['mcp']['servers']['laravel-boost']['args'])->toBe(['artisan', 'boost:mcp']);
+});

--- a/tests/Unit/Install/AgentsDetectorTest.php
+++ b/tests/Unit/Install/AgentsDetectorTest.php
@@ -18,6 +18,7 @@ use Laravel\Boost\Install\Agents\Junie;
 use Laravel\Boost\Install\Agents\Kiro;
 use Laravel\Boost\Install\Agents\OpenCode;
 use Laravel\Boost\Install\Agents\Pi;
+use Laravel\Boost\Install\Agents\ZCode;
 use Laravel\Boost\Install\Agents\Zed;
 use Laravel\Boost\Install\AgentsDetector;
 use Laravel\Boost\Install\Enums\Platform;
@@ -36,9 +37,9 @@ it('returns collection of all registered agents', function (): void {
     $agents = $this->detector->getAgents();
 
     expect($agents)->toBeInstanceOf(Collection::class)
-        ->and($agents->count())->toBe(13)
+        ->and($agents->count())->toBe(14)
         ->and($agents->keys()->toArray())->toBe([
-            'amp', 'antigravity', 'claude_code', 'codex', 'copilot', 'cursor', 'factory', 'grok_build', 'junie', 'kiro', 'opencode', 'pi', 'zed',
+            'amp', 'antigravity', 'claude_code', 'codex', 'copilot', 'cursor', 'factory', 'grok_build', 'junie', 'kiro', 'opencode', 'pi', 'zcode', 'zed',
         ]);
 
     $agents->each(function ($agent): void {
@@ -72,6 +73,7 @@ it('returns an array of detected agents names for system discovery', function ()
     $this->container->bind(Zed::class, fn () => $mockOther);
     $this->container->bind(Pi::class, fn () => $mockOther);
     $this->container->bind(GrokBuild::class, fn () => $mockOther);
+    $this->container->bind(ZCode::class, fn () => $mockOther);
 
     $detector = new AgentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverSystemInstalledAgents();
@@ -97,6 +99,7 @@ it('returns an empty array when no agents are detected for system discovery', fu
     $this->container->bind(Zed::class, fn () => $mockAgent);
     $this->container->bind(Pi::class, fn () => $mockAgent);
     $this->container->bind(GrokBuild::class, fn () => $mockAgent);
+    $this->container->bind(ZCode::class, fn () => $mockAgent);
 
     $detector = new AgentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverSystemInstalledAgents();
@@ -132,6 +135,7 @@ it('returns an array of detected agent names for project discovery', function ()
     $this->container->bind(Zed::class, fn () => $mockOther);
     $this->container->bind(Pi::class, fn () => $mockOther);
     $this->container->bind(GrokBuild::class, fn () => $mockOther);
+    $this->container->bind(ZCode::class, fn () => $mockOther);
 
     $detector = new AgentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverProjectInstalledAgents($basePath);
@@ -159,6 +163,7 @@ it('returns an empty array when no agents are detected for project discovery', f
     $this->container->bind(Zed::class, fn () => $mockAgent);
     $this->container->bind(Pi::class, fn () => $mockAgent);
     $this->container->bind(GrokBuild::class, fn () => $mockAgent);
+    $this->container->bind(ZCode::class, fn () => $mockAgent);
 
     $detector = new AgentsDetector($this->container, $this->boostManager);
     $detected = $detector->discoverProjectInstalledAgents($basePath);

--- a/tests/Unit/Install/Mcp/FileWriterTest.php
+++ b/tests/Unit/Install/Mcp/FileWriterTest.php
@@ -45,7 +45,7 @@ test('save method returns boolean', function (): void {
     expect($result)->toBe(true);
 });
 
-test('written data is correct for brand new file', function (string $configKey, array $servers, string $expectedJson): void {
+test('written data is correct for brand new file', function (string|array $configKey, array $servers, string $expectedJson): void {
     $writtenPath = '';
     $writtenContent = '';
     mockFileOperations(capturedPath: $writtenPath, capturedContent: $writtenContent);
@@ -615,6 +615,149 @@ test('updated JSON5 file ends with a single trailing newline', function (): void
     expect($writtenContent)->not->toEndWith("\n\n");
 });
 
+test('updates existing nested config key in plain JSON preserving siblings', function (): void {
+    $writtenContent = '';
+    $content = <<<'JSON'
+    {
+        "mcp": {
+            "theme": "dark",
+            "servers": {
+                "existing": {
+                    "command": "node"
+                }
+            }
+        }
+    }
+    JSON;
+
+    mockFileOperations(
+        fileExists: true,
+        content: $content,
+        capturedContent: $writtenContent
+    );
+
+    File::shouldReceive('size')->andReturn(200);
+
+    $result = (new FileWriter('/path/to/config.json'))
+        ->configKey('mcp.servers')
+        ->addServerConfig('boost', [
+            'command' => 'php',
+            'args' => ['artisan', 'boost:mcp'],
+        ])
+        ->save();
+
+    $decoded = json_decode((string) $writtenContent, true);
+
+    expect($result)->toBeTrue()
+        ->and($decoded['mcp']['theme'])->toBe('dark')
+        ->and($decoded['mcp']['servers']['existing']['command'])->toBe('node')
+        ->and($decoded['mcp']['servers']['boost']['command'])->toBe('php');
+});
+
+test('injects into existing nested config key in JSON5 without duplicating existing servers', function (): void {
+    $writtenContent = '';
+    $content = <<<'JSON5'
+    {
+        // ZCode project config
+        "mcp": {
+            "servers": {
+                "existing": {
+                    "command": "node"
+                }
+            }
+        }
+    }
+    JSON5;
+
+    mockFileOperations(
+        fileExists: true,
+        content: $content,
+        capturedContent: $writtenContent
+    );
+
+    File::shouldReceive('size')->andReturn(200);
+
+    $result = (new FileWriter('/path/to/config.json'))
+        ->configKey('mcp.servers')
+        ->addServerConfig('existing', ['command' => 'node'])
+        ->addServerConfig('boost', [
+            'command' => 'php',
+            'args' => ['artisan', 'boost:mcp'],
+        ])
+        ->save();
+
+    expect($result)->toBeTrue()
+        ->and(substr_count($writtenContent, '"existing"'))->toBe(1)
+        ->and($writtenContent)->toContain(
+            '"boost"', // New server added
+            '// ZCode project config' // Comments preserved
+        );
+});
+
+test('injects missing nested segment into existing parent key in JSON5', function (): void {
+    $writtenContent = '';
+    $content = <<<'JSON5'
+    {
+        // ZCode project config
+        "mcp": {
+            "theme": "dark"
+        }
+    }
+    JSON5;
+
+    mockFileOperations(
+        fileExists: true,
+        content: $content,
+        capturedContent: $writtenContent
+    );
+
+    File::shouldReceive('size')->andReturn(200);
+
+    $result = (new FileWriter('/path/to/config.json'))
+        ->configKey('mcp.servers')
+        ->addServerConfig('boost', ['command' => 'php'])
+        ->save();
+
+    $withoutComments = preg_replace('/\/\/[^\n]*/', '', $writtenContent);
+    $decoded = json_decode((string) $withoutComments, true);
+
+    expect($result)->toBeTrue()
+        ->and($decoded['mcp']['theme'])->toBe('dark')
+        ->and($decoded['mcp']['servers']['boost']['command'])->toBe('php')
+        ->and($writtenContent)->toContain('// ZCode project config');
+});
+
+test('injects full nested config key into JSON5 without it', function (): void {
+    $writtenContent = '';
+    $content = <<<'JSON5'
+    {
+        // ZCode project config
+        "permissions": {}
+    }
+    JSON5;
+
+    mockFileOperations(
+        fileExists: true,
+        content: $content,
+        capturedContent: $writtenContent
+    );
+
+    File::shouldReceive('size')->andReturn(200);
+
+    $result = (new FileWriter('/path/to/config.json'))
+        ->configKey('mcp.servers')
+        ->addServerConfig('boost', ['command' => 'php'])
+        ->save();
+
+    $withoutComments = preg_replace('/\/\/[^\n]*/', '', $writtenContent);
+    $decoded = json_decode((string) $withoutComments, true);
+
+    expect($result)->toBeTrue()
+        ->and($decoded['mcp']['servers']['boost']['command'])->toBe('php')
+        ->and($decoded['permissions'])->toBe([])
+        ->and($writtenContent)->toContain('// ZCode project config');
+});
+
 function mockFileOperations(bool $fileExists = false, string $content = '{}', bool $writeSuccess = true, ?string &$capturedPath = null, ?string &$capturedContent = null): void
 {
     // Clear any existing File facade mock
@@ -692,6 +835,23 @@ function newFileServerConfigurations(): array
                 'test' => ['command' => 'test-cmd'],
             ],
             '{"customKey":{"test":{"command":"test-cmd"}}}',
+        ],
+        'array config key keeps literal dots' => [
+            ['amp.mcpServers'],
+            [
+                'test' => ['command' => 'test-cmd'],
+            ],
+            '{"amp.mcpServers":{"test":{"command":"test-cmd"}}}',
+        ],
+        'nested dot-notation config key' => [
+            'mcp.servers',
+            [
+                'boost' => [
+                    'command' => 'php',
+                    'args' => ['artisan', 'boost:mcp'],
+                ],
+            ],
+            '{"mcp":{"servers":{"boost":{"command":"php","args":["artisan","boost:mcp"]}}}}',
         ],
     ];
 }


### PR DESCRIPTION
This is a 2 part PR to add support for nested config keys as common pattern, and registers ZCode agent support.

**1/2 — Nested config keys**

Config keys may use dot notation `mcp.servers` to address nested objects, matching `data_get()`. Keys with a literal dot are passed as an array of segments instead. The JSON and JSON5 writers create any missing segments and preserve sibling keys. Amp's `amp.mcpServers` now uses this; its written output is unchanged for compat.

**2/2 — ZCode agent**

Registers ZCode for boost:install:

- Detection: global `~/.zcode`, or a project `.zcode/` directory or config file
- `AGENTS.md`: writes agent guidelines on install
- Skills: installs to `.zcode/skills`
- MCP: writes servers to `.zcode/config.json`, nested at `mcp.servers`