### PR TITLE
Point the skill sync workflow at the renamed deploying-to-cloud folder in cloud-cli

### DIFF
--- a/.github/workflows/update-skills.yml
+++ b/.github/workflows/update-skills.yml
@@ -22,11 +22,11 @@ jobs:
           git clone --no-checkout --depth 1 --filter=blob:none \
             https://github.com/laravel/cloud-cli.git /tmp/cloud-cli
           cd /tmp/cloud-cli
-          git sparse-checkout set skills/deploying-laravel-cloud
+          git sparse-checkout set skills/deploying-to-cloud
           git checkout
           rm -rf $GITHUB_WORKSPACE/.ai/deployments/skill/deploying-to-cloud
           mkdir -p $GITHUB_WORKSPACE/.ai/deployments/skill/deploying-to-cloud
-          cp -r skills/deploying-laravel-cloud/. \
+          cp -r skills/deploying-to-cloud/. \
             $GITHUB_WORKSPACE/.ai/deployments/skill/deploying-to-cloud/
           sed -i 's/^name: .*/name: deploying-to-cloud/' \
             $GITHUB_WORKSPACE/.ai/deployments/skill/deploying-to-cloud/SKILL.md


### PR DESCRIPTION
the nightly update skills workflow has failed on both runs since #1012. cloud-cli renamed the skill folder from skills/deploying-laravel-cloud to skills/deploying-to-cloud in laravel/cloud-cli#220 and the sparse checkout still asks for the old name

before, from the run log:

```
cp: cannot stat 'skills/deploying-laravel-cloud/.': No such file or directory
##[error]Process completed with exit code 1.
```

after, same shell steps run by hand against cloud-cli main:

```
.ai/deployments/skill/deploying-to-cloud/SKILL.md
.ai/deployments/skill/deploying-to-cloud/reference/checklists.md
```

just the two path strings. the sed on name: is a no-op now that upstream already says deploying-to-cloud so I left it alone. a PR cant trigger the schedule which is why the after is a manual run, and the bundled skill is already a bit behind upstream so the first green run will commit a real update
