### PR TITLE
Show repo-relative skill paths with forward slashes on Windows

### DIFF
--- a/src/Concerns/ReportsSkillParseFailures.php
+++ b/src/Concerns/ReportsSkillParseFailures.php
@@ -28,9 +28,14 @@ trait ReportsSkillParseFailures
         ));
 
         foreach ($entries as $entry) {
-            $location = str_replace(base_path().DIRECTORY_SEPARATOR, '', $entry['path']);
+            $location = Str::after($this->normalizeSeparators($entry['path']), $this->normalizeSeparators(base_path()).'/');
 
             $this->line(rtrim(sprintf('  - %s (%s): %s', $entry['name'], $location, $entry['reason']), ': '));
         }
+    }
+
+    private function normalizeSeparators(string $path): string
+    {
+        return str_replace(DIRECTORY_SEPARATOR, '/', $path);
     }
 }


### PR DESCRIPTION
`reportSkillParseFailures` strips the base path but leaves native separators, so on Windows the skipped-skill message renders a mixed path:

```
- broken-frontmatter (.ai/skills\broken-frontmatter\SKILL.md): A colon cannot be used in an unquoted mapping value at line 2
```

Every `windows-latest` job in the test matrix fails on `UpdateCommandTest::it preserves tracked skills with invalid frontmatter`, which asserts the forward-slash form.

## Why this is only surfacing now

The test arrived with #965 (a0acc63). That commit is `main`'s HEAD and **has no CI run against it** — the last green `main` run is 7c6ee72, which predates it. The first workflow to exercise it on Windows was an unrelated PR, so `main` is currently red on all ten Windows jobs without anyone having been told.

## The fix

Normalize separators before stripping the base path, and use `Str::after` so an unexpected path falls back to showing itself in full rather than being silently returned unchanged with a half-stripped prefix.

Simulating both platforms against the CI output:

| case | before | after |
|---|---|---|
| posix | `.ai/skills/broken/SKILL.md` | `.ai/skills/broken/SKILL.md` |
| windows (as seen in CI) | `.ai/skills\broken\SKILL.md` | `.ai/skills/broken/SKILL.md` |
| windows (all backslash) | `.ai\skills\broken\SKILL.md` | `.ai/skills/broken/SKILL.md` |
| path outside base | `/elsewhere/.ai/skills/broken/SKILL.md` | `/elsewhere/.ai/skills/broken/SKILL.md` |

No new test: `UpdateCommandTest` already asserts the forward-slash form and would have caught this. The gap was CI never running it, not missing coverage.