### PR TITLE
Run test workflows on pushes to main

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,7 +3,7 @@ name: static analysis
 on:
   push:
     branches:
-      - master
+      - main
       - '*.x'
   pull_request:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: tests
 on:
   push:
     branches:
-      - master
+      - main
       - '*.x'
   pull_request:
   schedule:


### PR DESCRIPTION
The repository’s default branch is `main`, but the test and static analysis workflows still restrict their push triggers to `master` and versioned `*.x` branches.

As a result, pushes to `main`, including merged pull requests, do not trigger these workflows through the `push` event.

This change replaces the stale `master` filters with `main` while preserving support for versioned branches.