### PR TITLE
Handle unquoted JSON5 MCP config keys

### DIFF
--- a/src/Install/Mcp/FileWriter.php
+++ b/src/Install/Mcp/FileWriter.php
@@ -93,7 +93,9 @@ class FileWriter
     protected function updateJson5File(string $content): bool
     {
         $masked = $this->maskUnquotedComments($content);
-        $configKeyPattern = '/["\']'.preg_quote($this->configKey, '/').'["\']\\s*:\\s*\\{/';
+        $quotedConfigKey = '["\']'.preg_quote($this->configKey, '/').'["\']';
+        $unquotedConfigKey = '(?<=^|\\s|,|{)'.preg_quote($this->configKey, '/');
+        $configKeyPattern = '/(?:'.$quotedConfigKey.'|'.$unquotedConfigKey.')\\s*:\\s*\\{/m';
 
         if (preg_match($configKeyPattern, $masked, $matches, PREG_OFFSET_CAPTURE)) {
             return $this->injectIntoExistingConfigKey($content, $masked, $matches);
@@ -285,11 +287,12 @@ class FileWriter
         for ($i = count($lines) - 1; $i >= 0; $i--) {
             $line = $lines[$i];
 
-            if (preg_match('/^(\s*)"([^"]+)"\s*:\s*\{/', $line, $matches)) {
+            if (preg_match('/^(\s*)(?:["\']([^"\']+)["\']|([a-zA-Z_][a-zA-Z0-9_]*))\s*:\s*\{/', $line, $matches)) {
                 $indent = strlen($matches[1]);
+                $key = $matches[2] !== '' ? $matches[2] : $matches[3];
 
                 // The configKey line itself sits one level shallower than its servers
-                return $matches[2] === $this->configKey ? max($indent * 2, 4) : $indent;
+                return $key === $this->configKey ? max($indent * 2, 4) : $indent;
             }
         }
 

--- a/tests/Unit/Install/Mcp/FileWriterTest.php
+++ b/tests/Unit/Install/Mcp/FileWriterTest.php
@@ -558,6 +558,37 @@ test('updates JSON5 file with only single-quoted strings', function (): void {
     expect($writtenContent)->toContain('"boost"', "'existing'");
 });
 
+test('injects into an unquoted JSON5 config key', function (): void {
+    $writtenContent = '';
+    $unquotedJson5 = <<<'JSON5'
+    {
+      mcpServers: {
+        existing: {
+          command: 'node'
+        }
+      }
+    }
+    JSON5;
+
+    mockFileOperations(
+        fileExists: true,
+        content: $unquotedJson5,
+        capturedContent: $writtenContent
+    );
+
+    $result = (new FileWriter('/path/to/mcp.json'))
+        ->addServerConfig('boost', [
+            'command' => 'php',
+            'args' => ['artisan', 'boost:mcp'],
+        ])
+        ->save();
+
+    expect($result)->toBeTrue()
+        ->and($writtenContent)->toContain('"boost"', 'existing')
+        ->and($writtenContent)->toContain("\n    \"boost\"")
+        ->and(substr_count($writtenContent, 'mcpServers'))->toBe(1);
+});
+
 test('injects a server that is only present as a comment', function (): void {
     $writtenContent = '';
     $commentedOutJson5 = <<<'JSON5'


### PR DESCRIPTION
## Summary

- recognize unquoted JSON5 MCP configuration keys
- inject new servers into the existing configuration section instead of creating a duplicate
- preserve the indentation used by unquoted configuration keys
- add regression coverage for the affected JSON5 structure

## Problem

`FileWriter` recognizes unquoted property names as a JSON5 feature, but its configuration key matcher only detects single- or double-quoted keys.

Given an existing configuration such as:

```json5
{
  mcpServers: {
    existing: {
      command: 'node'
    }
  }
}
```

installing an MCP server creates a second quoted `mcpServers` section instead of updating the existing one.

## Solution

Allow the JSON5 configuration key matcher and indentation detector to recognize unquoted property names. New server configuration is then inserted into the existing section while preserving its formatting.

## Testing

- added regression coverage for an unquoted `mcpServers` key
- verified the existing server is preserved
- verified only one `mcpServers` section remains
- verified the existing indentation is preserved
- 1078 tests passed with 3149 assertions
- PHPStan
- Laravel Pint
- `git diff --check`