### PR TITLE
Remove deprecated early return Rector set

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -18,5 +18,4 @@ return RectorConfig::configure()
         codeQuality: true,
         codingStyle: true,
         typeDeclarations: true,
-        earlyReturn: true,
     )->withPhpSets(php81: true);


### PR DESCRIPTION
The early return prepared set is deprecated and now empty because its rules have been moved to the code quality set or deprecated. Since the code quality set is already enabled, this removes the redundant configuration without changing behavior.