### PR TITLE
Reject non-object Boost configuration

### DIFF
--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -115,15 +115,7 @@ class Config
 
     public function isValid(): bool
     {
-        $path = base_path(self::FILE);
-
-        if (! file_exists($path)) {
-            return false;
-        }
-
-        json_decode(file_get_contents($path), true);
-
-        return json_last_error() === JSON_ERROR_NONE;
+        return $this->read() !== null;
     }
 
     public function flush(): void
@@ -157,18 +149,32 @@ class Config
 
     protected function all(): array
     {
+        return $this->read() ?? [];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    protected function read(): ?array
+    {
         $path = base_path(self::FILE);
 
         if (! file_exists($path)) {
-            return [];
+            return null;
         }
 
-        $config = json_decode(file_get_contents($path), true);
+        $contents = file_get_contents($path);
 
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            return [];
+        if ($contents === false) {
+            return null;
         }
 
-        return $config ?? [];
+        $config = json_decode($contents);
+
+        if (json_last_error() !== JSON_ERROR_NONE || ! is_object($config)) {
+            return null;
+        }
+
+        return (array) $config;
     }
 }

--- a/tests/Feature/Console/UpdateCommandTest.php
+++ b/tests/Feature/Console/UpdateCommandTest.php
@@ -43,13 +43,17 @@ it('it shows an error when boost.json does not exist', function (): void {
         ->assertFailed();
 });
 
-it('it shows an error when boost.json contains invalid json', function (): void {
-    file_put_contents(base_path('boost.json'), 'invalid json {{{');
+it('shows an error when boost.json does not contain a JSON object', function (string $contents): void {
+    file_put_contents(base_path('boost.json'), $contents);
 
     $this->artisan('boost:update')
         ->expectsOutputToContain('Please set up Boost with [php artisan boost:install] first.')
         ->assertFailed();
-});
+})->with([
+    'invalid JSON' => 'invalid json {{{',
+    'JSON string' => '"invalid config"',
+    'JSON list' => '[]',
+]);
 
 it('it shows an error when agents are empty', function (): void {
     $config = new Config;


### PR DESCRIPTION
A valid JSON scalar currently passes `Config::isValid()`. As a result, `boost:update` either throws a `TypeError` when the root value is a string or silently succeeds with an empty configuration when it is a list.

This change treats `boost.json` as valid only when its root value is a JSON object and shares the same read path between validation and configuration access. Invalid shapes now receive the existing setup error instead of continuing.

The regression test covers malformed JSON, a JSON string, and a JSON list.