### PR TITLE
Strip a leading BOM from TOML MCP config files so the existing server table is found instead of duplicated

### DIFF
--- a/src/Install/Mcp/TomlFileWriter.php
+++ b/src/Install/Mcp/TomlFileWriter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laravel\Boost\Install\Mcp;
 
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
 
 class TomlFileWriter
 {
@@ -40,11 +41,13 @@ class TomlFileWriter
     {
         File::ensureDirectoryExists(dirname($this->filePath));
 
-        if ($this->shouldWriteNew()) {
+        $content = File::exists($this->filePath) ? $this->normalizeContent(File::get($this->filePath)) : '';
+
+        if ($content === '') {
             return $this->createNewFile();
         }
 
-        return $this->updateExistingFile();
+        return $this->updateExistingFile($content);
     }
 
     protected function createNewFile(): bool
@@ -68,10 +71,8 @@ class TomlFileWriter
         return $this->writeFile(implode(PHP_EOL, $lines).PHP_EOL);
     }
 
-    protected function updateExistingFile(): bool
+    protected function updateExistingFile(string $content): bool
     {
-        $content = File::get($this->filePath);
-
         foreach ($this->serversToAdd as $key => $config) {
             if ($this->serverExists($content, $key)) {
                 $content = $this->removeExistingServer($content, $key);
@@ -161,13 +162,9 @@ class TomlFileWriter
         return preg_replace($mainPattern, '', $content) ?? $content;
     }
 
-    protected function shouldWriteNew(): bool
+    protected function normalizeContent(string $content): string
     {
-        if (! File::exists($this->filePath)) {
-            return true;
-        }
-
-        return File::size($this->filePath) < 3;
+        return trim(Str::chopStart($content, "\xEF\xBB\xBF"));
     }
 
     protected function writeFile(string $content): bool

--- a/tests/Unit/Install/Mcp/TomlFileWriterTest.php
+++ b/tests/Unit/Install/Mcp/TomlFileWriterTest.php
@@ -80,8 +80,6 @@ it('appends to an existing TOML file preserving other servers', function (): voi
         capturedContent: $capturedContent
     );
 
-    File::shouldReceive('size')->andReturn(100);
-
     $result = (new TomlFileWriter('/path/to/config.toml'))
         ->configKey('mcp_servers')
         ->addServerConfig('laravel_boost', [
@@ -119,8 +117,6 @@ TOML;
         content: $existingContent,
         capturedContent: $capturedContent
     );
-
-    File::shouldReceive('size')->andReturn(strlen($existingContent));
 
     $result = (new TomlFileWriter('/path/to/config.toml'))
         ->configKey('mcp_servers')
@@ -207,8 +203,6 @@ TOML;
         capturedContent: $capturedContent
     );
 
-    File::shouldReceive('size')->andReturn(strlen($existingContent));
-
     $result = (new TomlFileWriter('/path/to/config.toml'))
         ->configKey('mcp_servers')
         ->addServerConfig('laravel_boost', [
@@ -243,8 +237,6 @@ TOML;
         content: $existingContent,
         capturedContent: $capturedContent
     );
-
-    File::shouldReceive('size')->andReturn(strlen($existingContent));
 
     $result = (new TomlFileWriter('/project/.codex/config.toml'))
         ->configKey('mcp_servers')
@@ -348,8 +340,6 @@ TOML;
         capturedContent: $capturedContent
     );
 
-    File::shouldReceive('size')->andReturn(strlen($existingContent));
-
     $result = (new TomlFileWriter('/path/to/config.toml'))
         ->configKey('mcp_servers')
         ->addServerConfig('laravel_boost', [
@@ -418,8 +408,6 @@ TOML;
         capturedContent: $capturedContent
     );
 
-    File::shouldReceive('size')->andReturn(strlen($existingContent));
-
     $result = (new TomlFileWriter('/path/to/config.toml'))
         ->configKey('mcp_servers')
         ->addServerConfig('my-server.v2', [
@@ -442,8 +430,6 @@ it('treats an empty file as a new file', function (): void {
         capturedContent: $capturedContent
     );
 
-    File::shouldReceive('size')->andReturn(0);
-
     $result = (new TomlFileWriter('/path/to/config.toml'))
         ->configKey('mcp_servers')
         ->addServerConfig('it', ['command' => 'php'])
@@ -463,8 +449,6 @@ it('treats a file with only whitespace as a new file', function (): void {
         capturedContent: $capturedContent
     );
 
-    File::shouldReceive('size')->andReturn(2);
-
     $result = (new TomlFileWriter('/path/to/config.toml'))
         ->configKey('mcp_servers')
         ->addServerConfig('it', ['command' => 'php'])
@@ -473,6 +457,26 @@ it('treats a file with only whitespace as a new file', function (): void {
     expect($result)->toBeTrue()
         ->and($capturedContent)->toContain('[mcp_servers.it]')
         ->and($capturedContent)->toContain('command = "php"');
+});
+
+it('updates a file that starts with a UTF-8 BOM without duplicating the server table', function (): void {
+    $capturedContent = '';
+
+    mockTomlFileOperations(
+        fileExists: true,
+        content: "\xEF\xBB\xBF[mcp_servers.laravel-boost]\ncommand = \"php\"\n",
+        capturedContent: $capturedContent
+    );
+
+    $result = (new TomlFileWriter('/path/to/config.toml'))
+        ->configKey('mcp_servers')
+        ->addServerConfig('laravel-boost', ['command' => 'php', 'args' => ['artisan', 'boost:mcp']])
+        ->save();
+
+    expect($result)->toBeTrue()
+        ->and($capturedContent)->not->toStartWith("\xEF\xBB\xBF")
+        ->and(substr_count($capturedContent, '[mcp_servers.laravel-boost]'))->toBe(1)
+        ->and($capturedContent)->toContain('args = ["artisan", "boost:mcp"]');
 });
 
 function mockTomlFileOperations(


### PR DESCRIPTION
same bug as #1018 on the TOML side. with a leading BOM the first line doesnt start with `[` so serverExists misses the existing [mcp_servers.laravel-boost] table, Boost appends a second one and Codex refuses to load its config at all

real config.toml that starts with a BOM (shown as \xEF\xBB\xBF), then boost writes its server to it, before:

```
$ cat config.toml
\xEF\xBB\xBF[mcp_servers.laravel-boost]
command = "php"
args = ["artisan", "boost:mcp"]

[mcp_servers.laravel-boost]
command = "php"
args = ["artisan", "boost:mcp"]

$ codex mcp list
Error: failed to load configuration
Caused by:
    0: config.toml:5:14: duplicate key
```

after:

```
$ cat config.toml
[mcp_servers.laravel-boost]
command = "php"
args = ["artisan", "boost:mcp"]

$ codex mcp list
Name           Command  Args               Env  Cwd  Status   Auth
laravel-boost  php      artisan boost:mcp  -    -    enabled  Unsupported
```

same shape as the JSON writer after #1018, normalizeContent strips the BOM and trims, an empty file goes to createNewFile and the size < 3 shortcut is gone. codex reads a BOM file fine on its own so it was only the duplicate table that broke it. tested with codex-cli 0.124.0, new test fails on main
