### PR TITLE
Treat a whitespace-only MCP config file as new instead of failing the install

### DIFF
--- a/src/Install/Mcp/FileWriter.php
+++ b/src/Install/Mcp/FileWriter.php
@@ -65,6 +65,10 @@ class FileWriter
 
         $content = $this->readFile();
 
+        if (trim($content) === '') {
+            return $this->createNewFile();
+        }
+
         if ($this->isPlainJson($content)) {
             return $this->updatePlainJsonFile($content);
         }

--- a/src/Install/Mcp/FileWriter.php
+++ b/src/Install/Mcp/FileWriter.php
@@ -59,13 +59,10 @@ class FileWriter
     {
         $this->ensureDirectoryExists();
 
-        if ($this->shouldWriteNew()) {
-            return $this->createNewFile();
-        }
+        $content = $this->fileExists() ? $this->normalizeContent($this->readFile()) : '';
 
-        $content = $this->readFile();
-
-        if (trim($content) === '') {
+        // A bare `{}` is rebuilt so baseConfig defaults land in it.
+        if ($content === '' || $content === '{}') {
             return $this->createNewFile();
         }
 
@@ -459,19 +456,14 @@ class FileWriter
         return File::exists($this->filePath);
     }
 
-    protected function shouldWriteNew(): bool
-    {
-        if (! $this->fileExists()) {
-            return true;
-        }
-
-        return File::size($this->filePath) < 3;
-        // To account for files that are just `{}`
-    }
-
     protected function readFile(): string
     {
         return File::get($this->filePath);
+    }
+
+    protected function normalizeContent(string $content): string
+    {
+        return trim(Str::chopStart($content, "\xEF\xBB\xBF"));
     }
 
     protected function writeFile(string $content): bool

--- a/tests/Unit/Install/Agents/AgentTest.php
+++ b/tests/Unit/Install/Agents/AgentTest.php
@@ -296,8 +296,6 @@ test('installFileMcp updates existing config file', function (): void {
         ->once()
         ->with('.test');
 
-    File::shouldReceive('size')->once()->andReturn(10);
-
     File::shouldReceive('exists')
         ->once()
         ->with('.test/mcp.json')

--- a/tests/Unit/Install/Agents/AmpTest.php
+++ b/tests/Unit/Install/Agents/AmpTest.php
@@ -171,11 +171,6 @@ test('installMcp overwrites existing amp server config while preserving unrelate
         ->with($settingsPath)
         ->andReturn(true);
 
-    File::shouldReceive('size')
-        ->once()
-        ->with($settingsPath)
-        ->andReturn(strlen((string) $existingConfig));
-
     File::shouldReceive('get')
         ->once()
         ->with($settingsPath)
@@ -212,11 +207,6 @@ test('installMcp returns false when existing settings json is invalid', function
         ->once()
         ->with($settingsPath)
         ->andReturn(true);
-
-    File::shouldReceive('size')
-        ->once()
-        ->with($settingsPath)
-        ->andReturn(12);
 
     File::shouldReceive('get')
         ->once()

--- a/tests/Unit/Install/Mcp/FileWriterTest.php
+++ b/tests/Unit/Install/Mcp/FileWriterTest.php
@@ -48,7 +48,6 @@ test('save method returns boolean', function (): void {
 test('save writes servers when the existing file is whitespace only', function (): void {
     $writtenContent = '';
     mockFileOperations(fileExists: true, content: "\n  \n", capturedContent: $writtenContent);
-    File::shouldReceive('size')->andReturn(4);
 
     $result = (new FileWriter('/path/to/mcp.json'))
         ->addServerConfig('laravel-boost', ['command' => 'php artisan boost:mcp'])
@@ -57,6 +56,24 @@ test('save writes servers when the existing file is whitespace only', function (
     expect($result)->toBeTrue()
         ->and($writtenContent)->toContain('"laravel-boost"')
         ->and($writtenContent)->toContain('php artisan boost:mcp');
+});
+
+test('save updates a plain JSON file that starts with a UTF-8 BOM', function (): void {
+    $writtenContent = '';
+    mockFileOperations(
+        fileExists: true,
+        content: "\xEF\xBB\xBF".json_encode(['mcpServers' => ['existing' => ['command' => 'existing-cmd']]]),
+        capturedContent: $writtenContent
+    );
+
+    $result = (new FileWriter('/path/to/mcp.json'))
+        ->addServerConfig('laravel-boost', ['command' => 'php artisan boost:mcp'])
+        ->save();
+
+    expect($result)->toBeTrue()
+        ->and($writtenContent)->not->toStartWith("\xEF\xBB\xBF")
+        ->and($writtenContent)->toContain('"existing"')
+        ->and($writtenContent)->toContain('"laravel-boost"');
 });
 
 test('written data is correct for brand new file', function (string $configKey, array $servers, string $expectedJson): void {
@@ -89,9 +106,6 @@ test('updates existing plain JSON file using simple method', function (): void {
         capturedContent: $writtenContent
     );
 
-    // Need to mock File::size for fileEmpty check
-    File::shouldReceive('size')->andReturn(100);
-
     $result = (new FileWriter('/path/to/mcp.json'))
         ->configKey('servers')
         ->addServerConfig('new-server', [
@@ -122,8 +136,6 @@ test('adds to existing mcpServers in plain JSON', function (): void {
         capturedPath: $writtenPath,
         capturedContent: $writtenContent
     );
-
-    File::shouldReceive('size')->andReturn(200);
 
     $result = (new FileWriter('/path/to/mcp.json'))
         ->addServerConfig('boost', [
@@ -164,8 +176,6 @@ test('preserves empty objects in existing plain JSON files', function (): void {
         capturedContent: $writtenContent
     );
 
-    File::shouldReceive('size')->andReturn(200);
-
     $result = (new FileWriter('/path/to/opencode.json'))
         ->configKey('mcp')
         ->addServerConfig('laravel-boost', [
@@ -191,8 +201,6 @@ test('preserves complex JSON5 features that VS Code supports', function (): void
         capturedContent: $writtenContent
     );
 
-    File::shouldReceive('size')->andReturn(1000);
-
     $result = (new FileWriter('/path/to/mcp.json'))
         ->configKey('servers') // mcp.json5 uses "servers", not "mcpServers"
         ->addServerConfig('test', ['command' => 'cmd'])
@@ -216,8 +224,6 @@ test('detects plain JSON with comments inside strings as safe', function (): voi
         content: fixtureContent('mcp-comments-in-strings.json'),
         capturedContent: $writtenContent
     );
-
-    File::shouldReceive('size')->andReturn(200);
 
     $result = (new FileWriter('/path/to/mcp.json'))
         ->addServerConfig('new-server', ['command' => 'test-cmd'])
@@ -305,8 +311,6 @@ test('injects new configKey when it does not exist', function (): void {
         capturedContent: $writtenContent
     );
 
-    File::shouldReceive('size')->andReturn(200);
-
     $result = (new FileWriter('/path/to/mcp.json'))
         ->addServerConfig('boost', [
             'command' => 'php',
@@ -331,8 +335,6 @@ test('injects into existing configKey preserving JSON5 features', function (): v
         content: fixtureContent('mcp.json5'),
         capturedContent: $writtenContent
     );
-
-    File::shouldReceive('size')->andReturn(1000);
 
     $result = (new FileWriter('/path/to/mcp.json'))
         ->configKey('servers') // mcp.json5 uses "servers" not "mcpServers"
@@ -359,7 +361,6 @@ test("injecting twice into existing JSON 5 doesn't cause duplicates", function (
 
     File::shouldReceive('ensureDirectoryExists')->once();
     File::shouldReceive('exists')->andReturn(true);
-    File::shouldReceive('size')->andReturn(1000);
     File::shouldReceive('get')->andReturn(fixtureContent('mcp.json5'));
     File::shouldReceive('put')
         ->with(
@@ -393,7 +394,6 @@ test("injecting twice into existing JSON 5 doesn't cause duplicates", function (
 
     File::shouldReceive('ensureDirectoryExists')->once();
     File::shouldReceive('exists')->andReturn(true);
-    File::shouldReceive('size')->andReturn(1000);
     File::shouldReceive('get')->andReturn($newContent);
 
     $result = (new FileWriter('/path/to/mcp.json'))
@@ -421,8 +421,6 @@ test('injects into empty configKey object', function (): void {
         capturedContent: $writtenContent
     );
 
-    File::shouldReceive('size')->andReturn(200);
-
     $result = (new FileWriter('/path/to/mcp.json'))
         ->addServerConfig('boost', [
             'command' => 'php',
@@ -446,8 +444,6 @@ test('preserves trailing commas when injecting into existing servers', function 
         content: fixtureContent('mcp-trailing-comma.json5'),
         capturedContent: $writtenContent
     );
-
-    File::shouldReceive('size')->andReturn(200);
 
     $result = (new FileWriter('/path/to/mcp.json'))
         ->addServerConfig('boost', [
@@ -484,8 +480,6 @@ test('adds the comma outside a trailing comment in the servers object', function
         capturedContent: $writtenContent
     );
 
-    File::shouldReceive('size')->andReturn(200);
-
     $result = (new FileWriter('/path/to/mcp.json'))
         ->addServerConfig('boost', [
             'command' => 'php',
@@ -521,8 +515,6 @@ test('does not read a // inside a single-quoted string as a comment', function (
         capturedContent: $writtenContent
     );
 
-    File::shouldReceive('size')->andReturn(200);
-
     $result = (new FileWriter('/path/to/mcp.json'))
         ->addServerConfig('boost', [
             'command' => 'php',
@@ -554,8 +546,6 @@ test('updates JSON5 file with only single-quoted strings', function (): void {
         content: $singleQuotedJson5,
         capturedContent: $writtenContent
     );
-
-    File::shouldReceive('size')->andReturn(200);
 
     $result = (new FileWriter('/path/to/mcp.json'))
         ->addServerConfig('boost', [
@@ -599,8 +589,6 @@ test('updated plain JSON file ends with a trailing newline', function (): void {
         capturedContent: $writtenContent
     );
 
-    File::shouldReceive('size')->andReturn(200);
-
     $result = (new FileWriter('/path/to/mcp.json'))
         ->addServerConfig('boost', ['command' => 'php'])
         ->save();
@@ -616,8 +604,6 @@ test('updated JSON5 file ends with a single trailing newline', function (): void
         content: fixtureContent('mcp.json5'),
         capturedContent: $writtenContent
     );
-
-    File::shouldReceive('size')->andReturn(1000);
 
     $result = (new FileWriter('/path/to/mcp.json'))
         ->configKey('servers')

--- a/tests/Unit/Install/Mcp/FileWriterTest.php
+++ b/tests/Unit/Install/Mcp/FileWriterTest.php
@@ -45,6 +45,20 @@ test('save method returns boolean', function (): void {
     expect($result)->toBe(true);
 });
 
+test('save writes servers when the existing file is whitespace only', function (): void {
+    $writtenContent = '';
+    mockFileOperations(fileExists: true, content: "\n  \n", capturedContent: $writtenContent);
+    File::shouldReceive('size')->andReturn(4);
+
+    $result = (new FileWriter('/path/to/mcp.json'))
+        ->addServerConfig('laravel-boost', ['command' => 'php artisan boost:mcp'])
+        ->save();
+
+    expect($result)->toBeTrue()
+        ->and($writtenContent)->toContain('"laravel-boost"')
+        ->and($writtenContent)->toContain('php artisan boost:mcp');
+});
+
 test('written data is correct for brand new file', function (string $configKey, array $servers, string $expectedJson): void {
     $writtenPath = '';
     $writtenContent = '';


### PR DESCRIPTION
a whitespace only mcp config file fails the whole MCP install for that agent. shouldWriteNew treats anything under 3 bytes as a fresh file but "\n  \n" is 4 bytes, so it goes down the update path, parses as neither JSON nor JSON5 and save() returns false

real app, printf '\n  \n' > .mcp.json then boost:install --mcp, before:

```
 Claude Code.. ✗
✗ Failed to install MCP servers to 1 agent:
 - Claude Code: Failed to install Boost MCP: could not write configuration
```

after:

```
 Claude Code.. ✓
```

with .mcp.json holding a valid config with the laravel-boost server

fix adds a blank content check after the existing read in save(), the TomlFileWriter side already handles blank files so this just brings the JSON writer in line. new test fails on main
