### PR TITLE
Skip versionless packages in documentation searches

### DIFF
--- a/src/Mcp/Tools/SearchDocs.php
+++ b/src/Mcp/Tools/SearchDocs.php
@@ -83,15 +83,14 @@ class SearchDocs extends Tool
                 $packagesCollection = $packagesCollection->filter(fn (Package $package): bool => in_array($package->name(), $packagesFilter, true));
             }
 
-            $packages = $packagesCollection->map(function (Package $package): array {
-                $name = $package->name();
-                $version = $package->major().'.x';
-
-                return [
-                    'name' => $name,
-                    'version' => $version,
-                ];
-            });
+            $packages = $packagesCollection
+                ->reject(fn (Package $package): bool => $package->major() === null)
+                ->map(function (Package $package): array {
+                    return [
+                        'name' => $package->name(),
+                        'version' => $package->major().'.x',
+                    ];
+                });
 
             $packages = $packages->values()->toArray();
         } catch (Throwable $throwable) {

--- a/tests/Feature/Mcp/Tools/SearchDocsTest.php
+++ b/tests/Feature/Mcp/Tools/SearchDocsTest.php
@@ -105,6 +105,30 @@ test('it formats package data correctly', function (): void {
     ] && $request->data()['token_limit'] === 3000);
 });
 
+test('it skips packages without a major version', function (): void {
+    $packages = new PackageCollection([
+        rosterPackage('laravel/framework', ''),
+        rosterPackage('pestphp/pest', '4.1.0'),
+    ]);
+
+    $project = Mockery::mock(ProjectManager::class);
+    mockProjectPackages($project, $packages);
+
+    Http::fake([
+        'https://boost.laravel.com/api/docs' => Http::response('Documentation search results', 200),
+    ]);
+
+    $tool = new SearchDocs($project);
+    $response = $tool->handle(new Request(['queries' => ['testing']]));
+
+    expect($response)->isToolResult()
+        ->toolHasNoError();
+
+    Http::assertSent(fn ($request): bool => $request->data()['packages'] === [
+        ['name' => 'pestphp/pest', 'version' => '4.x'],
+    ]);
+});
+
 test('it handles empty results', function (): void {
     $packages = new PackageCollection([]);
 


### PR DESCRIPTION
The search-docs tool currently appends .x to every package's major version. When Laravel Roster cannot determine a package version, Package::major() returns null, causing Boost to send .x as the package version.

Requests containing this invalid version return no documentation results.

This change excludes packages without a detectable major version from the documentation search payload while preserving all versioned packages.

Regression coverage verifies that a versionless package is omitted and a package with a known major version is still sent correctly.