### PR TITLE
Simplify Herd home path assignment

### DIFF
--- a/src/Install/Herd.php
+++ b/src/Install/Herd.php
@@ -20,9 +20,7 @@ class Herd
     public function getHomePath(): string
     {
         if ($this->isWindowsPlatform()) {
-            if (! isset($_SERVER['HOME'])) {
-                $_SERVER['HOME'] = $_SERVER['USERPROFILE'];
-            }
+            $_SERVER['HOME'] ??= $_SERVER['USERPROFILE'];
 
             $_SERVER['HOME'] = str_replace('\\', '/', $_SERVER['HOME']);
         }


### PR DESCRIPTION
Herd::getHomePath() currently uses an explicit isset check before falling back to USERPROFILE on Windows.

Using null coalescing assignment preserves the existing behavior for missing or null HOME values while resolving the IfToNullCoalescingAssignRector finding.