### PR TITLE
Preserve SQL literals when applying table prefixes

### DIFF
--- a/src/Mcp/Tools/DatabaseQuery.php
+++ b/src/Mcp/Tools/DatabaseQuery.php
@@ -177,13 +177,20 @@ class DatabaseQuery extends Tool
     }
 
     /**
-     * @return array{structure: string, hasVersionComment: bool}
+     * Locate the string literals and comments in a query.
+     *
+     * `structure` blanks them out for keyword scanning, while `spans` gives their byte
+     * ranges so callers rewriting the original query can skip over them.
+     *
+     * @return array{structure: string, hasVersionComment: bool, spans: list<array{int, int}>}
      */
     protected function withoutLiteralsAndComments(string $query): array
     {
         $structure = '';
         $state = 'none';
         $hasVersionComment = false;
+        $spans = [];
+        $spanStart = 0;
         $length = strlen($query);
 
         for ($i = 0; $i < $length; $i++) {
@@ -197,9 +204,11 @@ class DatabaseQuery extends Tool
                         '"' => 'double',
                         default => 'backtick',
                     };
+                    $spanStart = $i;
                     $structure .= ' ';
                 } elseif ($char === '-' && $next === '-') {
                     $state = 'line_comment';
+                    $spanStart = $i;
                     $structure .= ' ';
                     $i++;
                 } elseif ($char === '/' && $next === '*') {
@@ -209,6 +218,7 @@ class DatabaseQuery extends Tool
                         $structure .= $char;
                     } else {
                         $state = 'block_comment';
+                        $spanStart = $i;
                         $structure .= ' ';
                         $i++;
                     }
@@ -217,11 +227,13 @@ class DatabaseQuery extends Tool
                 }
             } elseif ($state === 'line_comment') {
                 if ($char === "\n") {
+                    $spans[] = [$spanStart, $i];
                     $state = 'none';
                     $structure .= $char;
                 }
             } elseif ($state === 'block_comment') {
                 if ($char === '*' && $next === '/') {
+                    $spans[] = [$spanStart, $i + 2];
                     $state = 'none';
                     $i++;
                 }
@@ -236,51 +248,82 @@ class DatabaseQuery extends Tool
                     if ($next === $quote) {
                         $i++; // doubled quote escapes itself; literal continues
                     } else {
+                        $spans[] = [$spanStart, $i + 1];
                         $state = 'none';
                     }
                 }
             }
         }
 
-        return ['structure' => $structure, 'hasVersionComment' => $hasVersionComment];
+        if ($state !== 'none') {
+            $spans[] = [$spanStart, $length];
+        }
+
+        return ['structure' => $structure, 'hasVersionComment' => $hasVersionComment, 'spans' => $spans];
     }
 
     protected function addPrefixToQuery(string $query, string $prefix): string
     {
-        $structure = $this->withoutLiteralsAndComments($query)['structure'];
-        $cteNames = $this->extractCteNames($structure);
-
         // Anchored to the start so the `ORDER BY ... DESC` sort direction is never matched.
         $describePattern = '/^(\s*)(DESCRIBE|DESC)\s+((?:[`"]?\w+[`"]?\s*\.\s*)?)([`"\']?)(\w+)\4/i';
 
-        $query = preg_replace_callback($describePattern, function (array $matches) use ($prefix, $cteNames): string {
+        // The anchor also means no CTE can precede the table name here.
+        $query = preg_replace_callback($describePattern, function (array $matches) use ($prefix): string {
             [$full, $leading, $keyword, $qualifier, $quote, $tableName] = $matches;
 
-            if ($this->tableIsPrefixedOrCte($tableName, $prefix, $cteNames)) {
+            if (str_starts_with($tableName, $prefix)) {
                 return $full;
             }
 
             return "{$leading}{$keyword} {$qualifier}{$quote}{$prefix}{$tableName}{$quote}";
         }, $query) ?? $query;
 
-        $pattern = <<<'REGEX'
-~'(?:''|\\.|[^'\\])*'|"(?:""|\\.|[^"\\])*"|`(?:``|[^`])*`|--[^\r\n]*|/\*[\s\S]*?\*/|\b(FROM|JOIN|INTO|UPDATE|TABLE)\s+((?:[`"]?\w+[`"]?\s*\.\s*)?)([`"']?)(\w+)\3~i
-REGEX;
+        ['structure' => $structure, 'spans' => $spans] = $this->withoutLiteralsAndComments($query);
+        $cteNames = $this->extractCteNames($structure);
 
-        return preg_replace_callback($pattern, function (array $matches) use ($prefix, $cteNames): string {
-            // String literals, quoted fragments, and comments must be preserved verbatim.
-            if (! isset($matches[1])) {
-                return $matches[0];
+        $pattern = '/\b(FROM|JOIN|INTO|UPDATE|TABLE)\s+((?:[`"]?\w+[`"]?\s*\.\s*)?)([`"\']?)(\w+)\3/i';
+
+        if (! preg_match_all($pattern, $query, $allMatches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE)) {
+            return $query;
+        }
+
+        // Rewriting right to left keeps the offsets of the matches still to come valid.
+        foreach (array_reverse($allMatches) as $matches) {
+            [$full, $offset] = $matches[0];
+
+            if ($this->offsetIsInsideLiteralOrComment($offset, $spans)) {
+                continue;
             }
 
-            [$full, $keyword, $qualifier, $quote, $tableName] = $matches;
+            $keyword = $matches[1][0];
+            $qualifier = $matches[2][0];
+            $quote = $matches[3][0];
+            $tableName = $matches[4][0];
 
             if ($this->tableIsPrefixedOrCte($tableName, $prefix, $cteNames)) {
-                return $full;
+                continue;
             }
 
-            return "{$keyword} {$qualifier}{$quote}{$prefix}{$tableName}{$quote}";
-        }, $query) ?? $query;
+            $query = substr_replace($query, "{$keyword} {$qualifier}{$quote}{$prefix}{$tableName}{$quote}", $offset, strlen($full));
+        }
+
+        return $query;
+    }
+
+    /**
+     * A keyword starting inside a literal or comment is text, not a table reference.
+     *
+     * @param  list<array{int, int}>  $spans
+     */
+    protected function offsetIsInsideLiteralOrComment(int $offset, array $spans): bool
+    {
+        foreach ($spans as [$start, $end]) {
+            if ($offset >= $start && $offset < $end) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Mcp/Tools/DatabaseQuery.php
+++ b/src/Mcp/Tools/DatabaseQuery.php
@@ -247,7 +247,8 @@ class DatabaseQuery extends Tool
 
     protected function addPrefixToQuery(string $query, string $prefix): string
     {
-        $cteNames = $this->extractCteNames($query);
+        $structure = $this->withoutLiteralsAndComments($query)['structure'];
+        $cteNames = $this->extractCteNames($structure);
 
         // Anchored to the start so the `ORDER BY ... DESC` sort direction is never matched.
         $describePattern = '/^(\s*)(DESCRIBE|DESC)\s+((?:[`"]?\w+[`"]?\s*\.\s*)?)([`"\']?)(\w+)\4/i';
@@ -262,9 +263,16 @@ class DatabaseQuery extends Tool
             return "{$leading}{$keyword} {$qualifier}{$quote}{$prefix}{$tableName}{$quote}";
         }, $query) ?? $query;
 
-        $pattern = '/\b(FROM|JOIN|INTO|UPDATE|TABLE)\s+((?:[`"]?\w+[`"]?\s*\.\s*)?)([`"\']?)(\w+)\3/i';
+        $pattern = <<<'REGEX'
+~'(?:''|\\.|[^'\\])*'|"(?:""|\\.|[^"\\])*"|`(?:``|[^`])*`|--[^\r\n]*|/\*[\s\S]*?\*/|\b(FROM|JOIN|INTO|UPDATE|TABLE)\s+((?:[`"]?\w+[`"]?\s*\.\s*)?)([`"']?)(\w+)\3~i
+REGEX;
 
         return preg_replace_callback($pattern, function (array $matches) use ($prefix, $cteNames): string {
+            // String literals, quoted fragments, and comments must be preserved verbatim.
+            if (! isset($matches[1])) {
+                return $matches[0];
+            }
+
             [$full, $keyword, $qualifier, $quote, $tableName] = $matches;
 
             if ($this->tableIsPrefixedOrCte($tableName, $prefix, $cteNames)) {

--- a/src/Mcp/Tools/DatabaseQuery.php
+++ b/src/Mcp/Tools/DatabaseQuery.php
@@ -64,7 +64,7 @@ class DatabaseQuery extends Tool
             $prefix = $connection->getTablePrefix();
 
             if ($prefix) {
-                $query = $this->addPrefixToQuery($query, $prefix);
+                $query = $this->addPrefixToQuery($query, $prefix, $this->usesBackslashEscapes($connection->getDriverName()));
             }
 
             return Response::json(
@@ -184,7 +184,7 @@ class DatabaseQuery extends Tool
      *
      * @return array{structure: string, hasVersionComment: bool, spans: list<array{int, int}>}
      */
-    protected function withoutLiteralsAndComments(string $query): array
+    protected function withoutLiteralsAndComments(string $query, bool $backslashEscapes = false): array
     {
         $structure = '';
         $state = 'none';
@@ -244,6 +244,12 @@ class DatabaseQuery extends Tool
                     default => '`',
                 };
 
+                if ($backslashEscapes && $char === '\\' && $state !== 'backtick') {
+                    $i++; // MySQL only: the escaped character cannot close the literal
+
+                    continue;
+                }
+
                 if ($char === $quote) {
                     if ($next === $quote) {
                         $i++; // doubled quote escapes itself; literal continues
@@ -262,7 +268,7 @@ class DatabaseQuery extends Tool
         return ['structure' => $structure, 'hasVersionComment' => $hasVersionComment, 'spans' => $spans];
     }
 
-    protected function addPrefixToQuery(string $query, string $prefix): string
+    protected function addPrefixToQuery(string $query, string $prefix, bool $backslashEscapes = false): string
     {
         // Anchored to the start so the `ORDER BY ... DESC` sort direction is never matched.
         $describePattern = '/^(\s*)(DESCRIBE|DESC)\s+((?:[`"]?\w+[`"]?\s*\.\s*)?)([`"\']?)(\w+)\4/i';
@@ -278,7 +284,7 @@ class DatabaseQuery extends Tool
             return "{$leading}{$keyword} {$qualifier}{$quote}{$prefix}{$tableName}{$quote}";
         }, $query) ?? $query;
 
-        ['structure' => $structure, 'spans' => $spans] = $this->withoutLiteralsAndComments($query);
+        ['structure' => $structure, 'spans' => $spans] = $this->withoutLiteralsAndComments($query, $backslashEscapes);
         $cteNames = $this->extractCteNames($structure);
 
         $pattern = '/\b(FROM|JOIN|INTO|UPDATE|TABLE)\s+((?:[`"]?\w+[`"]?\s*\.\s*)?)([`"\']?)(\w+)\3/i';
@@ -308,6 +314,14 @@ class DatabaseQuery extends Tool
         }
 
         return $query;
+    }
+
+    /**
+     * MySQL and MariaDB treat "\" as an escape inside string literals; the other drivers do not.
+     */
+    protected function usesBackslashEscapes(string $driver): bool
+    {
+        return in_array($driver, ['mysql', 'mariadb'], true);
     }
 
     /**

--- a/tests/Feature/Mcp/Tools/DatabaseQueryTest.php
+++ b/tests/Feature/Mcp/Tools/DatabaseQueryTest.php
@@ -228,6 +228,10 @@ it('adds table prefix to queries', function (): void {
         'SELECT * FROM users -- JOIN posts' => 'SELECT * FROM wp_users -- JOIN posts',
         'SELECT * FROM users /* JOIN posts */' => 'SELECT * FROM wp_users /* JOIN posts */',
         "SELECT 'users AS (' AS label FROM users" => "SELECT 'users AS (' AS label FROM wp_users",
+        "SELECT 'it''s FROM posts' AS label FROM users" => "SELECT 'it''s FROM posts' AS label FROM wp_users",
+        "SELECT 'a\\' AS x, 'b' AS y FROM users, 'c' AS z" => "SELECT 'a\\' AS x, 'b' AS y FROM wp_users, 'c' AS z",
+        "SELECT * FROM users WHERE note = 'unterminated" => "SELECT * FROM wp_users WHERE note = 'unterminated",
+        "SELECT * FROM users -- JOIN posts\nJOIN comments ON 1 = 1" => "SELECT * FROM wp_users -- JOIN posts\nJOIN wp_comments ON 1 = 1",
     ];
 
     foreach ($testCases as $input => $expected) {

--- a/tests/Feature/Mcp/Tools/DatabaseQueryTest.php
+++ b/tests/Feature/Mcp/Tools/DatabaseQueryTest.php
@@ -229,7 +229,7 @@ it('adds table prefix to queries', function (): void {
         'SELECT * FROM users /* JOIN posts */' => 'SELECT * FROM wp_users /* JOIN posts */',
         "SELECT 'users AS (' AS label FROM users" => "SELECT 'users AS (' AS label FROM wp_users",
         "SELECT 'it''s FROM posts' AS label FROM users" => "SELECT 'it''s FROM posts' AS label FROM wp_users",
-        "SELECT 'a\\' AS x, 'b' AS y FROM users, 'c' AS z" => "SELECT 'a\\' AS x, 'b' AS y FROM wp_users, 'c' AS z",
+        "SELECT * FROM users WHERE a = 'don\\'t' AND b IN (SELECT id FROM posts)" => "SELECT * FROM wp_users WHERE a = 'don\\'t' AND b IN (SELECT id FROM wp_posts)",
         "SELECT * FROM users WHERE note = 'unterminated" => "SELECT * FROM wp_users WHERE note = 'unterminated",
         "SELECT * FROM users -- JOIN posts\nJOIN comments ON 1 = 1" => "SELECT * FROM wp_users -- JOIN posts\nJOIN wp_comments ON 1 = 1",
     ];
@@ -243,3 +243,22 @@ it('adds table prefix to queries', function (): void {
         expect($response)->isToolResult()->toolHasNoError();
     }
 });
+
+it('only treats backslashes as escapes on mysql', function (string $driver, string $expected): void {
+    DB::shouldReceive('connection')->andReturnSelf();
+    DB::shouldReceive('getTablePrefix')->andReturn('wp_');
+    DB::shouldReceive('getDriverName')->andReturn($driver);
+    DB::shouldReceive('beginTransaction');
+    DB::shouldReceive('statement')->andReturn(true);
+    DB::shouldReceive('rollBack');
+    DB::shouldReceive('select')->with($expected)->once()->andReturn([]);
+
+    $tool = new DatabaseQuery;
+    $response = $tool->handle(new Request(['query' => "SELECT 'a\\' AS x, 'b' AS y FROM users, 'c' AS z"]));
+
+    expect($response)->isToolResult()->toolHasNoError();
+})->with([
+    // On MySQL the escaped quote keeps the literal open, so "FROM users" sits inside one.
+    ['mysql', "SELECT 'a\\' AS x, 'b' AS y FROM users, 'c' AS z"],
+    ['pgsql', "SELECT 'a\\' AS x, 'b' AS y FROM wp_users, 'c' AS z"],
+]);

--- a/tests/Feature/Mcp/Tools/DatabaseQueryTest.php
+++ b/tests/Feature/Mcp/Tools/DatabaseQueryTest.php
@@ -223,6 +223,11 @@ it('adds table prefix to queries', function (): void {
         'SELECT * FROM public.users JOIN public.posts ON public.users.id = public.posts.user_id' => 'SELECT * FROM public.wp_users JOIN public.wp_posts ON public.users.id = public.posts.user_id',
         'SELECT * FROM "public"."users"' => 'SELECT * FROM "public"."wp_users"',
         'SELECT * FROM `mydb`.`users`' => 'SELECT * FROM `mydb`.`wp_users`',
+        "SELECT 'FROM users' AS label FROM users" => "SELECT 'FROM users' AS label FROM wp_users",
+        'SELECT "FROM users" AS label FROM users' => 'SELECT "FROM users" AS label FROM wp_users',
+        'SELECT * FROM users -- JOIN posts' => 'SELECT * FROM wp_users -- JOIN posts',
+        'SELECT * FROM users /* JOIN posts */' => 'SELECT * FROM wp_users /* JOIN posts */',
+        "SELECT 'users AS (' AS label FROM users" => "SELECT 'users AS (' AS label FROM wp_users",
     ];
 
     foreach ($testCases as $input => $expected) {


### PR DESCRIPTION
The database-query tool applies the configured table prefix to raw SQL table references. However, the current regular expression also rewrites table-like references inside SQL string literals and comments.

For example, with the wp_ prefix:

**SELECT 'FROM users' AS label FROM users**

was transformed into:

**SELECT 'FROM wp_users' AS label FROM wp_users**

This change preserves string literals and comments while continuing to prefix actual table references. It also derives CTE names from the query structure without literals and comments so their contents cannot affect CTE detection.

Regression coverage has been added for:

- Single- and double-quoted content
- 
- Line and block comments
- 
- CTE-like content inside string literals
- 
- Existing quoted and schema-qualified table references