### PR TITLE
Remove redundant test lifecycle overrides

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,16 +19,6 @@ abstract class TestCase extends OrchestraTestCase
         $app->useStoragePath(realpath(__DIR__.'/../workbench/storage'));
     }
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-    }
-
     protected function getPackageProviders($app)
     {
         return [BoostServiceProvider::class];


### PR DESCRIPTION
The base test case overrides setUp() and tearDown() only to call their parent implementations.

Removing these pass-through methods preserves the existing lifecycle behavior while resolving the RemoveParentDelegatingClassMethodRector findings for this file.