### PR TITLE
Use unlimited memory for PHPStan type checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
             "pint --test --format agent",
             "rector --dry-run"
         ],
-        "test:types": "phpstan",
+        "test:types": "phpstan --memory-limit=-1",
         "check": [
             "@composer lint",
             "@composer test"


### PR DESCRIPTION
The `lint` script already runs PHPStan with `--memory-limit=-1`, while the dedicated `test:types` script does not.

On environments using PHP's default 128 MB memory limit, `composer test:types` can fail because PHPStan's parallel workers run out of memory.

This change makes the dedicated type-checking script consistent with the existing lint command.