### PR TITLE
Drop the truncated leading fragment when the log chunk boundary lands inside an entry

### DIFF
--- a/src/Concerns/ReadsLogs.php
+++ b/src/Concerns/ReadsLogs.php
@@ -252,6 +252,10 @@ trait ReadsLogs
                 return [];
             }
 
+            if ($offset > 0 && preg_match('/^'.$this->getTimestampRegex().'/', $entries[0]) !== 1) {
+                array_shift($entries);
+            }
+
             return $entries; // already in chronological order relative to chunk
         } finally {
             fclose($handle);

--- a/tests/Feature/Mcp/Tools/ReadLogEntriesTest.php
+++ b/tests/Feature/Mcp/Tools/ReadLogEntriesTest.php
@@ -211,6 +211,36 @@ it('handles missing channel configuration gracefully', function (): void {
         ->toolTextContains('local.DEBUG: Fallback log');
 });
 
+it('does not serve a truncated entry when the chunk boundary lands inside a stack trace', function (): void {
+    $logFile = storage_path('logs'.DIRECTORY_SEPARATOR.'laravel.log');
+
+    Config::set('logging.default', 'single');
+    Config::set('logging.channels.single', [
+        'driver' => 'single',
+        'path' => $logFile,
+    ]);
+
+    $trace = implode("\n", array_map(
+        fn (int $i): string => "#{$i} /app/vendor/framework/src/Handler.php(42): padding trace frame for the boundary",
+        range(1, 900),
+    ));
+
+    createLogFile($logFile, implode("\n", [
+        '[2024-01-15 09:00:00] local.ERROR: Big exception',
+        $trace,
+        '[2024-01-15 10:00:00] local.INFO: First small entry',
+        '[2024-01-15 10:01:00] local.INFO: Second small entry',
+        '[2024-01-15 10:02:00] local.INFO: Third small entry',
+    ]));
+
+    $tool = new ReadLogEntries;
+    $response = $tool->handle(new Request(['entries' => 4]));
+
+    expect($response)->isToolResult()
+        ->toolHasNoError()
+        ->toolTextContains('local.ERROR: Big exception', 'Third small entry');
+});
+
 it('returns error when entries argument is invalid', function (): void {
     $tool = new ReadLogEntries;
 


### PR DESCRIPTION
scanLogChunkForEntries reads the last 64KB of the log and aligns to the next line, but entries span many lines, so when the boundary lands inside a stack trace the headerless tail gets counted as its own entry and read-log-entries serves it

real repro, a 75KB laravel.log with 6 ErrorException entries carrying 12KB traces, tool asked for 6 entries

first entry served on main, mid trace of the oldest entry, no header:

```
#28 vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/InvokeDeferredCallbacks.php(22)
#29 vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(219)
```

first entry served with this change:

```
[2026-09-08 09:00:31] local.ERROR: Undefined array key "data"
```

fix drops the leading piece when the read didnt start at byte 0 and it has no timestamp header, the existing chunk doubling then picks up the complete entry. new test fails on main
