### PR TITLE
Key nested user guidelines by relative path so same-named files stop overwriting each other

### DIFF
--- a/src/Install/GuidelineComposer.php
+++ b/src/Install/GuidelineComposer.php
@@ -149,12 +149,10 @@ class GuidelineComposer
      */
     protected function getUserGuidelines(): Collection
     {
-        $root = str_replace('\\', '/', (string) (realpath($this->customGuidelinePath()) ?: $this->customGuidelinePath()));
-
         return collect($this->guidelinesDir(
             $this->customGuidelinePath(),
             false,
-            fn (SplFileInfo $file): string => '.ai/'.$this->relativeGuidelineKey($root, $file->getRealPath()),
+            fn (SplFileInfo $file): string => '.ai/'.$this->relativeGuidelineKey($file),
         ));
     }
 
@@ -277,12 +275,10 @@ class GuidelineComposer
                 continue;
             }
 
-            $root = str_replace('\\', '/', (string) (realpath($path) ?: $path));
-
             $keyed = $this->guidelinesDir(
                 $path,
                 true,
-                fn (SplFileInfo $file): string => $package.'/'.$this->relativeGuidelineKey($root, $file->getRealPath()),
+                fn (SplFileInfo $file): string => $package.'/'.$this->relativeGuidelineKey($file),
             );
 
             foreach ($keyed as $key => $guideline) {
@@ -308,15 +304,13 @@ class GuidelineComposer
         return false;
     }
 
-    private function relativeGuidelineKey(string $root, string $file): string
+    private function relativeGuidelineKey(SplFileInfo $file): string
     {
-        $file = str_replace('\\', '/', $file);
-
-        $relative = str_starts_with($file, $root)
-            ? ltrim(Str::after($file, $root), '/')
-            : basename($file);
-
-        return (string) preg_replace('/\.(blade\.php|md)$/', '', $relative);
+        return (string) preg_replace(
+            '/\.(blade\.php|md)$/',
+            '',
+            str_replace('\\', '/', $file->getRelativePathname())
+        );
     }
 
     /**
@@ -419,7 +413,8 @@ class GuidelineComposer
 
     protected function guidelinePath(string $path, ?string $overrideKey = null): ?string
     {
-        if ($overrideKey !== null) {
+        // A user guideline is never its own override.
+        if ($overrideKey !== null && ! $this->isCustomGuideline($path)) {
             foreach (['.blade.php', '.md'] as $ext) {
                 $customPath = $this->prependUserGuidelinePath($overrideKey.$ext);
 

--- a/src/Install/GuidelineComposer.php
+++ b/src/Install/GuidelineComposer.php
@@ -149,8 +149,13 @@ class GuidelineComposer
      */
     protected function getUserGuidelines(): Collection
     {
-        return collect($this->guidelinesDir($this->customGuidelinePath()))
-            ->mapWithKeys(fn ($guideline): array => ['.ai/'.$guideline['name'] => $guideline]);
+        $root = str_replace('\\', '/', (string) (realpath($this->customGuidelinePath()) ?: $this->customGuidelinePath()));
+
+        return collect($this->guidelinesDir(
+            $this->customGuidelinePath(),
+            false,
+            fn (SplFileInfo $file): string => '.ai/'.$this->relativeGuidelineKey($root, $file->getRealPath()),
+        ));
     }
 
     /**

--- a/tests/Feature/Install/GuidelineComposerTest.php
+++ b/tests/Feature/Install/GuidelineComposerTest.php
@@ -1288,6 +1288,47 @@ test('symlinked custom guideline file does not produce duplicates', function ():
     }
 });
 
+test('symlinked nested user guidelines with the same filename keep distinct keys', function (): void {
+    $packages = new PackageCollection([
+        rosterPackage('laravel/framework', '11.0.0'),
+    ]);
+
+    mockProjectPackages($this->project, $packages);
+
+    $customDir = testDirectory('Fixtures/.ai/symlinked-nested-guidelines');
+    $cleanup = function () use ($customDir): void {
+        foreach (['frontend', 'backend'] as $group) {
+            @unlink($customDir.'/'.$group.'/api.blade.php');
+            @rmdir($customDir.'/'.$group);
+        }
+
+        @rmdir($customDir);
+    };
+
+    $cleanup();
+
+    foreach (['frontend', 'backend'] as $group) {
+        mkdir($customDir.'/'.$group, 0755, true);
+        symlink(
+            realpath(testDirectory('Fixtures/.ai/guidelines-nested/'.$group.'/api.blade.php')),
+            $customDir.'/'.$group.'/api.blade.php'
+        );
+    }
+
+    try {
+        $composer = Mockery::mock(GuidelineComposer::class, [$this->project, $this->herd])->makePartial();
+        $composer
+            ->shouldReceive('customGuidelinePath')
+            ->andReturnUsing(fn ($path = ''): string => $customDir.'/'.ltrim((string) $path, '/'));
+
+        expect($composer->used())
+            ->toContain('.ai/frontend/api')
+            ->toContain('.ai/backend/api');
+    } finally {
+        $cleanup();
+    }
+});
+
 test('php core guideline adapts enum naming guidance to the application enums', function (array $enums, ?string $fixtureName, string $expected, string $notExpected): void {
     $assist = Mockery::mock(GuidelineAssist::class);
     $assist->shouldReceive('enums')->andReturn($enums);

--- a/tests/Feature/Install/GuidelineComposerTest.php
+++ b/tests/Feature/Install/GuidelineComposerTest.php
@@ -375,6 +375,25 @@ test('includes user custom guidelines from .ai/guidelines directory', function (
         ->toContain('.ai/project-specific');
 });
 
+test('nested user guidelines with the same filename do not overwrite each other', function (): void {
+    $packages = new PackageCollection([
+        rosterPackage('laravel/framework', '11.0.0'),
+    ]);
+
+    mockProjectPackages($this->project, $packages);
+
+    $composer = Mockery::mock(GuidelineComposer::class, [$this->project, $this->herd])->makePartial();
+    $composer
+        ->shouldReceive('customGuidelinePath')
+        ->andReturnUsing(fn ($path = ''): string => realpath(testDirectory('Fixtures/.ai/guidelines-nested')).'/'.ltrim((string) $path, '/'));
+
+    expect($composer->compose())
+        ->toContain('=== .ai/frontend/api rules ===')
+        ->toContain('=== .ai/backend/api rules ===')
+        ->toContain('Frontend api guideline body')
+        ->toContain('Backend api guideline body');
+});
+
 test('a user override still applies for a package whose bundled core.blade.php no longer exists', function (): void {
     $packages = new PackageCollection([
         rosterPackage('laravel/framework', '11.0.0'),

--- a/tests/Fixtures/.ai/guidelines-nested/backend/api.blade.php
+++ b/tests/Fixtures/.ai/guidelines-nested/backend/api.blade.php
@@ -1,0 +1,3 @@
+# Backend API rules
+
+Backend api guideline body

--- a/tests/Fixtures/.ai/guidelines-nested/frontend/api.blade.php
+++ b/tests/Fixtures/.ai/guidelines-nested/frontend/api.blade.php
@@ -1,0 +1,3 @@
+# Frontend API rules
+
+Frontend api guideline body


### PR DESCRIPTION
user guidelines in .ai/guidelines get picked up recursively but keyed by basename, so frontend/api.blade.php and backend/api.blade.php both become .ai/api and one silently vanishes from CLAUDE.md

real app with those two files, boost:install --guidelines, before:

```
=== .ai/api rules ===

# Frontend API conventions
```

backend is just gone, no warning. after:

```
=== .ai/backend/api rules ===

# Backend API conventions

=== .ai/frontend/api rules ===

# Frontend API conventions
```

fix keys user guidelines by relative path, same way third party guidelines already are (relativeGuidelineKey), flat files keep their exact keys. new test fails on main
