### PR TITLE
Resolve the browser log path from the browser channel config instead of a hardcoded location

### DIFF
--- a/src/Concerns/ReadsLogs.php
+++ b/src/Concerns/ReadsLogs.php
@@ -41,14 +41,14 @@ trait ReadsLogs
     /**
      * Resolve the current log file path based on Laravel's logging configuration.
      */
-    protected function resolveLogFilePath(): string
+    protected function resolveLogFilePath(?string $channel = null, ?string $default = null): string
     {
-        $channel = Config::get('logging.default');
+        $channel ??= Config::get('logging.default');
         $channelConfig = Config::get("logging.channels.{$channel}");
 
         $channelConfig = $this->resolveChannelWithPath($channelConfig);
 
-        $baseLogPath = Arr::get($channelConfig, 'path', storage_path('logs/laravel.log'));
+        $baseLogPath = Arr::get($channelConfig, 'path') ?? $default ?? storage_path('logs/laravel.log');
 
         if (Arr::get($channelConfig, 'driver') === 'daily') {
             return $this->resolveDailyLogFilePath($baseLogPath);

--- a/src/Mcp/Tools/BrowserLogs.php
+++ b/src/Mcp/Tools/BrowserLogs.php
@@ -6,8 +6,6 @@ namespace Laravel\Boost\Mcp\Tools;
 
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\JsonSchema\Types\Type;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Config;
 use Laravel\Boost\Concerns\ReadsLogs;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
@@ -49,17 +47,10 @@ class BrowserLogs extends Tool
             return Response::error('The "entries" argument must be greater than 0.');
         }
 
-        // Locate the correct log file using the shared helper.
-        $channelConfig = Config::get('logging.channels.browser');
-
-        $logFile = Arr::get($channelConfig, 'path', storage_path('logs'.DIRECTORY_SEPARATOR.'browser.log'));
-
-        if (Arr::get($channelConfig, 'driver') === 'daily') {
-            $logFile = $this->resolveDailyLogFilePath($logFile);
-        }
+        $logFile = $this->resolveLogFilePath('browser', storage_path('logs'.DIRECTORY_SEPARATOR.'browser.log'));
 
         if (! file_exists($logFile)) {
-            return Response::error('No log file found, probably means no logs yet.');
+            return Response::error('No log file found at '.$logFile.'. This probably means no logs yet, or the `browser` log channel does not write to a file.');
         }
 
         $entries = $this->readLastLogEntries($logFile, $maxEntries);

--- a/src/Mcp/Tools/BrowserLogs.php
+++ b/src/Mcp/Tools/BrowserLogs.php
@@ -6,6 +6,8 @@ namespace Laravel\Boost\Mcp\Tools;
 
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\JsonSchema\Types\Type;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Config;
 use Laravel\Boost\Concerns\ReadsLogs;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
@@ -48,7 +50,13 @@ class BrowserLogs extends Tool
         }
 
         // Locate the correct log file using the shared helper.
-        $logFile = storage_path('logs'.DIRECTORY_SEPARATOR.'browser.log');
+        $channelConfig = Config::get('logging.channels.browser');
+
+        $logFile = Arr::get($channelConfig, 'path', storage_path('logs'.DIRECTORY_SEPARATOR.'browser.log'));
+
+        if (Arr::get($channelConfig, 'driver') === 'daily') {
+            $logFile = $this->resolveDailyLogFilePath($logFile);
+        }
 
         if (! file_exists($logFile)) {
             return Response::error('No log file found, probably means no logs yet.');

--- a/tests/Feature/Mcp/Tools/BrowserLogsTest.php
+++ b/tests/Feature/Mcp/Tools/BrowserLogsTest.php
@@ -38,6 +38,12 @@ beforeEach(function (): void {
     }
 });
 
+afterEach(function (): void {
+    File::delete(File::glob(storage_path('logs'.DIRECTORY_SEPARATOR.'browser-*.log')) ?: []);
+    File::delete(storage_path('logs'.DIRECTORY_SEPARATOR.'frontend.log'));
+    File::delete(storage_path('logs'.DIRECTORY_SEPARATOR.'stacked-browser.log'));
+});
+
 test('it returns log entries when file exists', function (): void {
     createBrowserLogFile(<<<'LOG'
 [2024-01-15 10:00:00] browser.DEBUG: console log message {"url":"http://example.com","user_agent":"Mozilla/5.0","timestamp":"2024-01-15T10:00:00.000000Z"}
@@ -70,8 +76,6 @@ test('it reads from a user-defined browser channel path', function (): void {
     expect($response)->isToolResult()
         ->toolHasNoError()
         ->toolTextContains('browser.ERROR: Custom channel error');
-
-    File::delete($customLogFile);
 });
 
 test('it reads from a user-defined browser channel with a daily driver', function (): void {
@@ -90,8 +94,39 @@ test('it reads from a user-defined browser channel with a daily driver', functio
     expect($response)->isToolResult()
         ->toolHasNoError()
         ->toolTextContains('browser.WARNING: Daily channel warning');
+});
 
-    File::delete($dailyLogFile);
+test('it reads from a user-defined browser channel using a stack driver', function (): void {
+    $stackedLogFile = storage_path('logs'.DIRECTORY_SEPARATOR.'stacked-browser.log');
+
+    Config::set('logging.channels.browser', [
+        'driver' => 'stack',
+        'channels' => ['browser_file'],
+    ]);
+    Config::set('logging.channels.browser_file', [
+        'driver' => 'single',
+        'path' => $stackedLogFile,
+    ]);
+
+    File::put($stackedLogFile, '[2024-01-15 10:00:00] browser.ERROR: Stacked channel error {"url":"http://example.com"}');
+
+    $tool = new BrowserLogs;
+    $response = $tool->handle(new Request(['entries' => 1]));
+
+    expect($response)->isToolResult()
+        ->toolHasNoError()
+        ->toolTextContains('browser.ERROR: Stacked channel error');
+});
+
+test('it reports the resolved path when the browser channel does not write to a file', function (): void {
+    Config::set('logging.channels.browser', ['driver' => 'stderr']);
+
+    $tool = new BrowserLogs;
+    $response = $tool->handle(new Request(['entries' => 1]));
+
+    expect($response)->isToolResult()
+        ->toolHasError()
+        ->toolTextContains('does not write to a file');
 });
 
 test('it returns error when entries argument is invalid', function (): void {
@@ -114,7 +149,7 @@ test('it returns error when a log file does not exist', function (): void {
 
     expect($response)->isToolResult()
         ->toolHasError()
-        ->toolTextContains('No log file found, probably means no logs yet.');
+        ->toolTextContains('No log file found at');
 });
 
 test('it returns error when log file is empty', function (): void {

--- a/tests/Feature/Mcp/Tools/BrowserLogsTest.php
+++ b/tests/Feature/Mcp/Tools/BrowserLogsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Http\Request as HttpRequest;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Route;
@@ -51,6 +52,46 @@ LOG);
         ->toolHasNoError()
         ->toolTextContains('browser.WARNING: Warning message', 'browser.ERROR: JavaScript error occurred')
         ->toolTextDoesNotContain('browser.DEBUG: console log message');
+});
+
+test('it reads from a user-defined browser channel path', function (): void {
+    $customLogFile = storage_path('logs'.DIRECTORY_SEPARATOR.'frontend.log');
+
+    Config::set('logging.channels.browser', [
+        'driver' => 'single',
+        'path' => $customLogFile,
+    ]);
+
+    File::put($customLogFile, '[2024-01-15 10:00:00] browser.ERROR: Custom channel error {"url":"http://example.com"}');
+
+    $tool = new BrowserLogs;
+    $response = $tool->handle(new Request(['entries' => 1]));
+
+    expect($response)->isToolResult()
+        ->toolHasNoError()
+        ->toolTextContains('browser.ERROR: Custom channel error');
+
+    File::delete($customLogFile);
+});
+
+test('it reads from a user-defined browser channel with a daily driver', function (): void {
+    $dailyLogFile = storage_path('logs'.DIRECTORY_SEPARATOR.'browser-'.date('Y-m-d').'.log');
+
+    Config::set('logging.channels.browser', [
+        'driver' => 'daily',
+        'path' => storage_path('logs'.DIRECTORY_SEPARATOR.'browser.log'),
+    ]);
+
+    File::put($dailyLogFile, '[2024-01-15 10:00:00] browser.WARNING: Daily channel warning {"url":"http://example.com"}');
+
+    $tool = new BrowserLogs;
+    $response = $tool->handle(new Request(['entries' => 1]));
+
+    expect($response)->isToolResult()
+        ->toolHasNoError()
+        ->toolTextContains('browser.WARNING: Daily channel warning');
+
+    File::delete($dailyLogFile);
 });
 
 test('it returns error when entries argument is invalid', function (): void {


### PR DESCRIPTION
registerBrowserLogger backs off when the app defines its own `browser` log channel, so writes go wherever that channel points. the browser-logs tool doesnt, it reads the hardcoded storage/logs/browser.log

real app with a browser channel pointing at storage/logs/frontend.log, posting a browser log lands in frontend.log like it should, then browser-logs before:

```
No log file found, probably means no logs yet.
```

after:

```
[2026-09-08 08:37:14] local.ERROR: custom channel repro entry
```

fix resolves the path from logging.channels.browser the way ReadsLogs already resolves the default channel, daily driver included, and falls back to the hardcoded path when no channel is defined. both new tests fail on main
